### PR TITLE
Add ENGI 220 resource page and refresh documentation

### DIFF
--- a/audit_tasks.md
+++ b/audit_tasks.md
@@ -1,0 +1,21 @@
+# Codebase Audit Follow-up Tasks
+
+## Typo Fix
+- **Issue:** The reference entry for Lund et al. in the APA references page misspells the journal title as "Journal of Academics Ethics" (extra "s").
+- **Impact:** Introduces an inaccurate citation on a published references list.
+- **Proposed Task:** Correct the journal title to "Journal of Academic Ethics" in `projects/Bootcamp2025/References.html`.
+
+## Bug Fix
+- **Issue:** The "ENGI 220" card on the learning resources page links to `engi220.html`, but that file does not exist in the repository.
+- **Impact:** Users encounter a broken link when trying to access the Engineering Economy resources.
+- **Proposed Task:** Either add the missing `engi220.html` resource page or update the link in `learn.html` to point to an existing resource.
+
+## Documentation Discrepancy
+- **Issue:** `website_improvements.md` claims that `projects.html` still contains placeholder cards with `#` links, but the page now lists real projects with working URLs.
+- **Impact:** Maintainers reviewing the improvement checklist receive outdated guidance.
+- **Proposed Task:** Update the documentation to accurately describe the current contents of `projects.html` and adjust any related recommendations.
+
+## Test Improvement
+- **Issue:** The `sortByTimeEstimate` helper in the TaskApp V3 Alpine component handles minutes, hours, and a "Supertask" sentinel, yet no automated test exercises these branches.
+- **Impact:** Regressions in the custom parsing/ordering logic could slip by unnoticed.
+- **Proposed Task:** Extend the TaskApp V3 test suite (e.g., add a Jest case in `__tests__`) to verify `sortByTimeEstimate` ordering for minutes, hours, missing estimates, and the "Supertask" label.

--- a/courses/engi220.html
+++ b/courses/engi220.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ENGI 220: Engineering Economy</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <nav class="shortcut-bar">
+    <a href="../index.html" aria-label="Home" title="Home">🏠</a>
+    <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube" title="YouTube Channel">📺</a>
+    <a href="../CV.html" aria-label="About Me" title="About Me">👤</a>
+    <a href="../projects.html" aria-label="Projects" title="Projects">🔧</a>
+    <a href="../learn.html" aria-label="Learning Resources" title="Learning Resources">📚</a>
+    <a href="../projects/PME/MathClubPlan.html" aria-label="Math Club" title="Math Club">🧮</a>
+    <a href="mailto:ahvolk@liberty.edu" aria-label="Contact" title="Contact">✉️</a>
+  </nav>
+
+  <header>
+    <div class="container">
+      <h1>ENGI 220: Engineering Economy</h1>
+      <p class="subtitle">Applying economic analysis to engineering design and decision making.</p>
+    </div>
+  </header>
+
+  <main class="container">
+    <section>
+      <h2>Course Overview</h2>
+      <p>
+        Engineering Economy introduces the analytic tools needed to evaluate design alternatives, capital investments,
+        and strategic decisions. Students learn to quantify time value of money, compare mutually exclusive options, and
+        communicate recommendations using clear financial justification.
+      </p>
+    </section>
+
+    <section>
+      <h2>Key Topics</h2>
+      <ul>
+        <li>Simple and compound interest, effective rates, and cash-flow diagrams</li>
+        <li>Present, future, and annual worth analysis for project evaluation</li>
+        <li>Rate of return methods and incremental analysis</li>
+        <li>Break-even, payback, and benefit-cost comparisons</li>
+        <li>Inflation, taxes, and replacement analysis considerations</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Course Documents</h2>
+      <p>Downloadable materials will be added here as they become available.</p>
+      <ul>
+        <li><a href="mailto:ahvolk@liberty.edu">Contact Prof. Volk</a> for the current syllabus and assignment schedule.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Supplemental Resources</h2>
+      <ul>
+        <li><a href="https://www.nspe.org/resources/education/resources/engineering-economy" target="_blank" rel="noopener noreferrer">NSPE Engineering Economy primer</a></li>
+        <li><a href="https://www.omnicalculator.com/finance/npv" target="_blank" rel="noopener noreferrer">Net Present Value calculator</a></li>
+        <li><a href="https://www.asce.org/-/media/asce-images-and-files/ceorg/files/pdfs/engineering-economics-module1.pdf" target="_blank" rel="noopener noreferrer">ASCE Engineering Economics module</a></li>
+      </ul>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 - All Rights Reserved</p>
+      <div class="social-links">
+        <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">📺</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/learn.html
+++ b/learn.html
@@ -111,7 +111,7 @@
         <div class="card-icon">⚙️</div>
         <h2>ENGI 220: Engineering Economy</h2>
         <p>Application of economic and financial analysis methods to engineering design, systems, and management.</p>
-        <a href="engi220.html" class="button">View ENGI 220 Resources</a>
+        <a href="courses/engi220.html" class="button">View ENGI 220 Resources</a>
       </div>
 
     </div>

--- a/projects/Bootcamp2025/References.html
+++ b/projects/Bootcamp2025/References.html
@@ -92,7 +92,7 @@
     </div>
 
     <div class="reference">
-        Lund, B. D., Lee, T. H., Mannuru, N. R., & Arutla, N. (2025). AI and academic integrity: Exploring student perceptions and implications for Higher Education. <i>Journal of Academics Ethics</i>. <a href="https://doi.org/10.1007/s10805-025-09613-3" target="_blank" rel="noopener noreferrer">https://doi.org/10.1007/s10805-025-09613-3</a>
+        Lund, B. D., Lee, T. H., Mannuru, N. R., & Arutla, N. (2025). AI and academic integrity: Exploring student perceptions and implications for Higher Education. <i>Journal of Academic Ethics</i>. <a href="https://doi.org/10.1007/s10805-025-09613-3" target="_blank" rel="noopener noreferrer">https://doi.org/10.1007/s10805-025-09613-3</a>
     </div>
 
     <div class="reference">

--- a/website_improvements.md
+++ b/website_improvements.md
@@ -5,12 +5,11 @@ Based on a review of the website files (`index.html`, `CV.html`, `projects.html`
 ## 1. Content & Structure
 
 *   **Projects Page (`projects.html`):**
-    *   This page currently contains placeholder content ("Project One", "Project Two", etc.) and non-functional links (`#`).
-    *   **Suggestion:** Replace placeholders with actual project details, descriptions, and potentially links to demos, repositories, or related publications. If there are no current projects to display, consider removing the page or adding a note indicating it's under construction.
+    *   The page now highlights real initiatives including an Undergraduate Math Journals guide, TaskAppV3, and PrayerAppV1, each linked to live resources.
+    *   **Suggestion:** Continue updating the project cards as new work is published and consider adding brief metrics or outcomes (e.g., user adoption, publication venues) to showcase impact.
 *   **Learning Resources (`learn.html`):**
-    *   The link for "ENGI 220: Engineering Economy" points to `engi220.html`, which doesn't exist in the provided file list.
-    *   **Suggestion:** Verify if `engi220.html` exists or needs to be created. If not, update the link to point to the correct resource page or remove the card if no resources are available yet.
-    *   Consider adding more context or specific resources (like links to PDFs, videos, or external sites) directly on the course pages linked from `learn.html` (e.g., `courses/math114.html`). Many course pages seem to be missing or potentially basic.
+    *   The ENGI 220 card now links to `courses/engi220.html`, providing a high-level course overview and curated external references.
+    *   **Suggestion:** Add downloadable course documents (syllabus, assignment templates) directly to the new page and continue enriching other course pages with concrete study aids.
 *   **CV Page (`CV.html`):**
     *   The page is very comprehensive but long. The sticky navigation helps, but users might still find it dense.
     *   **Suggestion:** Consider minor restructuring or visual breaks. Perhaps use accordions for lengthy sections like "Professional Experience" or "Conference Presentations" to make the initial view less overwhelming.


### PR DESCRIPTION
## Summary
- correct the Lund et al. reference to use the proper Journal of Academic Ethics title
- add a dedicated ENGI 220 course resource page and update the learn page card to link to it
- refresh the website improvements checklist to describe the current projects and learning resources pages

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dc0378b7088331bf2907303545c4cd