### PR TITLE
Add top navigation to root pages missing the global navbar

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -307,8 +307,33 @@
     #tab-formulas::before { content: 'Math 130 \2014  Test 1 Formula Sheet'; display: block; font-size: 16pt; font-weight: bold; text-align: center; margin-bottom: 0.6rem; padding-bottom: 0.4rem; border-bottom: 2px solid #000; }
   }
 </style>
+
+<style>
+  .top-nav { position: sticky; top: 0; z-index: 1000; background: rgba(15, 23, 42, 0.92); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
+  .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+  .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
+  .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
+  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
+  .top-nav-links a:hover { color: #93c5fd; }
+</style>
+
 </head>
 <body>
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    <div class="top-nav-links">
+      <a href="index.html">Home</a>
+      <a href="CV.html">About Me</a>
+      <a href="learn.html">Course Resources</a>
+      <a href="projects.html">Projects</a>
+      <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
+      <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>
+      <a href="mailto:ahvolk@liberty.edu">Contact</a>
+    </div>
+  </div>
+</nav>
+
 <div class="container">
   <header>
     <button class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode">

--- a/130Test2.html
+++ b/130Test2.html
@@ -990,8 +990,33 @@
         }
 
 </style>
+
+<style>
+  .top-nav { position: sticky; top: 0; z-index: 1000; background: rgba(15, 23, 42, 0.92); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
+  .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+  .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
+  .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
+  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
+  .top-nav-links a:hover { color: #93c5fd; }
+</style>
+
 </head>
 <body>
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    <div class="top-nav-links">
+      <a href="index.html">Home</a>
+      <a href="CV.html">About Me</a>
+      <a href="learn.html">Course Resources</a>
+      <a href="projects.html">Projects</a>
+      <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
+      <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>
+      <a href="mailto:ahvolk@liberty.edu">Contact</a>
+    </div>
+  </div>
+</nav>
+
 <div class="container">
 <header>
 <div class="header-copy">

--- a/Taskflow.html
+++ b/Taskflow.html
@@ -62,8 +62,33 @@
       width: 100%;
     }
   </style>
+
+<style>
+  .top-nav { position: sticky; top: 0; z-index: 1000; background: rgba(15, 23, 42, 0.92); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
+  .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+  .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
+  .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
+  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
+  .top-nav-links a:hover { color: #93c5fd; }
+</style>
+
 </head>
 <body>
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    <div class="top-nav-links">
+      <a href="index.html">Home</a>
+      <a href="CV.html">About Me</a>
+      <a href="learn.html">Course Resources</a>
+      <a href="projects.html">Projects</a>
+      <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
+      <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>
+      <a href="mailto:ahvolk@liberty.edu">Contact</a>
+    </div>
+  </div>
+</nav>
+
   <h1>Should You Work On That Task Right Now?</h1>
   
   <div class="flowchart">

--- a/chessboard.html
+++ b/chessboard.html
@@ -101,8 +101,33 @@
          fill-opacity: 0.8; /* Slightly transparent on hover */
        }
     </style>
+
+<style>
+  .top-nav { position: sticky; top: 0; z-index: 1000; background: rgba(15, 23, 42, 0.92); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
+  .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+  .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
+  .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
+  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
+  .top-nav-links a:hover { color: #93c5fd; }
+</style>
+
 </head>
 <body class="bg-gray-100 p-4 md:p-8 flex flex-col items-center min-h-screen">
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    <div class="top-nav-links">
+      <a href="index.html">Home</a>
+      <a href="CV.html">About Me</a>
+      <a href="learn.html">Course Resources</a>
+      <a href="projects.html">Projects</a>
+      <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
+      <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>
+      <a href="mailto:ahvolk@liberty.edu">Contact</a>
+    </div>
+  </div>
+</nav>
+
 
     <div class="w-full max-w-6xl bg-white rounded-lg shadow-xl p-6 md:p-8">
         <h1 class="text-2xl md:text-3xl font-bold text-center text-gray-800 mb-6">

--- a/employeepay.html
+++ b/employeepay.html
@@ -35,8 +35,33 @@
             border: 2px solid; /* Add border for definition */
         }
     </style>
+
+<style>
+  .top-nav { position: sticky; top: 0; z-index: 1000; background: rgba(15, 23, 42, 0.92); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
+  .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+  .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
+  .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
+  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
+  .top-nav-links a:hover { color: #93c5fd; }
+</style>
+
 </head>
 <body class="p-4 md:p-8">
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    <div class="top-nav-links">
+      <a href="index.html">Home</a>
+      <a href="CV.html">About Me</a>
+      <a href="learn.html">Course Resources</a>
+      <a href="projects.html">Projects</a>
+      <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
+      <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>
+      <a href="mailto:ahvolk@liberty.edu">Contact</a>
+    </div>
+  </div>
+</nav>
+
 
     <h1 class="text-2xl md:text-4xl font-bold text-center text-sky-800 mb-6">
         Who Earns More Money?

--- a/growth.html
+++ b/growth.html
@@ -22,8 +22,33 @@
             transition: background-color 0.2s ease-in-out;
         }
     </style>
+
+<style>
+  .top-nav { position: sticky; top: 0; z-index: 1000; background: rgba(15, 23, 42, 0.92); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
+  .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+  .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
+  .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
+  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
+  .top-nav-links a:hover { color: #93c5fd; }
+</style>
+
 </head>
 <body class="bg-gray-100 p-4 md:p-8">
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    <div class="top-nav-links">
+      <a href="index.html">Home</a>
+      <a href="CV.html">About Me</a>
+      <a href="learn.html">Course Resources</a>
+      <a href="projects.html">Projects</a>
+      <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
+      <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>
+      <a href="mailto:ahvolk@liberty.edu">Contact</a>
+    </div>
+  </div>
+</nav>
+
     <div class="max-w-4xl mx-auto bg-white p-6 rounded-lg shadow-md">
         <h1 class="text-3xl font-bold text-center text-indigo-700 mb-8 border-b pb-4">Math Quiz Prep: Linear, Exponential & Logistic Growth</h1>
 


### PR DESCRIPTION
### Motivation

- Several standalone root-level HTML pages lacked the site navigation, causing inconsistent UX and making it harder to move between sections. 
- Provide a lightweight, self-contained top navigation so each standalone page (including `130Test1.html`) shows the same primary links without depending on external site scaffolding.

### Description

- Inserted a small `.top-nav` style block and a reusable `<nav class="top-nav" aria-label="Primary">...</nav>` markup near the top of the `body` in the affected pages so the nav is sticky and visually consistent. 
- Changes were applied to the following files: `130Test1.html`, `130Test2.html`, `Taskflow.html`, `chessboard.html`, `employeepay.html`, and `growth.html`.
- The nav contains the primary links: `Home`, `About Me`, `Course Resources`, `Projects`, `Math Club`, `YouTube`, and `Contact`, and uses `target="_blank" rel="noopener noreferrer"` where appropriate to avoid cross-site issues. 
- The component is intentionally self-contained (local CSS per page) to avoid collisions with existing page-specific layouts and theme systems.

### Testing

- Verified presence of the new nav in each file with a repository search for `'<nav class="top-nav"'`, which returned matches in all updated pages. 
- Served the site locally with `python -m http.server` and rendered `130Test1.html` in a headless browser to capture a screenshot, confirming the nav displays as expected (screenshot artifact produced). 
- Ran the `rg` presence checks and the headless render flow end-to-end and observed successful results for the updated pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b016547770833189e8607953b429bd)