### PR TITLE
Fix exp-form grading for fractional exponents in Test 3 review

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -3152,7 +3152,12 @@
             const uexp = parseFloat(document.getElementById('inp-exp').value);
             const uans = parseFloat(document.getElementById('inp-ans').value);
             if(isNaN(ub) || isNaN(uexp) || isNaN(uans)) return;
-            isCorrect = (ub === currentQuestion.a.base && uexp === currentQuestion.a.exp && uans === currentQuestion.a.ans);
+            const expTolerance = currentQuestion.expTol || 0.005;
+            isCorrect = (
+                ub === currentQuestion.a.base &&
+                Math.abs(uexp - currentQuestion.a.exp) <= expTolerance &&
+                uans === currentQuestion.a.ans
+            );
         } else if (currentQuestion.inputType === 'interest_table') {
             const u1 = parseFloat(document.getElementById('inp-a1').value);
             const u2 = parseFloat(document.getElementById('inp-a2').value);


### PR DESCRIPTION
### Motivation
- Fix a high-priority grading bug where `exp_form` answers required exact floating-point equality, which incorrectly marked valid student entries (rounded decimals for fractional exponents like `2/3`) as wrong in `130Test3.html`.

### Description
- Relaxed the exponent comparison in `checkAnswer()` for `exp_form` to use a tolerance (`currentQuestion.expTol || 0.005`) and accept answers where `Math.abs(userExp - expectedExp) <= expTolerance`, while keeping base and result checks unchanged.

### Testing
- Verified the fix by searching for the old equality and confirming the new tolerance-based comparison is present with `rg` and `nl`, and inspected the diff with `git diff`; these checks succeeded and show the updated code in `130Test3.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18c5431d88331a72bc6640e3ced4f)