### PR TITLE
Follow-up: Tolerant comparison for exp_form fractional exponents

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -3133,6 +3133,7 @@
         if (!currentQuestion) return;
         
         let isCorrect = false;
+        const nearlyEqual = (a, b, tolerance = 0.001) => Math.abs(a - b) <= tolerance;
         
         // Validate based on input type
         if (currentQuestion.inputType === 'dms') {
@@ -3152,7 +3153,11 @@
             const uexp = parseFloat(document.getElementById('inp-exp').value);
             const uans = parseFloat(document.getElementById('inp-ans').value);
             if(isNaN(ub) || isNaN(uexp) || isNaN(uans)) return;
-            isCorrect = (ub === currentQuestion.a.base && uexp === currentQuestion.a.exp && uans === currentQuestion.a.ans);
+            isCorrect = (
+                ub === currentQuestion.a.base &&
+                nearlyEqual(uexp, currentQuestion.a.exp) &&
+                uans === currentQuestion.a.ans
+            );
         } else if (currentQuestion.inputType === 'interest_table') {
             const u1 = parseFloat(document.getElementById('inp-a1').value);
             const u2 = parseFloat(document.getElementById('inp-a2').value);


### PR DESCRIPTION
### Motivation
- The `exp_form` answer check used strict floating-point equality which marked correct rounded decimal inputs as wrong when `logexp_conv` generated fractional exponents (e.g. `2/3`, `4/3`, `5/3`) that are stored as repeating decimals.

### Description
- Add a `nearlyEqual(a, b, tolerance = 0.001)` helper inside `checkAnswer()` and use it to compare the user-entered exponent to `currentQuestion.a.exp` for `inputType === 'exp_form'`, while keeping exact checks for the base and result.

### Testing
- Parsed the inline JavaScript from `130Test3.html` with Node (`new Function(...)`) to ensure no syntax regressions and it succeeded.
- Verified occurrences with `rg` to confirm the `exp_form` handler was updated and `logexp_conv` generation code remains present and unchanged, and those searches succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18d0529dc833192634c10d90e245e)