### PR TITLE
Update Test 3 slide links from Unit 2 to Unit 3 assets

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -1567,19 +1567,19 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Module 10</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit2A.pdf" target="_blank" aria-label="Open Module 10 PDF slides">
-<img alt="Thumbnail preview for Math 130 Module 10 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit2A.png"/>
+<a class="slide-thumb-wrap" href="slides/Math130Unit3A.pdf" target="_blank" aria-label="Open Module 10 PDF slides">
+<img alt="Thumbnail preview for Math 130 Module 10 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3A.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
 <div class="slide-thumb-label">Click to Open PDF</div>
-<div class="slide-thumb-note">Add <code>Math130Unit2A.png</code> to the slides folder.</div>
+<div class="slide-thumb-note">Add <code>Math130Unit3A.png</code> to the slides folder.</div>
 </div>
 </a>
 <h3>Trig Foundations (5.1–5.2)</h3>
 <p class="slide-subtitle">Covers angle sketching, coterminal angles, and arc length/central-angle skills from Sections 5.1 and 5.2.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit2A.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit2A.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit3A.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit3A.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1587,19 +1587,19 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Module 11</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit2B.pdf" target="_blank" aria-label="Open Module 11 PDF slides">
-<img alt="Thumbnail preview for Math 130 Module 11 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit2B.png"/>
+<a class="slide-thumb-wrap" href="slides/Math130Unit3B.pdf" target="_blank" aria-label="Open Module 11 PDF slides">
+<img alt="Thumbnail preview for Math 130 Module 11 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3B.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
 <div class="slide-thumb-label">Click to Open PDF</div>
-<div class="slide-thumb-note">Add <code>Math130Unit2B.png</code> to the slides folder.</div>
+<div class="slide-thumb-note">Add <code>Math130Unit3B.png</code> to the slides folder.</div>
 </div>
 </a>
 <h3>Reference Angles (5.3, 5.7)</h3>
 <p class="slide-subtitle">Covers reference angles and trig-function sign/value reasoning from Sections 5.3 and 5.7.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit2B.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit2B.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit3B.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit3B.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1607,19 +1607,19 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Module 12</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit2C.pdf" target="_blank" aria-label="Open Module 12 PDF slides">
-<img alt="Thumbnail preview for Math 130 Module 12 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit2C.png"/>
+<a class="slide-thumb-wrap" href="slides/Math130Unit3C.pdf" target="_blank" aria-label="Open Module 12 PDF slides">
+<img alt="Thumbnail preview for Math 130 Module 12 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3C.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
 <div class="slide-thumb-label">Click to Open PDF</div>
-<div class="slide-thumb-note">Add <code>Math130Unit2C.png</code> to the slides folder.</div>
+<div class="slide-thumb-note">Add <code>Math130Unit3C.png</code> to the slides folder.</div>
 </div>
 </a>
 <h3>Right-Triangle Applications (7.1)</h3>
 <p class="slide-subtitle">Covers right-triangle trigonometry applications and modeling problems from Section 7.1.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit2C.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit2C.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit3C.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit3C.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1627,19 +1627,19 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Module 13</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit2D.pdf" target="_blank" aria-label="Open Module 13 PDF slides">
-<img alt="Thumbnail preview for Math 130 Module 13 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit2D.png"/>
+<a class="slide-thumb-wrap" href="slides/Math130Unit3D.pdf" target="_blank" aria-label="Open Module 13 PDF slides">
+<img alt="Thumbnail preview for Math 130 Module 13 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3D.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
 <div class="slide-thumb-label">Click to Open PDF</div>
-<div class="slide-thumb-note">Add <code>Math130Unit2D.png</code> to the slides folder.</div>
+<div class="slide-thumb-note">Add <code>Math130Unit3D.png</code> to the slides folder.</div>
 </div>
 </a>
 <h3>Vectors (8.4)</h3>
 <p class="slide-subtitle">Covers vector component form, operations, magnitude, and direction from Section 8.4.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit2D.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit2D.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit3D.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit3D.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1647,19 +1647,19 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Unit 3 Review</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit2E.pdf" target="_blank" aria-label="Open Unit 3 Review PDF slides">
-<img alt="Thumbnail preview for Math 130 Unit 3 Review lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit2E.png"/>
+<a class="slide-thumb-wrap" href="slides/Math130Unit3E.pdf" target="_blank" aria-label="Open Unit 3 Review PDF slides">
+<img alt="Thumbnail preview for Math 130 Unit 3 Review lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3E.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
 <div class="slide-thumb-label">Click to Open PDF</div>
-<div class="slide-thumb-note">Add <code>Math130Unit2E.png</code> to the slides folder.</div>
+<div class="slide-thumb-note">Add <code>Math130Unit3E.png</code> to the slides folder.</div>
 </div>
 </a>
 <h3>Math 130 Unit 3: Test 3 Review</h3>
 <p class="slide-subtitle">Consolidates Modules 10–13 into a focused Test 3 review aligned to the Unit 3 checklist.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit2E.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit2E.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit3E.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit3E.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 </div>
@@ -1745,7 +1745,7 @@
     const TAB_META = {
         slides: {
             title: 'Slides',
-            note: 'Start with Units 2A–2D for content review, then use 2E as your final pass before practice.',
+            note: 'Start with Units 3A–3D for content review, then use 3E as your final pass before practice.',
             next: 'formulas',
             nextLabel: 'Next: Formulas'
         },


### PR DESCRIPTION
### Motivation
- Fix broken/mismatched slide links in the Test 3 (Unit 3) Slides section so the pages point to the correct Unit 3 asset filenames instead of Unit 2 filenames.

### Description
- Replaced all `Math130Unit2A`–`Math130Unit2E` references with `Math130Unit3A`–`Math130Unit3E` in `130Test3.html` for PDF, PPTX, thumbnail `src`, and placeholder filename notes.
- Updated the slide guidance copy in `TAB_META` from "Units 2A–2D" / "2E" to "Units 3A–3D" / "3E" to match the new filenames.
- The change was applied in a single file: `130Test3.html` and committed.
- No external skills were used in this change.

### Testing
- Ran `rg` to search for remaining `Math130Unit2*` references in `130Test3.html` and found none (success).
- Launched a local server with `python3 -m http.server 4173` and captured a screenshot via Playwright visiting `http://127.0.0.1:4173/130Test3.html`, which loaded the updated Slides section (Playwright screenshot run succeeded) while server logs showed 404s for the new thumbnail images because those image files are not yet present (expected placeholder behavior).
- Verified the change was committed using `git` (commit recorded successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18fde11208331b393a84e4ec75628)