### PR TITLE
Fix syntax error in 130Test3 question generators

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -1940,10 +1940,17 @@
                     q: `Convert $${deg.toFixed(4)}^\circ$ to degrees, minutes, and seconds. (Round to the nearest second)`,
                     inputType: 'dms', a: { d, m, s },
                     solution: `Multiply the decimal by 60 to get minutes, then multiply the remaining decimal by 60 to get seconds. <br> $${deg.toFixed(4)}^\circ = ${d}^\circ ${m}' ${s}''$`
-                const angle = [25, 30, 35, 40, 45, 50, 60][Math.floor(Math.random()*7)];
-                const known = Math.floor(Math.random()*14)+6;
+                };
+            }
+        },
+        {
+            id: 'solve_right_triangle_side', section: 'Section 7.1',
+            label: 'Solve Right Triangle Side',
+            generate: () => {
+                const angle = [25, 30, 35, 40, 45, 50, 60][Math.floor(Math.random() * 7)];
+                const known = Math.floor(Math.random() * 14) + 6;
                 const type = Math.random() > 0.5 ? 'opp' : 'adj';
-                const ans = type === 'opp' ? known * Math.tan(angle*Math.PI/180) : known / Math.tan(angle*Math.PI/180);
+                const ans = type === 'opp' ? known * Math.tan(angle * Math.PI / 180) : known / Math.tan(angle * Math.PI / 180);
                 return {
                     q: type === 'opp' ? `A right triangle has angle $${angle}^\circ$ and adjacent side $${known}$. Find the opposite side. (Round to 2 decimals)` : `A right triangle has angle $${angle}^\circ$ and opposite side $${known}$. Find the adjacent side. (Round to 2 decimals)`,
                     inputType: 'number', a: ans, tol: 0.05,


### PR DESCRIPTION
### Motivation
- Resolve a runtime parse error (`Uncaught SyntaxError: Unexpected token 'const'`) caused by a malformed object return inside the `dms` question generator so the page's inline script can load correctly.

### Description
- Properly closed the returned object in the `dms` generator by adding the missing `};` and closing the function and object, restoring valid JavaScript structure for that generator.
- Restored the right-triangle side problem by moving its logic into a new generator object `solve_right_triangle_side` under `Section 7.1`, preserving the original question text, answer calculation, and tolerances.

### Testing
- Ran a JavaScript parse check of the inline `<script>` in `130Test3.html` using `node` (executing the script body via `new Function(...)`), and the parse succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a96847a883319c6a5405578800f8)