### PR TITLE
Validate coterminal angles by equivalence (coterminal_deg)

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -1845,8 +1845,8 @@
                 const ans = theta + 360 * (Math.random() > 0.5 ? k : -k);
                 return {
                     q: `Find one coterminal angle (in degrees) for $\theta = ${theta}^\circ$.`,
-                    inputType: 'number', a: ans, tol: 0.1,
-                    solution: `Coterminal angles differ by multiples of $360^\circ$. One valid answer is $${theta} ${ans > theta ? '+' : '-'} ${Math.abs(ans - theta)} = ${ans}^\circ$.`
+                    inputType: 'coterminal_deg', baseTheta: theta, tol: 0.1,
+                    solution: `Coterminal angles differ by multiples of $360^\circ$, so infinitely many answers are valid. One sample valid answer is $${theta} ${ans > theta ? '+' : '-'} ${Math.abs(ans - theta)} = ${ans}^\circ$.`
                 };
             }
         },
@@ -2617,6 +2617,14 @@
             const userVal = parseFloat(input.value);
             if (isNaN(userVal)) return;
             isCorrect = Math.abs(userVal - currentQuestion.a) <= currentQuestion.tol;
+        } else if (currentQuestion.inputType === 'coterminal_deg') {
+            const input = document.getElementById('answer-input');
+            const userVal = parseFloat(input.value);
+            if (isNaN(userVal)) return;
+            const tol = currentQuestion.tol ?? 0.1;
+            const baseTheta = currentQuestion.baseTheta;
+            const k = Math.round((userVal - baseTheta) / 360);
+            isCorrect = Math.abs(userVal - (baseTheta + 360 * k)) <= tol;
         } else {
             const input = document.getElementById('answer-input');
             const userVal = parseFloat(input.value);


### PR DESCRIPTION
### Motivation
- Coterminal-angle questions should accept any angle equivalent to the base angle modulo 360° instead of requiring one stored numeric answer.

### Description
- Change the `angle_coterminal` generator to emit `inputType: 'coterminal_deg'` and store the original angle as `baseTheta` rather than a single numeric `a` value. 
- Update the solution text to note that infinitely many answers are valid while still showing one sample valid answer. 
- Add a `coterminal_deg` branch in `checkAnswer()` that computes `k = Math.round((userVal - baseTheta) / 360)` and marks correct when `|userVal - (baseTheta + 360*k)| <= tol` using the generator `tol` (default 0.1).

### Testing
- Ran `git diff --check` which passed with no whitespace or diff errors.
- Inspected the modified file (`130Test3.html`) to verify the generator and `checkAnswer()` branches were updated as intended and committed the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1abebc2f0833192f1c1dbd76d4afc)