### PR TITLE
Normalize DMS generator output and accept equivalent DMS answers

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -2040,10 +2040,19 @@
             label: 'Convert DMS',
             generate: () => {
                 const deg = (Math.random() * 80 + 10).toFixed(4);
-                const d = Math.floor(deg);
+                let d = Math.floor(deg);
                 const rem = (deg - d) * 60;
-                const m = Math.floor(rem);
-                const s = Math.round((rem - m) * 60);
+                let m = Math.floor(rem);
+                let s = Math.round((rem - m) * 60);
+
+                if (s === 60) {
+                    s = 0;
+                    m += 1;
+                }
+                if (m === 60) {
+                    m = 0;
+                    d += 1;
+                }
                 
                 return {
                     q: `Convert $${deg}^\\circ$ to degrees, minutes, and seconds. (Round to the nearest second)`,
@@ -3201,7 +3210,9 @@
             const um = parseInt(document.getElementById('inp-m').value);
             const us = parseInt(document.getElementById('inp-s').value);
             if(isNaN(ud) || isNaN(um) || isNaN(us)) return;
-            isCorrect = (ud === currentQuestion.a.d && um === currentQuestion.a.m && us === currentQuestion.a.s);
+            const userTotalSeconds = ud * 3600 + um * 60 + us;
+            const answerTotalSeconds = currentQuestion.a.d * 3600 + currentQuestion.a.m * 60 + currentQuestion.a.s;
+            isCorrect = userTotalSeconds === answerTotalSeconds;
         } else if (currentQuestion.inputType === 'log_form') {
             const ub = parseFloat(document.getElementById('inp-base').value);
             const uarg = parseFloat(document.getElementById('inp-arg').value);


### PR DESCRIPTION
### Motivation
- Prevent edge-case incorrect outputs when rounding seconds to 60 or minutes to 60 for the DMS generator by carrying the overflow into the next unit. 
- Allow users to enter mathematically equivalent DMS answers (carry/borrow variants) without being marked incorrect.

### Description
- In the `dms` generator, changed `d` to `let` and compute `m` and `s` with rounding, then normalize by carrying `s === 60` into `m` and `m === 60` into `d`, and use the normalized tuple in `a: { d, m, s }` and the solution text. 
- In `checkAnswer()` for `inputType === 'dms'`, replaced strict tuple equality with a comparison of total seconds by computing `userTotalSeconds = ud*3600 + um*60 + us` and `answerTotalSeconds = currentQuestion.a.d*3600 + currentQuestion.a.m*60 + currentQuestion.a.s` and checking equality. 
- Kept existing UI/solution formatting unchanged except to reference the normalized values.

### Testing
- Ran a quick Node sanity check with `node -e` to verify normalization behavior (examples: `12.9999°` → `{d:13,m:0,s:0}` and `45.0166667°` → `{d:45,m:1,s:0}`) which succeeded. 
- Verified equivalence comparison works via a small script that returns `true` for equivalent representations such as `{d:12,m:60,s:0}` vs `{d:13,m:0,s:0}` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b00fbe848331b1935f709718096d)