### PR TITLE
Make `quadrant_signs` require discrete integer answers

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -2016,8 +2016,8 @@
                 ];
                 const pick = options[Math.floor(Math.random()*options.length)];
                 return {
-                    q: `Determine the quadrant number where $\theta$ can lie if ${pick.q}.`,
-                    inputType: 'number', a: pick.a, tol: 0.1,
+                    q: `Determine the quadrant number where $\theta$ can lie if ${pick.q}. Enter 1, 2, 3, or 4.`,
+                    inputType: 'quadrant_int', a: pick.a,
                     solution: `Use ASTC signs. The condition places $\theta$ in Quadrant ${pick.a}.`
                 };
             }
@@ -2558,6 +2558,8 @@
                     <input type="number" step="any" id="inp-c4" placeholder="°">
                 </div>
             `;
+        } else if (currentQuestion.inputType === 'quadrant_int') {
+            inputArea.innerHTML = `<input type="number" min="1" max="4" step="1" id="answer-input" class="inp-standard" placeholder="1-4" autocomplete="off">`;
         } else {
             inputArea.innerHTML = `<input type="number" step="any" id="answer-input" class="inp-standard" placeholder="Your Answer" autocomplete="off">`;
         }
@@ -2685,6 +2687,14 @@
             const baseTheta = currentQuestion.baseTheta;
             const k = Math.round((userVal - baseTheta) / 360);
             isCorrect = Math.abs(userVal - (baseTheta + 360 * k)) <= tol;
+        } else if (currentQuestion.inputType === 'quadrant_int') {
+            const input = document.getElementById('answer-input');
+            const userVal = parseStrictNumber(input.value);
+            if (userVal === null) {
+                showInvalidNumberFeedback();
+                return;
+            }
+            isCorrect = Number.isInteger(userVal) && userVal === currentQuestion.a;
         } else {
             const input = document.getElementById('answer-input');
             const userVal = parseStrictNumber(input.value);


### PR DESCRIPTION
### Motivation
- Ensure the "Quadrant from Signs" practice is graded as a discrete choice (1–4) rather than a numeric value with tolerance to avoid accidental partial-credit from near matches.

### Description
- Changed the `quadrant_signs` generator prompt to: `Determine the quadrant number where $\theta$ can lie if ${pick.q}. Enter 1, 2, 3, or 4.` and set `inputType` to `quadrant_int` with `a: pick.a` in `130Test3.html`.
- Added UI rendering for `inputType === 'quadrant_int'` using `<input type="number" min="1" max="4" step="1">` to guide integer entry.
- Added discrete grading in `checkAnswer()` for `quadrant_int` that requires an exact integer match using `Number.isInteger(userVal)` and `userVal === currentQuestion.a` (no tolerance).

### Testing
- Verified code locations and diffs with `rg`/`git diff` and inspected the updated file lines in `130Test3.html`, and committed the change (commit `3370bdf`). — Success.
- Launched a local `python3 -m http.server` and attempted a Playwright screenshot to visually validate the UI, but the headless Chromium failed to launch in this environment (SIGSEGV), so the browser-based screenshot attempt failed; the server start itself completed. — Partial (non-fatal) failure.
- Confirmed the new generator branch, input rendering branch, and grading branch are present by printing file snippets with `nl`/`sed`. — Success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b18f844483319e03e385e174d540)