### PR TITLE
Use epsilon tolerance for log/exp form answer validation

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -3218,13 +3218,21 @@
             const uarg = parseFloat(document.getElementById('inp-arg').value);
             const uans = parseFloat(document.getElementById('inp-ans').value);
             if(isNaN(ub) || isNaN(uarg) || isNaN(uans)) return;
-            isCorrect = (ub === currentQuestion.a.base && uarg === currentQuestion.a.arg && uans === currentQuestion.a.ans);
+            const eps = 1e-6;
+            const bOk = Math.abs(ub - currentQuestion.a.base) <= eps;
+            const argOk = Math.abs(uarg - currentQuestion.a.arg) <= eps;
+            const ansOk = Math.abs(uans - currentQuestion.a.ans) <= eps;
+            isCorrect = bOk && argOk && ansOk;
         } else if (currentQuestion.inputType === 'exp_form') {
             const ub = parseFloat(document.getElementById('inp-base').value);
             const uexp = parseFloat(document.getElementById('inp-exp').value);
             const uans = parseFloat(document.getElementById('inp-ans').value);
             if(isNaN(ub) || isNaN(uexp) || isNaN(uans)) return;
-            isCorrect = (ub === currentQuestion.a.base && uexp === currentQuestion.a.exp && uans === currentQuestion.a.ans);
+            const eps = 1e-6;
+            const bOk = Math.abs(ub - currentQuestion.a.base) <= eps;
+            const expOk = Math.abs(uexp - currentQuestion.a.exp) <= eps;
+            const ansOk = Math.abs(uans - currentQuestion.a.ans) <= eps;
+            isCorrect = bOk && expOk && ansOk;
         } else if (currentQuestion.inputType === 'interest_table') {
             const u1 = parseFloat(document.getElementById('inp-a1').value);
             const u2 = parseFloat(document.getElementById('inp-a2').value);


### PR DESCRIPTION
### Motivation
- Avoid false negatives from strict floating-point `===` comparisons when users enter values with formatting or rounding differences by using small absolute-difference tolerances.

### Description
- Replace strict equality checks in `checkAnswer()` for `inputType === 'log_form'` with epsilon-based comparisons using `Math.abs(user - expected) <= 1e-6` for `base`, `arg`, and `ans`.
- Replace strict equality checks in `checkAnswer()` for `inputType === 'exp_form'` with epsilon-based comparisons using `Math.abs(user - expected) <= 1e-6` for `base`, `exp`, and `ans`.
- All other input-type validations were left unchanged.

### Testing
- No automated test suite was run for this static HTML/JS update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b197100883318256cb63386bbaea)