### PR TITLE
Use ordered blueprint for Quiz 7 and refactor startMockQuiz

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -3503,7 +3503,7 @@
         },
         7: {
             label: 'Quiz 7 — Angles & Polygons',
-            blueprint: ['quiz7_similar_multi', 'quiz7_parallel_multi', 'trapezoid_area', 'parallelogram_area', 'right_triangle_area', 'herons', 'dms', 'dms_to_dec']
+            blueprint: ['similar_triangles', 'parallel_angles', 'basic_areas', 'basic_areas', 'basic_areas', 'herons', 'dms', 'dms_to_dec']
         },
         8: {
             label: 'Quiz 8 — Circles',

--- a/130Test2.html
+++ b/130Test2.html
@@ -3503,8 +3503,7 @@
         },
         7: {
             label: 'Quiz 7 — Angles & Polygons',
-            section: 'Angles & Polygons',
-            count: 5
+            blueprint: ['quiz7_similar_multi', 'quiz7_parallel_multi', 'trapezoid_area', 'parallelogram_area', 'right_triangle_area', 'herons', 'dms', 'dms_to_dec']
         },
         8: {
             label: 'Quiz 8 — Circles',
@@ -3525,25 +3524,50 @@
         const config = QUIZ_CONFIG[quizNum];
         if (!config) return;
 
-        const pool = generators.filter(g => g.section === config.section);
-        if (pool.length === 0) return;
-
         const selected = [];
-        const uniquePool = shuffleInPlace([...pool]);
+        const examResults = document.getElementById('exam-results');
+        const quizActiveArea = document.getElementById('quiz-active-area');
 
-        // First pass: sample without replacement from every generator in the section
-        for (const gen of uniquePool) {
-            if (selected.length >= config.count) break;
-            selected.push(gen);
+        if (Array.isArray(config.blueprint)) {
+            const missingBlueprintIds = [];
+
+            for (const genId of config.blueprint) {
+                const gen = generators.find(g => g.id === genId);
+                if (!gen) {
+                    missingBlueprintIds.push(genId);
+                    continue;
+                }
+                selected.push(gen);
+            }
+
+            if (missingBlueprintIds.length > 0) {
+                examResults.style.display = 'block';
+                quizActiveArea.style.display = 'none';
+                document.getElementById('exam-progress-bar').style.display = 'none';
+                document.getElementById('exam-score-display').innerHTML = '<div style="font-size:1.1rem; color: var(--red);">Unable to start this quiz.</div>';
+                document.getElementById('exam-breakdown').innerHTML = `<div style="color: var(--text-muted); text-align: center;">Missing generator IDs: <code>${missingBlueprintIds.join(', ')}</code></div>`;
+                return;
+            }
+        } else {
+            const pool = generators.filter(g => g.section === config.section);
+            if (pool.length === 0) return;
+
+            const uniquePool = shuffleInPlace([...pool]);
+
+            // First pass: sample without replacement from every generator in the section
+            for (const gen of uniquePool) {
+                if (selected.length >= config.count) break;
+                selected.push(gen);
+            }
+
+            // If the section has fewer generators than the quiz length, fill by random re-sampling
+            while (selected.length < config.count) {
+                selected.push(pool[Math.floor(Math.random() * pool.length)]);
+            }
+
+            // Final shuffle
+            shuffleInPlace(selected);
         }
-
-        // If the section has fewer generators than the quiz length, fill by random re-sampling
-        while (selected.length < config.count) {
-            selected.push(pool[Math.floor(Math.random() * pool.length)]);
-        }
-
-        // Final shuffle
-        shuffleInPlace(selected);
 
         examState = {
             isActive: true,


### PR DESCRIPTION
### Motivation
- Ensure Quiz 7 uses a fixed, ordered set of generators instead of sampling by `section` + `count` so the quiz content is deterministic and follows the required sequence.
- Provide a clear failure mode when a configured generator ID is missing so users don't launch a broken quiz.

### Description
- Replace Quiz 7 `section`/`count` with a required `blueprint` array set to `['quiz7_similar_multi', 'quiz7_parallel_multi', 'trapezoid_area', 'parallelogram_area', 'right_triangle_area', 'herons', 'dms', 'dms_to_dec']` in `QUIZ_CONFIG`.
- Refactor `startMockQuiz(quizNum)` to detect `config.blueprint`, resolve each blueprint ID via `generators.find(g => g.id === genId)`, and build `selected` in blueprint order while preserving the prior section/count sampling path for other quizzes.
- Set `examState.total` from the resolved `selected.length` (8 for Quiz 7) and keep existing UI flows for successful starts.
- Add a guard/fallback UI that displays an “Unable to start this quiz” message plus a list of missing generator IDs when any blueprint ID cannot be resolved.

### Testing
- Verified the updated `QUIZ_CONFIG` and logic locations with `rg` and file listing output, which showed the new `blueprint` and modified `startMockQuiz` function (searches for `QUIZ_CONFIG|blueprint|startMockQuiz|missingBlueprintIds`).
- Ran `git diff --check` to confirm no whitespace issues and inspected the modified file region with `nl -ba` to confirm the patch contents. All checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b8492d84833199b973050d1b3c7e)