### PR TITLE
Update Quiz 7 CTA subtitle and QUIZ_CONFIG label

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -1435,8 +1435,8 @@
 <div style="font-size: 0.8rem; color: var(--text-muted);">Logarithms</div>
 </button>
 <button class="btn-secondary" onclick="startMockQuiz(7)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 7 — Angles &amp; Polygons</div>
-<div style="font-size: 0.8rem; color: var(--text-muted);">Similar Triangles, Parallel Lines, Areas, Heron's</div>
+<div style="font-weight: 600; margin-bottom: 2px;">Quiz 7 — Triangles, Lines &amp; Areas</div>
+<div style="font-size: 0.8rem; color: var(--text-muted);">Similar Triangles, Parallel Lines, Triangle/Polygon Areas, DMS Conversions</div>
 </button>
 <button class="btn-secondary" onclick="startMockQuiz(8)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
 <div style="font-weight: 600; margin-bottom: 2px;">Quiz 8 — Circles</div>
@@ -3502,7 +3502,7 @@
             count: 5
         },
         7: {
-            label: 'Quiz 7 — Angles & Polygons',
+            label: 'Quiz 7 — Triangles, Lines & Areas',
             section: 'Angles & Polygons',
             count: 5
         },


### PR DESCRIPTION
### Motivation
- Replace the Quiz 7 CTA title/subtitle with the requested wording and ensure progress/results use the same label by updating `QUIZ_CONFIG[7].label` so displayed text is consistent.

### Description
- In `130Test2.html` updated the `startMockQuiz(7)` CTA to show the title `Quiz 7 — Triangles, Lines & Areas` and the subtitle `Similar Triangles, Parallel Lines, Triangle/Polygon Areas, DMS Conversions`, and changed `QUIZ_CONFIG[7].label` to `Quiz 7 — Triangles, Lines & Areas`.

### Testing
- Verified the updated strings are present using `rg` and inspected the file with `nl`/`sed`, committed the change with `git commit`, and attempted a Playwright screenshot which failed in this environment due to file/timeout issues (string verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b8cab3e8833197699c3530c975e3)