### PR TITLE
Make Quiz 7 selection explicit via blueprint IDs only

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -3503,6 +3503,8 @@
         },
         7: {
             label: 'Quiz 7 — Angles & Polygons',
+            // Quiz 7 membership is controlled only by this explicit generator blueprint.
+            // Do not infer membership from any section label.
             blueprint: ['similar_triangles', 'parallel_angles', 'basic_areas', 'basic_areas', 'basic_areas', 'herons', 'dms', 'dms_to_dec']
         },
         8: {


### PR DESCRIPTION
### Motivation
- Ensure Quiz 7 membership is determined only by an explicit `blueprint` list to prevent accidental inclusion via section labels and to make the intent explicit in `QUIZ_CONFIG`.

### Description
- Added clarifying comments and left Quiz 7 configured as a `blueprint`-driven entry (no `section` field) in `130Test2.html` under `QUIZ_CONFIG`, keeping runtime selection logic unchanged.

### Testing
- Ran small automated checks (using `python` scripts and `rg`) to parse the `blueprint` in `130Test2.html` and verified that `piecewise_rect` and `transversals` are absent, `dms` and `dms_to_dec` are present, `herons` appears exactly once, and Quizzes 5/6/8 remain section-based; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c92fe7448331a0b5f2e707558bd5)