### PR TITLE
Resolve merge conflict in QUIZ_CONFIG and pick blueprint for Quiz 7

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -3646,16 +3646,10 @@
             count: 5
         },
         7: {
-<<<<<<< codex/update-mock-quiz-cta-title-and-subtitle
-            label: 'Quiz 7 — Triangles, Lines & Areas',
-            section: 'Angles & Polygons',
-            count: 5
-=======
             label: 'Quiz 7 — Angles & Polygons',
             // Quiz 7 membership is controlled only by this explicit generator blueprint.
             // Do not infer membership from any section label.
             blueprint: ['similar_triangles', 'parallel_angles', 'basic_areas', 'basic_areas', 'basic_areas', 'herons', 'dms', 'dms_to_dec']
->>>>>>> main
         },
         8: {
             label: 'Quiz 8 — Circles',


### PR DESCRIPTION
### Motivation
- Remove leftover merge conflict markers in the mock-quiz configuration and choose a single valid schema for `QUIZ_CONFIG[7]` so `startMockQuiz()` can deterministically build Quiz 7.

### Description
- Deleted conflict markers and kept the `blueprint`-based configuration for quiz 7 in `130Test2.html` (replacing the alternate `section`/`count` variant) while leaving other quizzes unchanged.

### Testing
- Ran `rg -n "<<<<<<<|=======|>>>>>>>" 130Test2.html` to confirm no conflict markers remained and it reported none (success). 
- Printed the affected region with `nl -ba 130Test2.html | sed -n '3638,3708p'` to verify the final `QUIZ_CONFIG` structure (success). 
- Verified repository state with `git status --short` and committed the change with `git commit` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b23da57fd4833194c698733238f15d)