### PR TITLE
Update Unit 13 practice tab messaging to match live mock modes

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -1357,18 +1357,18 @@
 <div class="tab-content" id="tab-practice">
 <div class="card">
 <h2 style="text-align: center; margin-bottom: 0.5rem;">Practice Generators</h2>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Practice generators for this unit are still in development and will be added once they are aligned to Unit 13 outcomes.</p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Practice generators are live for Unit 13 and aligned to Sections 5.1, 5.2, 5.3, 7.1, and 8.4.</p>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Select a topic to generate infinite, exam-style questions.</p>
 <!-- Mock Exam CTA -->
 <div id="exam-cta" style="background: linear-gradient(135deg, var(--accent-glow), var(--red-bg)); border: 2px solid var(--accent); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem; text-align: center;">
 <h3 style="font-family: 'DM Serif Display', serif; font-size: 1.4rem; margin-bottom: 0.5rem;">🎯 Mock Exam Mode</h3>
-<p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.95rem;">20 mixed review questions aligned to Unit 3 skills from Sections 5.1, 5.2, 5.3, 7.1, and 8.4.</p>
+<p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.95rem;">20 mixed Unit 13 review questions with coverage from Sections 5.1, 5.2, 5.3, 7.1, and 8.4 (at least one per section).</p>
 <button class="btn-primary" id="btn-start-exam" onclick="startMockExam()">Start Mock Exam</button>
 </div>
 <!-- Mock Quiz CTA -->
 <div id="quiz-cta" style="background: var(--surface2); border: 1px solid var(--border); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem;">
 <h3 style="font-family: 'DM Serif Display', serif; font-size: 1.25rem; margin-bottom: 0.75rem; text-align: center;">📝 Mock Quiz Mode</h3>
-<p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.9rem; text-align: center;">5 focused questions randomly drawn from all skill generators in the section. One attempt per question.</p>
+<p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.9rem; text-align: center;">Each mock quiz has 5 one-attempt questions sampled from its listed section pool (Quiz 10 combines Sections 5.1/5.2; Quizzes 11–13 use Sections 5.3, 7.1, and 8.4).</p>
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75rem;">
 <button class="btn-secondary" onclick="startMockQuiz(5)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
 <div style="font-weight: 600; margin-bottom: 2px;">Quiz 10 — Section 5.1/5.2</div>


### PR DESCRIPTION
### Motivation
- Remove outdated "still in development" copy and correct the unit label so the Practice tab reflects the currently available Unit 13 generators and mock modes.

### Description
- Updated the intro copy in `130Test3.html` to state that practice generators are live for Unit 13 and list the covered sections (5.1, 5.2, 5.3, 7.1, and 8.4). 
- Replaced the mock exam blurb to reference Unit 13 and clarified it builds a 20-question mixed review with coverage from the listed sections. 
- Revised the mock quiz description to state quizzes are 5 one-attempt questions sampled from the configured section pools and noted that Quiz 10 combines Sections 5.1/5.2 while Quizzes 11–13 use Sections 5.3, 7.1, and 8.4.

### Testing
- Used `rg` to confirm the updated strings and to locate the `startMockExam()`/`startMockQuiz()` functions in `130Test3.html`, and the searches succeeded. 
- Inspected the file diff to verify the three text replacements in `130Test3.html`, and the diff matched the intended updates. 
- Attempted an automated browser render/screenshot via Playwright to visually validate the UI, but the Playwright runs timed out or returned `Not Found` in the container environment, so no screenshot could be captured though the HTTP HEAD check returned `200` during troubleshooting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b24462b6bc8331a961462dc9e331f9)