### PR TITLE
Remove DMS generator from Test 3 (Section 8.4)

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -1939,33 +1939,6 @@
             }
         },
         {
-            id: 'dms', section: 'Section 8.4',
-            label: 'Convert DMS',
-            generate: () => {
-                const deg = Number((Math.random() * 80 + 10).toFixed(4));
-                let d = Math.floor(deg);
-                const rem = (deg - d) * 60;
-                let m = Math.floor(rem);
-                let s = Math.round((rem - m) * 60);
-
-                // Normalize edge cases like 59.9999 seconds -> 60 seconds
-                if (s === 60) {
-                    s = 0;
-                    m += 1;
-                }
-                if (m === 60) {
-                    m = 0;
-                    d += 1;
-                }
-
-                return {
-                    q: `Convert $${deg.toFixed(4)}^\circ$ to degrees, minutes, and seconds. (Round to the nearest second)`,
-                    inputType: 'dms', a: { d, m, s },
-                    solution: `Multiply the decimal by 60 to get minutes, then multiply the remaining decimal by 60 to get seconds. <br> $${deg.toFixed(4)}^\circ = ${d}^\circ ${m}' ${s}''$`
-                };
-            }
-        },
-        {
             id: 'solve_right_triangle_side', section: 'Section 7.1',
             label: 'Solve Right Triangle Side',
             generate: () => {


### PR DESCRIPTION
### Motivation
- The `dms` practice generator was assigned to `Section 8.4` (vectors), which is out-of-scope for the Test 3 vector-focused content, so it should not appear in section-based quizzes or practice lists.

### Description
- Removed the `dms` generator object (id: `dms`) from the `generators` array in `130Test3.html` so Section 8.4 no longer includes a DMS conversion topic.
- Left runtime input handling for `inputType === 'dms'` intact to avoid regressions elsewhere, but the generator definition that would surface DMS in section pools was deleted.
- No other files were modified and Section 8.4 now contains only vector-related generators (`vector_components`, `vector_magnitude`, `vector_direction`).

### Testing
- Ran `rg -n "\bdms\b|inputType === 'dms'|Convert DMS" 130Test3.html` and confirmed the `dms` generator definition is gone and only runtime `inputType` checks remain (command succeeded).
- Inspected quiz/section selection logic (the `generators.filter(g => g.section === ...)` and `QUIZ_CONFIG`) to verify removing the generator removes DMS from section quiz pools (manual code inspection via `sed`/`nl` commands succeeded).
- Committed the change with `git commit` and verified the working tree with `git status --short`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2a7d1e5088331bcfe718f5e663b70)