### PR TITLE
Fix circles sector SVG to use theta-based endpoint geometry

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -2759,7 +2759,7 @@
             id: 'circles', section: 'Circles',
             label: 'Sectors & Arcs (Visual)',
             generate: () => {
-                const rNum = (Math.random() * 10 + 2).toFixed(1);
+                const rNum = Number((Math.random() * 10 + 2).toFixed(1));
                 const isDeg = Math.random() > 0.5;
                 let thetaStr, thetaRad;
 
@@ -2774,8 +2774,17 @@
                     thetaRad = (num * Math.PI) / den;
                 }
 
+                const centerX = 60;
+                const centerY = 60;
+                const radius = 50;
+                const startX = centerX + radius;
+                const startY = centerY;
+                const endX = centerX + radius * Math.cos(thetaRad);
+                const endY = centerY - radius * Math.sin(thetaRad);
+                const largeArcFlag = thetaRad > Math.PI ? 1 : 0;
+
                 const svg = `<svg viewBox="0 0 120 120" class="svg-canvas" width="250" height="250">
-                    <path d="M60,60 L110,60 A50,50 0 0,0 25,25 Z" fill="var(--accent-glow)" stroke="var(--accent)" stroke-width="2"/>
+                    <path d="M${centerX},${centerY} L${startX},${startY} A${radius},${radius} 0 ${largeArcFlag},0 ${endX.toFixed(2)},${endY.toFixed(2)} Z" fill="var(--accent-glow)" stroke="var(--accent)" stroke-width="2"/>
                     <text x="85" y="75" fill="var(--text)" font-size="12">r = ${rNum}</text>
                     <text x="45" y="45" fill="var(--text)" font-size="12">${isDeg ? thetaStr.replace('^\\circ','°') : thetaStr}</text>
                 </svg>`;


### PR DESCRIPTION
### Motivation
- The `circles` generator previously used a fixed SVG arc endpoint which could mismatch the displayed angle and computed arc/area values.
- The goal is to make the shaded sector geometry derive from the same `thetaRad` used in formulas so visuals and numeric answers are consistent.

### Description
- Convert `rNum` to a numeric value with `Number(...)` so arithmetic uses a numeric radius rather than a string.
- Compute SVG sector geometry from center `(60,60)` and radius `50` by calculating `endX = cx + r*cos(thetaRad)` and `endY = cy - r*sin(thetaRad)` and use those in the `A` arc command.
- Add `largeArcFlag = thetaRad > Math.PI ? 1 : 0` and include it in the SVG `A` command so arcs > π render correctly, while preserving the existing labels and answer calculations tied to `thetaRad`.

### Testing
- Verified the updated code and presence of the dynamic `A` command and `largeArcFlag` with `rg` (pattern search) which returned the expected lines.
- Inspected diffs with `git diff -- 130Test2.html` and committed the change with `git commit` which succeeded.
- Started a local server with `python3 -m http.server 4173` successfully, and attempted a Playwright screenshot, but Chromium crashed (SIGSEGV) in this environment so visual screenshot capture failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2f1157bc08331884ccb324c58e26e)