### PR TITLE
Add Section 5.2 checklist entries for angle/radian conversion

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -1688,8 +1688,10 @@
             { id: '51_4', cat: 'Section 5.1', label: 'Sketching an angle with absolute value greater than 360 degrees in standard position', done: false, practiceId: 'angle_coterminal' },
             { id: '51_5', cat: 'Section 5.1', label: 'Arc length and central angle measure', done: false, practiceId: 'arc_length' },
 
-            // Section 5.2 (8 topics)
+            // Section 5.2 (10 topics)
             { id: '52_1', cat: 'Section 5.2', label: 'Using a calculator to approximate sine, cosine, and tangent values', done: false, practiceId: 'trig_calculator_values' },
+            { id: '52_9', cat: 'Section 5.2', label: 'Convert degrees to radians', done: false, practiceId: 'angle_unit_conversion' },
+            { id: '52_10', cat: 'Section 5.2', label: 'Convert radians to degrees', done: false, practiceId: 'angle_unit_conversion' },
             { id: '52_2', cat: 'Section 5.2', label: 'Sine, cosine, and tangent ratios: Numbers for side lengths', done: false, practiceId: 'trig_ratio' },
             { id: '52_3', cat: 'Section 5.2', label: 'Sine, cosine, and tangent ratios: Variables for side lengths', done: false, practiceId: 'trig_ratio' },
             { id: '52_4', cat: 'Section 5.2', label: 'Using the Pythagorean Theorem to find a sine, cosine, or tangent ratio in a right triangle', done: false, practiceId: 'trig_ratio' },


### PR DESCRIPTION
### Motivation
- Provide explicit checklist rows in Section 5.2 for students to practice converting between degrees and radians and to enable direct jump-to-practice via `angle_unit_conversion`.

### Description
- Added two `DEFAULT_CHECKLIST` entries in the Section 5.2 block with unique IDs and `practiceId: 'angle_unit_conversion'`: `52_9` — `Convert degrees to radians` and `52_10` — `Convert radians to degrees`, and updated the section comment to `// Section 5.2 (10 topics)`.

### Testing
- Confirmed presence of the new entries with `rg`, verified ID uniqueness with a small Python check script, served the page with `python3 -m http.server`, and ran a Playwright script that validated both labels render, clicking the new row's practice icon switches to the Practice tab and activates `angle_unit_conversion`, and produced a screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2f337b05c83318a433a9abcc728bb)