### PR TITLE
Clarify repeating-decimal entry, add checklist coverage audit, and harden KaTeX rendering for Math130 Test 2 & 3

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -1414,7 +1414,9 @@
 <div class="tab-content" id="tab-practice">
 <div class="card">
 <h2 style="text-align: center; margin-bottom: 0.5rem;">Practice Generators</h2>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Select a topic to generate infinite, exam-style questions.</p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Select a topic to generate infinite, exam-style questions.</p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">For decimal answers, enter rounded values as directed. Repeating decimals are accepted within tolerance (for example, $0.3333$ for $0.\overline{3}$).</p>
+<p id="coverage-audit" style="text-align: center; color: var(--text-muted); margin-bottom: 2rem; font-size: 0.9rem;"></p>
 <!-- Mock Exam CTA -->
 <div id="exam-cta" style="background: linear-gradient(135deg, var(--accent-glow), var(--red-bg)); border: 2px solid var(--accent); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem; text-align: center;">
 <h3 style="font-family: 'DM Serif Display', serif; font-size: 1.4rem; margin-bottom: 0.5rem;">🎯 Mock Exam Mode</h3>
@@ -3059,6 +3061,7 @@
         applyTheme(state.theme);
         renderChecklist();
         renderQuizCategories();
+        renderCoverageAudit();
         updateStatsUI();
         renderHistory();
         highlightScheduleDates();
@@ -3215,6 +3218,19 @@
             group.appendChild(btnRow);
             container.appendChild(group);
         });
+    }
+
+
+    function renderCoverageAudit() {
+        const coverageEl = document.getElementById('coverage-audit');
+        if (!coverageEl) return;
+
+        const checklistPracticeIds = [...new Set(state.checklist.map(item => item.practiceId).filter(Boolean))];
+        const generatorIds = new Set(generators.map(gen => gen.id));
+        const covered = checklistPracticeIds.filter(id => generatorIds.has(id));
+        const missing = checklistPracticeIds.filter(id => !generatorIds.has(id));
+
+        coverageEl.textContent = `Checklist coverage audit: ${covered.length}/${checklistPracticeIds.length} checklist-linked topics have matching practice generators${missing.length ? `. Missing: ${missing.join(', ')}` : ' (full coverage).'}`;
     }
 
     function updateStatsUI() {
@@ -3906,12 +3922,19 @@
         }
     }
 
-    function renderMath() {
+    let _mathRetryTimer = null;
+    function renderMath(retries = 8) {
         if (window.renderMathInElement) {
             renderMathInElement(document.body, {
                 delimiters: [ {left: '$$', right: '$$', display: true}, {left: '$', right: '$', display: false} ],
                 throwOnError: false
             });
+            return;
+        }
+
+        if (retries > 0) {
+            clearTimeout(_mathRetryTimer);
+            _mathRetryTimer = setTimeout(() => renderMath(retries - 1), 150);
         }
     }
 </script>

--- a/130Test3.html
+++ b/130Test3.html
@@ -1357,7 +1357,9 @@
 <div class="tab-content" id="tab-practice">
 <div class="card">
 <h2 style="text-align: center; margin-bottom: 0.5rem;">Practice Generators</h2>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Practice generators are live for Unit 13 and aligned to Sections 5.1, 5.2, 5.3, 7.1, and 8.4.</p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Practice generators are live for Unit 13 and aligned to Sections 5.1, 5.2, 5.3, 7.1, and 8.4.</p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">For decimal answers, enter rounded values as directed. Repeating decimals are accepted within tolerance (for example, $0.6667$ for $0.\overline{6}$).</p>
+<p id="coverage-audit" style="text-align: center; color: var(--text-muted); margin-bottom: 2rem; font-size: 0.9rem;"></p>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Select a topic to generate infinite, exam-style questions.</p>
 <!-- Mock Exam CTA -->
 <div id="exam-cta" style="background: linear-gradient(135deg, var(--accent-glow), var(--red-bg)); border: 2px solid var(--accent); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem; text-align: center;">
@@ -2356,6 +2358,7 @@
         applyTheme(state.theme);
         renderChecklist();
         renderQuizCategories();
+        renderCoverageAudit();
         updateStatsUI();
         renderHistory();
         highlightScheduleDates();
@@ -2517,6 +2520,19 @@
             group.appendChild(btnRow);
             container.appendChild(group);
         });
+    }
+
+
+    function renderCoverageAudit() {
+        const coverageEl = document.getElementById('coverage-audit');
+        if (!coverageEl) return;
+
+        const checklistPracticeIds = [...new Set(state.checklist.map(item => item.practiceId).filter(Boolean))];
+        const generatorIds = new Set(generators.map(gen => gen.id));
+        const covered = checklistPracticeIds.filter(id => generatorIds.has(id));
+        const missing = checklistPracticeIds.filter(id => !generatorIds.has(id));
+
+        coverageEl.textContent = `Checklist coverage audit: ${covered.length}/${checklistPracticeIds.length} checklist-linked topics have matching practice generators${missing.length ? `. Missing: ${missing.join(', ')}` : ' (full coverage).'}`;
     }
 
     function updateStatsUI() {
@@ -3131,12 +3147,19 @@
         }
     }
 
-    function renderMath() {
+    let _mathRetryTimer = null;
+    function renderMath(retries = 8) {
         if (window.renderMathInElement) {
             renderMathInElement(document.body, {
                 delimiters: [ {left: '$$', right: '$$', display: true}, {left: '$', right: '$', display: false} ],
                 throwOnError: false
             });
+            return;
+        }
+
+        if (retries > 0) {
+            clearTimeout(_mathRetryTimer);
+            _mathRetryTimer = setTimeout(() => renderMath(retries - 1), 150);
         }
     }
 </script>


### PR DESCRIPTION
### Motivation
- Reduce student confusion about decimal entry (particularly repeating decimals) and make it explicit how practice generators accept rounded/repeating values. 
- Provide immediate, visible feedback about whether checklist topics are covered by interactive practice generators to catch gaps faster. 
- Prevent occasional first-render math/TeX flash when KaTeX loads slightly after the page or after the first generated question. 

### Description
- Added a short guidance paragraph in the Practice tab of `130Test2.html` and `130Test3.html` clarifying decimal-entry expectations and that repeating decimals are accepted within tolerance (example shown). 
- Injected a `coverage-audit` element and implemented `renderCoverageAudit()` which compares `DEFAULT_CHECKLIST` `practiceId` values to the `generators` `id`s and reports coverage into the UI; the audit is run during `DOMContentLoaded`. 
- Wired the coverage audit into page initialization by calling `renderCoverageAudit()` during the UI setup sequence. 
- Hardened math rendering by replacing the previous `renderMath()` with a retry-capable implementation (`renderMath(retries = 8)`) that polls briefly for KaTeX before giving up to avoid raw-TeX display on first question. 

### Testing
- Ran JavaScript syntax checks (`node --check` on extracted script blocks) for both pages and they succeeded. 
- Ran a programmatic coverage check comparing checklist `practiceId` entries to generator `id`s which reported full coverage for both pages (`130Test2: 22/22`, `130Test3: 19/19`). 
- Automated browser verification (headless Playwright checks) confirmed the `coverage-audit` text renders on both practice tabs, a first-generated question on Test 3 produced KaTeX output on first render, and practice-tab screenshots were captured successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2f4607ca4833199386d2f1b0c4ee5)