### PR TITLE
Clarify decimal-only input and accept simple π expressions for coterminal radians

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -1415,7 +1415,7 @@
 <div class="card">
 <h2 style="text-align: center; margin-bottom: 0.5rem;">Practice Generators</h2>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Select a topic to generate infinite, exam-style questions.</p>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">For decimal answers, enter rounded values as directed. Repeating decimals are accepted within tolerance (for example, $0.3333$ for $0.\overline{3}$).</p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">For decimal answers, enter rounded values as directed. Repeating decimals are accepted within tolerance (for example, $0.3333$ for $0.\overline{3}$). Unless a question explicitly says otherwise, enter a decimal number only (not $\pi$ notation).</p>
 <p id="coverage-audit" style="text-align: center; color: var(--text-muted); margin-bottom: 2rem; font-size: 0.9rem;"></p>
 <!-- Mock Exam CTA -->
 <div id="exam-cta" style="background: linear-gradient(135deg, var(--accent-glow), var(--red-bg)); border: 2px solid var(--accent); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem; text-align: center;">
@@ -3454,7 +3454,7 @@
     function showInvalidNumberFeedback() {
         const feedback = document.getElementById('feedback-display');
         feedback.className = 'feedback incorrect';
-        feedback.textContent = 'Please enter a decimal number.';
+        feedback.textContent = 'Enter a decimal number only (not π notation).';
     }
 
     function checkAnswer() {

--- a/130Test3.html
+++ b/130Test3.html
@@ -1358,7 +1358,7 @@
 <div class="card">
 <h2 style="text-align: center; margin-bottom: 0.5rem;">Practice Generators</h2>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Practice generators are live for Unit 13 and aligned to Sections 5.1, 5.2, 5.3, 7.1, and 8.4.</p>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">For decimal answers, enter rounded values as directed. Repeating decimals are accepted within tolerance (for example, $0.6667$ for $0.\overline{6}$).</p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">For decimal answers, enter rounded values as directed. Repeating decimals are accepted within tolerance (for example, $0.6667$ for $0.\overline{6}$). Unless a question explicitly says otherwise, enter a decimal number only (not $\pi$ notation).</p>
 <p id="coverage-audit" style="text-align: center; color: var(--text-muted); margin-bottom: 2rem; font-size: 0.9rem;"></p>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Select a topic to generate infinite, exam-style questions.</p>
 <!-- Mock Exam CTA -->
@@ -1889,7 +1889,7 @@
                 return {
                     q: `Find one coterminal angle (in radians) for $\theta = \frac{${baseNum}\pi}{6}$. (Round to 3 decimals if entering a decimal.)`,
                     inputType: 'coterminal_rad', baseThetaRad: baseTheta, tol: 0.01,
-                    entryNote: 'Any answer of the form $\theta + 2\pi k$ is valid, where $k$ is an integer.',
+                    entryNote: 'Any answer of the form $\theta + 2\pi k$ is valid, where $k$ is an integer. For this input, you may enter either a decimal or simple $\pi$ notation such as $\pi$, $2\pi/3$, or $-5\pi/6$.',
                     solution: `Coterminal angles differ by multiples of $2\pi$. One sample valid answer is $\frac{${baseNum}\pi}{6} ${k >= 0 ? '+' : '-'}${Math.abs(k)}(2\pi) = ${ans.toFixed(3)}$ radians.`
                 };
             }
@@ -2738,10 +2738,29 @@
         return Number.isFinite(parsed) ? parsed : null;
     }
 
-    function showInvalidNumberFeedback() {
+    function parsePiRadiansExpression(rawValue) {
+        const trimmed = rawValue.trim().toLowerCase().replace(/\s+/g, '').replace(/π/g, 'pi');
+        if (!trimmed) return null;
+        const piPattern = /^([+-]?\d*(?:\.\d+)?)?\*?pi(?:\/(\d+(?:\.\d+)?))?$/;
+        const match = trimmed.match(piPattern);
+        if (!match) return null;
+
+        let coeffRaw = match[1];
+        let coeff;
+        if (coeffRaw === undefined || coeffRaw === '') coeff = 1;
+        else if (coeffRaw === '+') coeff = 1;
+        else if (coeffRaw === '-') coeff = -1;
+        else coeff = Number(coeffRaw);
+
+        const denom = match[2] ? Number(match[2]) : 1;
+        if (!Number.isFinite(coeff) || !Number.isFinite(denom) || denom === 0) return null;
+        return coeff * Math.PI / denom;
+    }
+
+    function showInvalidNumberFeedback(message = 'Enter a decimal number only (not π notation).') {
         const feedback = document.getElementById('feedback-display');
         feedback.className = 'feedback incorrect';
-        feedback.textContent = 'Please enter a valid number.';
+        feedback.textContent = message;
     }
 
     function checkAnswer() {
@@ -2840,9 +2859,12 @@
             isCorrect = Math.abs(userVal - (baseTheta + 360 * k)) <= tol;
         } else if (currentQuestion.inputType === 'coterminal_rad') {
             const input = document.getElementById('answer-input');
-            const userVal = parseStrictNumber(input.value);
+            let userVal = parseStrictNumber(input.value);
             if (userVal === null) {
-                showInvalidNumberFeedback();
+                userVal = parsePiRadiansExpression(input.value);
+            }
+            if (userVal === null) {
+                showInvalidNumberFeedback('Enter a decimal or simple π expression (e.g., pi, 2pi/3, -5pi/6).');
                 return;
             }
             const tol = currentQuestion.tol ?? 0.01;


### PR DESCRIPTION
### Motivation
- Make input expectations explicit so students know when decimal input is required versus when symbolic π notation might be allowed. 
- Provide a clearer, targeted invalid-input message to reduce confusion when non-decimal input is entered. 
- Optionally accept simple π expressions for the specific `coterminal_rad` input type so common student formats like `pi` or `2pi/3` work without requiring manual conversion.

### Description
- Updated the practice instructions text in `130Test3.html` and mirrored it in `130Test2.html` to state: "Unless a question explicitly says otherwise, enter a decimal number only (not π notation)." in the practice header. 
- Replaced the generic invalid-number feedback with the explicit wording `Enter a decimal number only (not π notation).` (used as the default message and as an overridable message for targeted cases). 
- Extended the `angle_coterminal_rad` `entryNote` in `130Test3.html` to state that either a decimal or simple π notation (examples: `pi`, `2pi/3`, `-5pi/6`) may be entered for that input. 
- Added `parsePiRadiansExpression` in `130Test3.html` and wired it into the `coterminal_rad` validation so simple π expressions are converted to numeric radians before tolerance checking, and added a targeted validation message when input is neither a decimal nor an accepted π expression.

### Testing
- Ran a text search with `rg` to verify the new phrasing and parser hook usage, which returned the updated locations (succeeded). 
- Served the site locally with `python3 -m http.server 8000` and used Playwright to open `http://127.0.0.1:8000/130Test3.html`, switch to the practice tab, and capture a screenshot to confirm the updated practice note (screenshot artifact generated successfully). 
- Verified that the new `parsePiRadiansExpression` path is invoked for `coterminal_rad` inputs and that other numeric parsing behavior via `parseStrictNumber` remains unchanged by inspecting the updated code (static checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2fba45fbc8331ab787d27ba64013a)