### PR TITLE
Add SVG-backed angle and vector prompt variants with text fallbacks

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -410,6 +410,8 @@
         
         .svg-canvas { background: var(--surface2); border: 1px solid var(--border); border-radius: 12px; padding: 1rem; margin: 0 auto 1.5rem auto; display: block; max-width: 100%; height: auto; }
 
+        .svg-fallback { margin: -0.9rem auto 1.2rem auto; max-width: 640px; color: var(--text-muted); font-size: 0.92rem; text-align: left; }
+
         /* Multi-Inputs */
         .input-group { display: flex; justify-content: center; align-items: center; gap: 0.75rem; margin-bottom: 2rem; flex-wrap: wrap; }
         .input-group input { background: var(--bg); border: 2px solid var(--border); color: var(--text); padding: 1rem; border-radius: 12px; font-size: 1.2rem; font-family: 'JetBrains Mono', monospace; text-align: center; transition: border-color 0.2s; outline: none; }
@@ -1861,6 +1863,102 @@
         }
     }
 
+    function createAngleSvg({ thetaDeg, labelText, fallbackText, referenceDeg = null, showReferenceLabel = false }) {
+        const size = 300;
+        const center = size / 2;
+        const radius = 105;
+        const thetaRad = thetaDeg * Math.PI / 180;
+        const terminalX = center + radius * Math.cos(thetaRad);
+        const terminalY = center - radius * Math.sin(thetaRad);
+        const arcR = 42;
+        const norm = ((thetaDeg % 360) + 360) % 360;
+        const largeArcFlag = norm > 180 ? 1 : 0;
+        const sweepFlag = 0;
+        const arcStartX = center + arcR;
+        const arcStartY = center;
+        const arcEndX = center + arcR * Math.cos(thetaRad);
+        const arcEndY = center - arcR * Math.sin(thetaRad);
+        const thetaLabelX = center + (arcR + 20) * Math.cos(thetaRad / 2);
+        const thetaLabelY = center - (arcR + 20) * Math.sin(thetaRad / 2);
+
+        const refMarkup = referenceDeg === null ? '' : (() => {
+            const refR = 66;
+            const refStartAngle = thetaDeg >= 0 ? 0 : 360;
+            const refSweepDeg = thetaDeg >= 0 ? referenceDeg : -referenceDeg;
+            const startRad = refStartAngle * Math.PI / 180;
+            const endRad = (refStartAngle + refSweepDeg) * Math.PI / 180;
+            const refStartX = center + refR * Math.cos(startRad);
+            const refStartY = center - refR * Math.sin(startRad);
+            const refEndX = center + refR * Math.cos(endRad);
+            const refEndY = center - refR * Math.sin(endRad);
+            const refLargeArc = Math.abs(refSweepDeg) > 180 ? 1 : 0;
+            const refSweepFlag = refSweepDeg >= 0 ? 0 : 1;
+            const refLabelAngle = (refStartAngle + refSweepDeg / 2) * Math.PI / 180;
+            const refLabelX = center + (refR + 16) * Math.cos(refLabelAngle);
+            const refLabelY = center - (refR + 16) * Math.sin(refLabelAngle);
+            return `
+                <path d="M ${refStartX.toFixed(2)} ${refStartY.toFixed(2)} A ${refR} ${refR} 0 ${refLargeArc} ${refSweepFlag} ${refEndX.toFixed(2)} ${refEndY.toFixed(2)}"
+                    fill="none" stroke="#fbbf24" stroke-width="3" stroke-dasharray="4 4"></path>
+                ${showReferenceLabel ? `<text x="${refLabelX.toFixed(2)}" y="${refLabelY.toFixed(2)}" fill="#fbbf24" font-size="13" font-weight="600">ref = ${referenceDeg}°</text>` : ''}
+            `;
+        })();
+
+        return `
+            <svg viewBox="0 0 ${size} ${size}" width="300" height="300" role="img" aria-label="${fallbackText.replace(/"/g, '&quot;')}">
+                <rect x="0" y="0" width="${size}" height="${size}" fill="#0f172a"></rect>
+                <g stroke="#334155" stroke-width="1">
+                    ${Array.from({ length: 13 }, (_, i) => {
+                        const p = 30 + i * 20;
+                        return `<line x1="${p}" y1="30" x2="${p}" y2="270"></line><line x1="30" y1="${p}" x2="270" y2="${p}"></line>`;
+                    }).join('')}
+                </g>
+                <line x1="30" y1="${center}" x2="270" y2="${center}" stroke="#e2e8f0" stroke-width="2"></line>
+                <line x1="${center}" y1="30" x2="${center}" y2="270" stroke="#e2e8f0" stroke-width="2"></line>
+                <text x="273" y="${center - 5}" fill="#e2e8f0" font-size="12">x</text>
+                <text x="${center + 6}" y="26" fill="#e2e8f0" font-size="12">y</text>
+                <line x1="${center}" y1="${center}" x2="${terminalX.toFixed(2)}" y2="${terminalY.toFixed(2)}" stroke="#38bdf8" stroke-width="3"></line>
+                <circle cx="${center}" cy="${center}" r="4" fill="#e2e8f0"></circle>
+                <path d="M ${arcStartX} ${arcStartY} A ${arcR} ${arcR} 0 ${largeArcFlag} ${sweepFlag} ${arcEndX.toFixed(2)} ${arcEndY.toFixed(2)}"
+                    fill="none" stroke="#22c55e" stroke-width="3"></path>
+                <text x="${thetaLabelX.toFixed(2)}" y="${thetaLabelY.toFixed(2)}" fill="#22c55e" font-size="13" font-weight="600">${labelText}</text>
+                <text x="36" y="286" fill="#94a3b8" font-size="12">grid: 1 square = 1 unit</text>
+                ${refMarkup}
+            </svg>
+        `;
+    }
+
+    function createVectorSvg({ x, y, labelText, fallbackText }) {
+        const size = 300;
+        const center = size / 2;
+        const scale = 18;
+        const endX = center + x * scale;
+        const endY = center - y * scale;
+        return `
+            <svg viewBox="0 0 ${size} ${size}" width="300" height="300" role="img" aria-label="${fallbackText.replace(/"/g, '&quot;')}">
+                <defs>
+                    <marker id="vec-arrow" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+                        <polygon points="0 0, 9 4.5, 0 9" fill="#ff4d4d"></polygon>
+                    </marker>
+                </defs>
+                <rect x="0" y="0" width="${size}" height="${size}" fill="#0f172a"></rect>
+                <g stroke="#334155" stroke-width="1">
+                    ${Array.from({ length: 15 }, (_, i) => `<line x1="${i * 20 + 10}" y1="10" x2="${i * 20 + 10}" y2="290"></line>`).join('')}
+                    ${Array.from({ length: 15 }, (_, i) => `<line x1="10" y1="${i * 20 + 10}" x2="290" y2="${i * 20 + 10}"></line>`).join('')}
+                </g>
+                <line x1="10" y1="${center}" x2="290" y2="${center}" stroke="#e2e8f0" stroke-width="2"></line>
+                <line x1="${center}" y1="10" x2="${center}" y2="290" stroke="#e2e8f0" stroke-width="2"></line>
+                <text x="293" y="${center - 5}" fill="#e2e8f0" font-size="12">x</text>
+                <text x="${center + 6}" y="16" fill="#e2e8f0" font-size="12">y</text>
+                <line x1="${center}" y1="${center}" x2="${endX.toFixed(2)}" y2="${endY.toFixed(2)}" stroke="#ff4d4d" stroke-width="3" marker-end="url(#vec-arrow)"></line>
+                <circle cx="${center}" cy="${center}" r="4" fill="#e2e8f0"></circle>
+                <circle cx="${endX.toFixed(2)}" cy="${endY.toFixed(2)}" r="4" fill="#22c55e"></circle>
+                <text x="${Math.min(258, endX + 8).toFixed(2)}" y="${Math.max(18, endY - 8).toFixed(2)}" fill="#22c55e" font-size="13">(${x}, ${y})</text>
+                <text x="36" y="286" fill="#94a3b8" font-size="12">scale: 1 unit per grid line</text>
+                <text x="18" y="28" fill="#38bdf8" font-size="13" font-weight="600">${labelText}</text>
+            </svg>
+        `;
+    }
+
     const generators = [
         {
             id: 'angle_coterminal', section: 'Section 5.1',
@@ -1869,8 +1967,16 @@
                 const theta = (Math.floor(Math.random() * 25) + 1) * 15 * (Math.random() > 0.5 ? 1 : -1);
                 const k = Math.floor(Math.random() * 3) + 1;
                 const ans = theta + 360 * (Math.random() > 0.5 ? k : -k);
+                const normalizedTheta = normalizeDegrees(theta);
+                const fallbackText = `Standard-position angle theta = ${theta} degrees. Terminal side matches ${normalizedTheta} degrees.`;
                 return {
                     q: `Find one coterminal angle (in degrees) for $\theta = ${theta}^\circ$.`,
+                    svg: createAngleSvg({
+                        thetaDeg: normalizedTheta,
+                        labelText: `\u03b8=${theta}\u00b0`,
+                        fallbackText
+                    }),
+                    svgAltText: fallbackText,
                     inputType: 'coterminal_deg', baseTheta: theta, tol: 0.1,
                     solution: `Coterminal angles differ by multiples of $360^\circ$, so infinitely many answers are valid. One sample valid answer is $${theta} ${ans > theta ? '+' : '-'} ${Math.abs(ans - theta)} = ${ans}^\circ$.`
                 };
@@ -2066,8 +2172,17 @@
 
                 // Guard: by our convention with non-axis terminal sides, answer must be acute.
                 assertReferenceAngleConvention(ans);
+                const fallbackText = `Angle ${raw} degrees in standard position. Reference angle is ${ans} degrees.`;
                 return {
                     q: `Find the reference angle for $${raw}^\circ$.`,
+                    svg: createAngleSvg({
+                        thetaDeg: t,
+                        labelText: `${raw}\u00b0`,
+                        fallbackText,
+                        referenceDeg: ans,
+                        showReferenceLabel: true
+                    }),
+                    svgAltText: fallbackText,
                     inputType: 'number', a: ans, tol: 0.1,
                     solution: `First find a coterminal angle between $0^\circ$ and $360^\circ$: $${t}^\circ$. This generator excludes axis cases (${0}^\circ, ${90}^\circ, ${180}^\circ, ${270}^\circ), so the reference angle is the acute angle to the $x$-axis: $${ans}^\circ$.`
                 };
@@ -2214,43 +2329,36 @@
                 if (x2 === x1 && y2 === y1) x2 += 2;
                 const dx = x2 - x1;
                 const dy = y2 - y1;
-                const useGraphVariant = Math.random() < 0.5;
-
-                let svg = null;
-                let q = `Given points $P(${x1},${y1})$ and $Q(${x2},${y2})$, find $\vec{PQ}$ in component form.`;
-
-                if (useGraphVariant) {
-                    const px = 140 + x1 * 20;
-                    const py = 140 - y1 * 20;
-                    const qx = 140 + x2 * 20;
-                    const qy = 140 - y2 * 20;
-                    svg = `
-                        <svg viewBox="0 0 280 280" width="280" height="280" role="img" aria-label="Coordinate plane with vector from P to Q">
-                            <defs>
-                                <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="7" refY="3.5" orient="auto">
-                                    <polygon points="0 0, 8 3.5, 0 7" fill="#ff4d4d"></polygon>
-                                </marker>
-                            </defs>
-                            <rect x="0" y="0" width="280" height="280" fill="#0f172a"></rect>
-                            <g stroke="#334155" stroke-width="1">
-                                ${Array.from({ length: 15 }, (_, i) => `<line x1="${i * 20}" y1="0" x2="${i * 20}" y2="280"></line>`).join('')}
-                                ${Array.from({ length: 15 }, (_, i) => `<line x1="0" y1="${i * 20}" x2="280" y2="${i * 20}"></line>`).join('')}
-                            </g>
-                            <line x1="0" y1="140" x2="280" y2="140" stroke="#e2e8f0" stroke-width="2"></line>
-                            <line x1="140" y1="0" x2="140" y2="280" stroke="#e2e8f0" stroke-width="2"></line>
-                            <line x1="${px}" y1="${py}" x2="${qx}" y2="${qy}" stroke="#ff4d4d" stroke-width="3" marker-end="url(#arrowhead)"></line>
-                            <circle cx="${px}" cy="${py}" r="4" fill="#38bdf8"></circle>
-                            <circle cx="${qx}" cy="${qy}" r="4" fill="#22c55e"></circle>
-                            <text x="${px + 6}" y="${py - 8}" fill="#38bdf8" font-size="14">P(${x1},${y1})</text>
-                            <text x="${qx + 6}" y="${qy - 8}" fill="#22c55e" font-size="14">Q(${x2},${y2})</text>
-                        </svg>
-                    `;
-                    q = `Use the graph to find $\vec{PQ}$ in component form.`;
-                }
+                const fallbackText = `Coordinate graph with P(${x1}, ${y1}) and Q(${x2}, ${y2}). Find vector PQ.`;
+                const svg = `
+                    <svg viewBox="0 0 300 300" width="300" height="300" role="img" aria-label="${fallbackText}">
+                        <defs>
+                            <marker id="arrowhead-pq" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+                                <polygon points="0 0, 9 4.5, 0 9" fill="#ff4d4d"></polygon>
+                            </marker>
+                        </defs>
+                        <rect x="0" y="0" width="300" height="300" fill="#0f172a"></rect>
+                        <g stroke="#334155" stroke-width="1">
+                            ${Array.from({ length: 15 }, (_, i) => `<line x1="${i * 20 + 10}" y1="10" x2="${i * 20 + 10}" y2="290"></line>`).join('')}
+                            ${Array.from({ length: 15 }, (_, i) => `<line x1="10" y1="${i * 20 + 10}" x2="290" y2="${i * 20 + 10}"></line>`).join('')}
+                        </g>
+                        <line x1="10" y1="150" x2="290" y2="150" stroke="#e2e8f0" stroke-width="2"></line>
+                        <line x1="150" y1="10" x2="150" y2="290" stroke="#e2e8f0" stroke-width="2"></line>
+                        <text x="293" y="145" fill="#e2e8f0" font-size="12">x</text>
+                        <text x="156" y="16" fill="#e2e8f0" font-size="12">y</text>
+                        <line x1="${150 + x1 * 20}" y1="${150 - y1 * 20}" x2="${150 + x2 * 20}" y2="${150 - y2 * 20}" stroke="#ff4d4d" stroke-width="3" marker-end="url(#arrowhead-pq)"></line>
+                        <circle cx="${150 + x1 * 20}" cy="${150 - y1 * 20}" r="4" fill="#38bdf8"></circle>
+                        <circle cx="${150 + x2 * 20}" cy="${150 - y2 * 20}" r="4" fill="#22c55e"></circle>
+                        <text x="${158 + x1 * 20}" y="${142 - y1 * 20}" fill="#38bdf8" font-size="13">P(${x1},${y1})</text>
+                        <text x="${158 + x2 * 20}" y="${142 - y2 * 20}" fill="#22c55e" font-size="13">Q(${x2},${y2})</text>
+                        <text x="36" y="286" fill="#94a3b8" font-size="12">scale: 1 unit per grid line</text>
+                    </svg>
+                `;
 
                 return {
-                    q,
+                    q: `Use the graph to find $\vec{PQ}$ in component form. (Fallback text: Given points $P(${x1},${y1})$ and $Q(${x2},${y2})$.)`,
                     svg,
+                    svgAltText: fallbackText,
                     inputType: 'vector_xy',
                     a: { x: dx, y: dy },
                     tol: { x: 0.1, y: 0.1 },
@@ -2291,8 +2399,11 @@
                 let direction = Math.atan2(b, a) * 180 / Math.PI;
                 if (direction < 0) direction += 360;
                 const magnitude = Math.sqrt(a * a + b * b);
+                const fallbackText = `Vector from origin to (${a}, ${b}) on a coordinate grid.`;
                 return {
-                    q: `For vector $\langle ${a}, ${b}\rangle$, enter BOTH the magnitude and direction angle (in degrees, from $0^\circ$ to $360^\circ$).`,
+                    q: `Use the graph to enter BOTH the magnitude and direction angle (in degrees, from $0^\circ$ to $360^\circ$) of the vector. (Fallback text: vector $\langle ${a}, ${b}\rangle$.)`,
+                    svg: createVectorSvg({ x: a, y: b, labelText: `v = <${a}, ${b}>`, fallbackText }),
+                    svgAltText: fallbackText,
                     inputType: 'vector_mag_dir',
                     a: { mag: magnitude, dir: direction },
                     tol: { mag: 0.005, dir: 0.15 },
@@ -2723,7 +2834,8 @@
         // Handle SVG injection
         const svgContainer = document.getElementById('svg-display');
         if(currentQuestion.svg) {
-            svgContainer.innerHTML = currentQuestion.svg;
+            const fallback = currentQuestion.svgAltText ? `<p class="svg-fallback"><strong>Text fallback:</strong> ${currentQuestion.svgAltText}</p>` : '';
+            svgContainer.innerHTML = `${currentQuestion.svg}${fallback}`;
             svgContainer.style.display = 'block';
         } else {
             svgContainer.style.display = 'none';


### PR DESCRIPTION
### Motivation
- Provide SVG-backed visual prompts for standard-position/coterminal angle tasks and vector graph tasks so students see graphics that match the numeric data used for grading.
- Reuse the existing `#svg-display` pipeline so visuals integrate without changing the question flow and so a text-only fallback is available when needed.

### Description
- Added reusable SVG helper builders `createAngleSvg()` and `createVectorSvg()` that render labeled coordinate/grid visuals with explicit scale notes and accessible `aria-label` text.
- Updated generators `angle_coterminal` and `reference_angle_deg` to include `svg` and `svgAltText` outputs using the angle helper so the displayed terminal side, angle label, and reference-angle marker match the numeric values used for answers.
- Updated `vector_components` and `vector_mag_direction` to emit graph-based SVG prompts (with axis labels, grid scale text, and plotted points/arrow) and corresponding `svgAltText` fallbacks tied to the same component values used for grading.
- Extended `loadQuestion()` to append a visible text fallback block when a question provides `svgAltText`, and added `.svg-fallback` styling so the fallback is readable while preserving existing input handling and tolerances.

### Testing
- Ran a syntax check by extracting the inline script from `130Test3.html` and executing `node --check` against it, which completed successfully (exit 0). 
- Captured an automated page screenshot via Playwright of the updated page rendering the new SVG content, which succeeded and produced visual artifacts. 
- Attempted a Playwright interaction to click specific practice selectors to exercise generator paths, but that targeted interaction timed out in this environment (failed), so I used the screenshot-based render as validation instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3005f452c83318511d653684a94b2)