### PR TITLE
Align Test 3 review labels and checklist grouping with Unit 3 skills

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -1024,7 +1024,7 @@
 <div class="header-copy">
 <h1>Math 130 – Test 3 Review</h1>
 <p class="header-meta">Spring 2026 | Prof. Young &amp; Prof. Volk</p>
-<p class="header-subtitle">Topics: Sections 5.1–5.3, 5.7–7.1, and 8.4</p>
+<p class="header-subtitle">Topics: Sections 5.1–5.3, 7.1, and 8.4</p>
 <div class="header-chips">
 <span class="header-chip accent"><i data-lucide="route"></i> Recommended order: Slides → Formulas → Practice</span>
 <span class="header-chip"><i data-lucide="calendar-clock"></i> Test 3: Fri, May 1</span>
@@ -1124,7 +1124,7 @@
 </tr>
 <tr data-date="2026-04-15">
 <td>Wed, 4/15</td>
-<td>Quiz 10 &amp; Sections 5.7–7.1</td>
+<td>Quiz 10 &amp; Sections 5.2–7.1</td>
 <td>
 <span class="badge badge-class">CLASS</span>
 <span class="badge badge-quiz">QUIZ</span>
@@ -1213,7 +1213,7 @@
 <td class="aleks-status"></td>
 </tr>
 <tr data-due="2026-04-15T14:10:00">
-<td><strong>Sections 5.3 &amp; 5.7</strong></td>
+<td><strong>Section 5.3</strong></td>
 <td>Apr 8 at 2:11 PM</td>
 <td><strong>Apr 15 at 2:10 PM</strong></td>
 <td class="aleks-status"></td>
@@ -1375,19 +1375,19 @@
 <p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.9rem; text-align: center;">Each mock quiz has 5 one-attempt questions sampled from its listed section pool (Quiz 10 uses Section 5.2; Quizzes 11–13 use Sections 5.3, 7.1, and 8.4).</p>
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75rem;">
 <button class="btn-secondary" onclick="startMockQuiz(5)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 10 — Section 5.2</div>
-<div style="font-size: 0.8rem; color: var(--text-muted);">Angles, Coterminal Angles, Arc Length, and Basic Trig Ratios</div>
+<div style="font-weight: 600; margin-bottom: 2px;">Quiz 10 — Section 5.2 (Core Skills)</div>
+<div style="font-size: 0.8rem; color: var(--text-muted);">Calculator trig values + right-triangle side-length skills</div>
 </button>
 <button class="btn-secondary" onclick="startMockQuiz(6)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 11 — Section 5.3</div>
+<div style="font-weight: 600; margin-bottom: 2px;">Quiz 11 — Section 5.3 (Core Skills)</div>
 <div style="font-size: 0.8rem; color: var(--text-muted);">Reference Angles and Signs of Trig Functions</div>
 </button>
 <button class="btn-secondary" onclick="startMockQuiz(7)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 12 — Section 7.1</div>
+<div style="font-weight: 600; margin-bottom: 2px;">Quiz 12 — Section 7.1 (Core Skills)</div>
 <div style="font-size: 0.8rem; color: var(--text-muted);">Right-Triangle Applications and Solving Triangles</div>
 </button>
 <button class="btn-secondary" onclick="startMockQuiz(8)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 13 — Section 8.4</div>
+<div style="font-weight: 600; margin-bottom: 2px;">Quiz 13 — Section 8.4 (Core Skills)</div>
 <div style="font-size: 0.8rem; color: var(--text-muted);">Vector Components, Magnitude, and Direction Angles</div>
 </button>
 </div>
@@ -1483,23 +1483,23 @@
 <div id="video-progress" style="color: var(--text-muted); font-size: 0.95rem; font-weight: 500;"></div>
 </div>
 <div class="checklist-section">
-<h3>Section 5.2: Exponentials</h3>
+<h3>Section 5.2: Right-Triangle Trigonometry</h3>
 <div class="checklist-grid">
 <a class="check-item video-link" data-practice-id="trig_ratio" data-video-id="v42_1" href="https://www.youtube.com/watch?v=kikGvjKFN8Q" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>Graphing &amp; Tables</span>
+<span>Trig Ratios from Right Triangles</span>
 </a>
 <a class="check-item video-link" data-practice-id="trig_ratio" data-video-id="v42_2" href="https://www.youtube.com/watch?v=aix8TLHdKgc" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>Calculator: Decimal Exponents</span>
+<span>Calculator Trig Values (Degree/Radian Mode)</span>
 </a>
 <a class="check-item video-link" data-practice-id="angle_unit_conversion" data-video-id="v42_3" href="https://www.youtube.com/watch?v=NCYNXkbTTUo" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>Simple vs Compound Interest</span>
+<span>Degree/Radian Unit Conversion</span>
 </a>
 <a class="check-item video-link" data-practice-id="angle_unit_conversion" data-video-id="v42_4" href="https://www.youtube.com/watch?v=2S4vK30dII0" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>Continuous Compounding</span>
+<span>Side Lengths from Trig Ratios</span>
 </a>
 </div>
 </div>
@@ -1508,19 +1508,19 @@
 <div class="checklist-grid">
 <a class="check-item video-link" data-practice-id="reference_angle_deg" data-video-id="v43_1" href="https://www.youtube.com/watch?v=-ZQvz4bc2Eg" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>Log ↔ Exp Conversions</span>
+<span>Reference Angles (Degrees and Radians)</span>
 </a>
 <a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_2" href="https://www.youtube.com/watch?v=eL2FhO11mf0" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>Evaluating Log Expressions</span>
+<span>Quadrant Signs (ASTC)</span>
 </a>
 <a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_3" href="https://www.youtube.com/watch?v=3Rf8KEhY0ts" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>Logarithm Change of Base</span>
+<span>Reference Angles: Extra Practice</span>
 </a>
 <a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_4" href="https://www.youtube.com/watch?v=fnhFneOz6n8" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>Solving Exponential Eqns using Logs</span>
+<span>Trig Values from Quadrant + Reference Angle</span>
 </a>
 </div>
 </div>
@@ -1529,19 +1529,19 @@
 <div class="checklist-grid">
 <a class="check-item video-link" data-practice-id="solve_right_triangle" data-video-id="vgeo_1" href="https://www.youtube.com/watch?v=8ysZhPknfYY" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>Piecewise Rectangular Areas</span>
+<span>Solve a Right Triangle</span>
 </a>
 <a class="check-item video-link" data-practice-id="angle_of_elevation" data-video-id="vgeo_2" href="https://www.youtube.com/watch?v=FcDyaiHO4GQ" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>DMS to Decimal Conversion</span>
+<span>Angle of Elevation/Depression</span>
 </a>
 <a class="check-item video-link" data-practice-id="distance_rate_time" data-video-id="vgeo_3" href="https://www.youtube.com/watch?v=JmLN3QxshlE" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>Radians &amp; Degrees Intro</span>
+<span>Distance-Rate-Time with Trig</span>
 </a>
 <a class="check-item video-link" data-practice-id="vector_magnitude" data-video-id="vgeo_4" href="https://www.youtube.com/watch?v=XUus6-9E9sQ" style="text-decoration: none;" target="_blank">
 <i data-lucide="play" style="color: var(--accent);"></i>
-<span>Circle Sectors &amp; Arc Length</span>
+<span>Vector Magnitude and Direction</span>
 </a>
 </div>
 </div>
@@ -1600,8 +1600,8 @@
 <div class="slide-thumb-note">Add <code>Math130Unit3B.png</code> to the slides folder.</div>
 </div>
 </a>
-<h3>Reference Angles (5.3, 5.7)</h3>
-<p class="slide-subtitle">Covers reference angles and trig-function sign/value reasoning from Sections 5.3 and 5.7.</p>
+<h3>Reference Angles and Trig Signs (5.3)</h3>
+<p class="slide-subtitle">Covers reference angles plus trig-function sign/value reasoning from Section 5.3.</p>
 <div class="slide-actions">
 <a class="btn-primary" href="slides/Math130Unit3B.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
 <a class="btn-secondary" href="slides/Math130Unit3B.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
@@ -1692,10 +1692,8 @@
             { id: '51_4', cat: 'Section 5.1', label: 'Sketching an angle with absolute value greater than 360 degrees in standard position', done: false, practiceId: 'angle_coterminal' },
             { id: '51_5', cat: 'Section 5.1', label: 'Arc length and central angle measure', done: false, practiceId: 'arc_length' },
 
-            // Section 5.2 (10 topics)
+            // Section 5.2 (8 core topics + 2 supplemental conversion refreshers)
             { id: '52_1', cat: 'Section 5.2', label: 'Using a calculator to approximate sine, cosine, and tangent values', done: false, practiceId: 'trig_calculator_values' },
-            { id: '52_9', cat: 'Section 5.2', label: 'Convert degrees to radians', done: false, practiceId: 'angle_unit_conversion' },
-            { id: '52_10', cat: 'Section 5.2', label: 'Convert radians to degrees', done: false, practiceId: 'angle_unit_conversion' },
             { id: '52_2', cat: 'Section 5.2', label: 'Sine, cosine, and tangent ratios: Numbers for side lengths', done: false, practiceId: 'trig_ratio' },
             { id: '52_3', cat: 'Section 5.2', label: 'Sine, cosine, and tangent ratios: Variables for side lengths', done: false, practiceId: 'trig_ratio' },
             { id: '52_4', cat: 'Section 5.2', label: 'Using the Pythagorean Theorem to find a sine, cosine, or tangent ratio in a right triangle', done: false, practiceId: 'trig_ratio' },
@@ -1703,6 +1701,10 @@
             { id: '52_6', cat: 'Section 5.2', label: 'Using a trigonometric ratio to find a side length in a right triangle', done: false, practiceId: 'solve_right_triangle_side_52' },
             { id: '52_7', cat: 'Section 5.2', label: 'Using trigonometry to find a length in a word problem with one right triangle', done: false, practiceId: 'solve_right_triangle_side_52' },
             { id: '52_8', cat: 'Section 5.2', label: 'Using trigonometry to find lengths in a figure involving two right triangles', done: false, practiceId: 'two_right_triangles' },
+
+            // Supplemental angle-unit conversions (helpful review, not counted in the 33 core Unit 3 skills)
+            { id: '52_9', cat: 'Section 5.2 Supplementary', label: 'Convert degrees to radians', done: false, practiceId: 'angle_unit_conversion' },
+            { id: '52_10', cat: 'Section 5.2 Supplementary', label: 'Convert radians to degrees', done: false, practiceId: 'angle_unit_conversion' },
 
             // Section 5.3 (8 topics)
             { id: '53_1', cat: 'Section 5.3', label: 'Sketching an angle with absolute value less than 360 degrees, and also its reference angle', done: false, practiceId: 'reference_angle_deg' },
@@ -2621,9 +2623,10 @@
 
         const moduleGroups = [
             { key: 'm10', label: 'Trig Foundations (5.1–5.2)', cats: ['Section 5.1', 'Section 5.2'] },
-            { key: 'm11', label: 'Reference Angles (5.3, 5.7)', cats: ['Section 5.3'] },
+            { key: 'm11', label: 'Reference Angles and Trig Signs (5.3)', cats: ['Section 5.3'] },
             { key: 'm12', label: 'Right-Triangle Applications (7.1)', cats: ['Section 7.1'] },
-            { key: 'm13', label: 'Vectors (8.4)', cats: ['Section 8.4', 'Chapter 8 Supplementary'] }
+            { key: 'm13', label: 'Vectors (8.4)', cats: ['Section 8.4', 'Chapter 8 Supplementary'] },
+            { key: 'm10sup', label: 'Section 5.2 Supplementary (Angle Unit Conversion)', cats: ['Section 5.2 Supplementary'] }
         ];
         const groups = moduleGroups.filter(g => state.checklist.some(item => g.cats.includes(item.cat)));
 
@@ -3306,22 +3309,22 @@
     // --- MOCK QUIZ MODE ---
     const QUIZ_CONFIG = {
         5: {
-            label: 'Quiz 10 — Section 5.2',
+            label: 'Quiz 10 — Section 5.2 (Core Skills)',
             section: 'Section 5.2',
             count: 5
         },
         6: {
-            label: 'Quiz 11 — Section 5.3',
+            label: 'Quiz 11 — Section 5.3 (Core Skills)',
             section: 'Section 5.3',
             count: 5
         },
         7: {
-            label: 'Quiz 12 — Section 7.1',
+            label: 'Quiz 12 — Section 7.1 (Core Skills)',
             section: 'Section 7.1',
             count: 5
         },
         8: {
-            label: 'Quiz 13 — Section 8.4',
+            label: 'Quiz 13 — Section 8.4 (Core Skills)',
             section: 'Section 8.4',
             count: 5
         }


### PR DESCRIPTION
### Motivation
- Remove outdated/non-Unit-3 labels (references to exponentials/logs and Section 5.7) that were visible in the Test 3 review page to avoid confusion about scope. 
- Ensure the visible checklist and quiz groupings match the canonical Unit 3 skill breakdown in `unit3.txt` (5.1=5, 5.2=8, 5.3=8, 7.1=7, 8.4=4). 
- Surface which items are core vs supplementary (especially degree↔radian conversions) so students know what to prioritize.

### Description
- Updated `130Test3.html` header and schedule text to remove stale references to Section 5.7 and to list the correct Unit 3 sections. 
- Renamed video tiles, slide headings, and mock-quiz labels to reflect trig/vector content (e.g., `Section 5.2: Right-Triangle Trigonometry`, `Reference Angles and Trig Signs (5.3)`, quiz labels appended with “(Core Skills)”).
- Reorganized the `DEFAULT_CHECKLIST` in-page structure by keeping the 8 core Section 5.2 items in `Section 5.2` and moving degree/radian conversion items into a new `Section 5.2 Supplementary` category, and added a `moduleGroups` entry to surface the supplementary group in progress UI.
- No changes were made to the core generator logic or numeric tolerances; coterminal-radian inputs retain the existing exception for simple π expressions and repeating-decimal guidance remains unchanged.

### Testing
- Ran targeted text searches with `rg` to confirm stale phrases were removed and new labels were present; all searches returned expected results. 
- Executed a Python check that cross-references checklist `practiceId` values against the `generators` list to ensure no checklist-linked topics are missing matching practice generators; result: no missing links. 
- Launched a local server (`python -m http.server 8000`) and captured a post-change page screenshot using Playwright to validate visible label/layout updates; screenshot produced successfully. 
- Verified the in-page coverage audit routine still reports full coverage for checklist-linked topics (coverage audit string assembled and no missing generator ids).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b303cae9c08331bd0b9216bbb12e15)