### PR TITLE
Reorder and relabel Module 10 supplementary checklist group

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -2623,10 +2623,10 @@
 
         const moduleGroups = [
             { key: 'm10', label: 'Trig Foundations (5.1–5.2)', cats: ['Section 5.1', 'Section 5.2'] },
+            { key: 'm10sup', label: 'Module 10 Supplementary Refreshers (not core 33 topics)', cats: ['Section 5.2 Supplementary'] },
             { key: 'm11', label: 'Reference Angles and Trig Signs (5.3)', cats: ['Section 5.3'] },
             { key: 'm12', label: 'Right-Triangle Applications (7.1)', cats: ['Section 7.1'] },
-            { key: 'm13', label: 'Vectors (8.4)', cats: ['Section 8.4', 'Chapter 8 Supplementary'] },
-            { key: 'm10sup', label: 'Section 5.2 Supplementary (Angle Unit Conversion)', cats: ['Section 5.2 Supplementary'] }
+            { key: 'm13', label: 'Vectors (8.4)', cats: ['Section 8.4', 'Chapter 8 Supplementary'] }
         ];
         const groups = moduleGroups.filter(g => state.checklist.some(item => g.cats.includes(item.cat)));
 


### PR DESCRIPTION
### Motivation
- Ensure the Section 5.2 supplementary items are shown with Module 10 content (immediately after the Module 10 core group) instead of after Module 13 so related refreshers are grouped logically.
- Make the supplementary group's status explicit in the UI by renaming the label to avoid confusion with core Unit 3 topics.
- Preserve existing checklist item and practice IDs so saved progress continues to map correctly.

### Description
- Updated the `moduleGroups` array inside `renderChecklist()` in `130Test3.html` to place the `Section 5.2 Supplementary` group directly after the Module 10 core group and before Module 11/12/13 groups.
- Renamed the supplementary group label to `Module 10 Supplementary Refreshers (not core 33 topics)` to explicitly indicate its non-core status.
- Left checklist item IDs and practice IDs unchanged (e.g., `52_9`, `52_10`, `angle_unit_conversion`) so existing progress data remains valid.

### Testing
- Ran `rg` to verify the presence and ordering of `moduleGroups` and the supplementary items and confirmed matches (`rg -n "52_9|52_10|Section 5.2 Supplementary|moduleGroups"`); check passed.
- Launched a local server with `python3 -m http.server 8000` and loaded the page to exercise `renderChecklist()`; server startup and page load succeeded.
- Executed a Playwright script to open the page and capture a screenshot of the updated checklist ordering; the screenshot generation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3075682d48331a429af002c86f209)