### PR TITLE
Fix Unit label in Test 3 Practice tab (Unit 13 → Unit 3)

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -1359,14 +1359,14 @@
 <div class="tab-content" id="tab-practice">
 <div class="card">
 <h2 style="text-align: center; margin-bottom: 0.5rem;">Practice Generators</h2>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Practice generators are live for Unit 13 and aligned to Sections 5.1, 5.2, 5.3, 7.1, and 8.4.</p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Practice generators are live for Unit 3 and aligned to Sections 5.1, 5.2, 5.3, 7.1, and 8.4.</p>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">For decimal answers, enter rounded values as directed. Repeating decimals are accepted within tolerance (for example, $0.6667$ for $0.\overline{6}$). Unless a question explicitly says otherwise, enter a decimal number only (not $\pi$ notation).</p>
 <p id="coverage-audit" style="text-align: center; color: var(--text-muted); margin-bottom: 2rem; font-size: 0.9rem;"></p>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Select a topic to generate infinite, exam-style questions.</p>
 <!-- Mock Exam CTA -->
 <div id="exam-cta" style="background: linear-gradient(135deg, var(--accent-glow), var(--red-bg)); border: 2px solid var(--accent); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem; text-align: center;">
 <h3 style="font-family: 'DM Serif Display', serif; font-size: 1.4rem; margin-bottom: 0.5rem;">🎯 Mock Exam Mode</h3>
-<p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.95rem;">20 mixed Unit 13 review questions with coverage from Sections 5.1, 5.2, 5.3, 7.1, and 8.4 (at least one per section).</p>
+<p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.95rem;">20 mixed Unit 3 review questions with coverage from Sections 5.1, 5.2, 5.3, 7.1, and 8.4 (at least one per section).</p>
 <button class="btn-primary" id="btn-start-exam" onclick="startMockExam()">Start Mock Exam</button>
 </div>
 <!-- Mock Quiz CTA -->


### PR DESCRIPTION
### Motivation
- The Practice tab and Mock Exam blurb on the Test 3 page referenced “Unit 13” instead of the intended “Unit 3”, causing an incorrect unit label that needed correction.
- The change should not modify the listed section coverage or other content.

### Description
- Replaced the Practice intro sentence in `130Test3.html` to read “Unit 3” instead of “Unit 13” while preserving the section list text.
- Updated the Mock Exam blurb in the same Practice card from “Unit 13” to “Unit 3” for consistency.
- Searched the page for remaining `Unit 13` occurrences and confirmed none remain.

### Testing
- Ran `rg -n "Unit 13|Unit 3" 130Test3.html` to verify the updated occurrences show `Unit 3` and no `Unit 13` remains.
- Inspected the updated context with `sed -n '1325,1405p' 130Test3.html` and `nl -ba 130Test3.html | sed -n '1356,1374p'` to confirm the new text appears in place and context.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b307e8e5c88331ab0d0147e21a3415)