### PR TITLE
Clarify default decimal-entry guidance in practice headers

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -1415,7 +1415,7 @@
 <div class="card">
 <h2 style="text-align: center; margin-bottom: 0.5rem;">Practice Generators</h2>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Select a topic to generate infinite, exam-style questions.</p>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">For decimal answers, enter rounded values as directed. Repeating decimals are accepted within tolerance (for example, $0.3333$ for $0.\overline{3}$). Unless a question explicitly says otherwise, enter a decimal number only (not $\pi$ notation).</p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">By default, enter decimal answers rounded as directed. Repeating decimals are accepted within tolerance (for example, $0.3333$ for $0.\overline{3}$). Some generators may allow additional formats noted in the question (for example, $\pi$ forms).</p>
 <p id="coverage-audit" style="text-align: center; color: var(--text-muted); margin-bottom: 2rem; font-size: 0.9rem;"></p>
 <!-- Mock Exam CTA -->
 <div id="exam-cta" style="background: linear-gradient(135deg, var(--accent-glow), var(--red-bg)); border: 2px solid var(--accent); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem; text-align: center;">

--- a/130Test3.html
+++ b/130Test3.html
@@ -1360,7 +1360,7 @@
 <div class="card">
 <h2 style="text-align: center; margin-bottom: 0.5rem;">Practice Generators</h2>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Practice generators are live for Unit 3 and aligned to Sections 5.1, 5.2, 5.3, 7.1, and 8.4.</p>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">For decimal answers, enter rounded values as directed. Repeating decimals are accepted within tolerance (for example, $0.6667$ for $0.\overline{6}$). Unless a question explicitly says otherwise, enter a decimal number only (not $\pi$ notation).</p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">By default, enter decimal answers rounded as directed. Repeating decimals are accepted within tolerance (for example, $0.6667$ for $0.\overline{6}$). Some generators may allow additional formats noted in the question (for example, $\pi$ forms), including coterminal-radian items that accept simple $\pi$ expressions.</p>
 <p id="coverage-audit" style="text-align: center; color: var(--text-muted); margin-bottom: 2rem; font-size: 0.9rem;"></p>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Select a topic to generate infinite, exam-style questions.</p>
 <!-- Mock Exam CTA -->


### PR DESCRIPTION
### Motivation
- Make the top-of-page practice guidance explicit that decimal entry is the default while acknowledging that some generators may accept alternate formats (for example, π notation) and to call out the coterminal-radian exception in plain language.

### Description
- Update the practice guidance paragraphs in `130Test2.html` and `130Test3.html` to say: by default enter decimal answers rounded as directed; repeating decimals are accepted within tolerance; some generators may allow additional formats noted in the question (e.g., π forms), and `130Test3.html` explicitly references coterminal-radian items that accept simple `π` expressions — no generator logic was changed.

### Testing
- Confirmed the change by inspecting the `git diff` and committing the files; served the site with `python3 -m http.server` and captured a screenshot via a Playwright script to verify the updated wording, and all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30b64c6748331837a50538ad6f691)