### PR TITLE
Adjust piecewise_rect SVG label positions for w2 and h2

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -2567,8 +2567,8 @@
                     <polygon points="${2*s},${2*s} ${(w1+2)*s},${2*s} ${(w1+2)*s},${(h1-h2+2)*s} ${(w1-w2+2)*s},${(h1-h2+2)*s} ${(w1-w2+2)*s},${(h1+2)*s} ${2*s},${(h1+2)*s}" fill="var(--surface)" stroke="var(--accent)" stroke-width="2"/>
                     <text x="${(w1/2+2)*s}" y="${1.4*s}" fill="var(--text)" font-size="13" text-anchor="middle">${w1}</text>
                     <text x="${0.8*s}" y="${(h1/2+2)*s}" fill="var(--text)" font-size="13" text-anchor="middle">${h1}</text>
-                    <text x="${(w1-w2/2+2)*s}" y="${(h1+2)*s + 14}" fill="var(--text)" font-size="13" text-anchor="middle">${w2}</text>
-                    <text x="${(w1+2)*s + 14}" y="${(h1-h2/2-h2+4)*s/2 + 10}" fill="var(--text)" font-size="13" text-anchor="start">${h2}</text>
+                    <text x="${(w1-w2/2+2)*s}" y="${(h1-h2+2)*s + 14}" fill="var(--text)" font-size="13" text-anchor="middle">${w2}</text>
+                    <text x="${(w1-w2+2)*s - 6}" y="${(h1-h2/2+2)*s + 4}" fill="var(--text)" font-size="13" text-anchor="start">${h2}</text>
                 </svg>`;
                 return {
                     q: `Find the total area of the L-shaped figure.`,


### PR DESCRIPTION
### Motivation
- Fix positioning of the width/height labels in the `piecewise_rect` SVG so `w2` and `h2` render near their respective edges and avoid overlap.

### Description
- Updated the `piecewise_rect` generator in `130Test2.html` by changing the two `<text>` nodes to `w2` -> `x="${(w1-w2/2+2)*s}" y="${(h1-h2+2)*s + 14}"` and `h2` -> `x="${(w1-w2+2)*s - 6}" y="${(h1-h2/2+2)*s + 4}"`, keeping existing `fill`, `font-size`, and `text-anchor` attributes.

### Testing
- Searched for relevant identifiers with `rg -n "piecewise_rect|w2|h2" 130Test2.html` and verified the updated lines; the search succeeded.
- Inspected the changes with `git diff -- 130Test2.html` which showed the two text-node updates; the diff matched expectations.
- Served the page with `python3 -m http.server 4173 --bind 0.0.0.0` and captured a Playwright screenshot using `mcp__browser_tools__run_playwright_script`, producing an artifact confirming the adjusted label positions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b330a4cf688331a76419126e2bb2ba)