### PR TITLE
Fix Quiz 7 parallel-lines angle label placement

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -2515,12 +2515,12 @@
             <line x1="130" y1="20" x2="350" y2="230" stroke="var(--green)" stroke-width="3"/>
             <text x="28" y="72" fill="var(--text-muted)" font-size="12">j</text>
             <text x="28" y="182" fill="var(--text-muted)" font-size="12">k</text>
-            <text x="92" y="58" fill="var(--text)" font-size="12">∠1 = ${acute}°</text>
+            <text x="205" y="58" fill="var(--text)" font-size="12">∠1 = ${acute}°</text>
             <text x="348" y="205" fill="var(--text)" font-size="12">∠8 = ${obtuse}°</text>
-            <text x="185" y="46" fill="var(--text-muted)" font-size="12">∠2 = ?</text>
+            <text x="92" y="58" fill="var(--text-muted)" font-size="12">∠2 = ?</text>
             <text x="141" y="96" fill="var(--text-muted)" font-size="12">∠3 = ?</text>
-            <text x="223" y="156" fill="var(--text-muted)" font-size="12">∠6 = ?</text>
-            <text x="314" y="165" fill="var(--text-muted)" font-size="12">∠7 = ?</text>
+            <text x="314" y="165" fill="var(--text-muted)" font-size="12">∠6 = ?</text>
+            <text x="223" y="156" fill="var(--text-muted)" font-size="12">∠7 = ?</text>
         </svg>`;
 
         return {


### PR DESCRIPTION
### Motivation
- Correct mismatched angle labels in the `quiz7_parallel_multi` SVG so the displayed acute/obtuse values appear in geometrically matching regions while keeping all math logic and answers unchanged.

### Description
- Repositioned SVG text coordinates so `∠1 = ${acute}°` is moved from the previous top-left location to the top-right acute region and the unknown labels were rearranged to match geometry (`∠2`, `∠6`, `∠7` positions updated). 
- Left the numeric assignments, answer keys, and solution narrative intact so the existing relationships (linear pair / vertical / corresponding / supplementary) remain correct.
- Modified only the label placement in `130Test2.html` (SVG block for `quiz7_parallel_multi`).

### Testing
- Inspected the updated SVG block with `nl -ba 130Test2.html | sed -n '2508,2538p'` to confirm the new `text` coordinates and placements were applied (succeeded). 
- Verified the file diff to ensure only label coordinate lines changed (succeeded). 
- Attempted to capture a headless screenshot for visual validation with Playwright, but the browser run failed due to environment/network constraints (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33311a08483319a6694de8fbdf141)