### PR TITLE
Add rel="noopener noreferrer" to all target="_blank" anchors in 130Test2/130Test3 pages

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -1540,19 +1540,19 @@
 <div class="checklist-section">
 <h3>Section 4.2: Exponentials</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="exp_table_graph" data-video-id="v42_1" href="https://www.youtube.com/watch?v=kikGvjKFN8Q" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="exp_table_graph" data-video-id="v42_1" href="https://www.youtube.com/watch?v=kikGvjKFN8Q" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Graphing &amp; Tables</span>
 </a>
-<a class="check-item video-link" data-practice-id="exp_table_graph" data-video-id="v42_2" href="https://www.youtube.com/watch?v=aix8TLHdKgc" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="exp_table_graph" data-video-id="v42_2" href="https://www.youtube.com/watch?v=aix8TLHdKgc" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Calculator: Decimal Exponents</span>
 </a>
-<a class="check-item video-link" data-practice-id="interest" data-video-id="v42_3" href="https://www.youtube.com/watch?v=NCYNXkbTTUo" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="interest" data-video-id="v42_3" href="https://www.youtube.com/watch?v=NCYNXkbTTUo" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Simple vs Compound Interest</span>
 </a>
-<a class="check-item video-link" data-practice-id="interest" data-video-id="v42_4" href="https://www.youtube.com/watch?v=2S4vK30dII0" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="interest" data-video-id="v42_4" href="https://www.youtube.com/watch?v=2S4vK30dII0" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Continuous Compounding</span>
 </a>
@@ -1561,19 +1561,19 @@
 <div class="checklist-section" style="margin-top: 2rem;">
 <h3>Section 4.3: Logarithms</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="logexp_conv" data-video-id="v43_1" href="https://www.youtube.com/watch?v=-ZQvz4bc2Eg" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="logexp_conv" data-video-id="v43_1" href="https://www.youtube.com/watch?v=-ZQvz4bc2Eg" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Log ↔ Exp Conversions</span>
 </a>
-<a class="check-item video-link" data-practice-id="logexp" data-video-id="v43_2" href="https://www.youtube.com/watch?v=eL2FhO11mf0" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="logexp" data-video-id="v43_2" href="https://www.youtube.com/watch?v=eL2FhO11mf0" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Evaluating Log Expressions</span>
 </a>
-<a class="check-item video-link" data-practice-id="logexp" data-video-id="v43_3" href="https://www.youtube.com/watch?v=3Rf8KEhY0ts" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="logexp" data-video-id="v43_3" href="https://www.youtube.com/watch?v=3Rf8KEhY0ts" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Logarithm Change of Base</span>
 </a>
-<a class="check-item video-link" data-practice-id="logexp" data-video-id="v43_4" href="https://www.youtube.com/watch?v=fnhFneOz6n8" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="logexp" data-video-id="v43_4" href="https://www.youtube.com/watch?v=fnhFneOz6n8" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Solving Exponential Eqns using Logs</span>
 </a>
@@ -1582,19 +1582,19 @@
 <div class="checklist-section" style="margin-top: 2rem;">
 <h3>Geometry &amp; Circles</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="piecewise_rect" data-video-id="vgeo_1" href="https://www.youtube.com/watch?v=8ysZhPknfYY" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="piecewise_rect" data-video-id="vgeo_1" href="https://www.youtube.com/watch?v=8ysZhPknfYY" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Piecewise Rectangular Areas</span>
 </a>
-<a class="check-item video-link" data-practice-id="dms_to_dec" data-video-id="vgeo_2" href="https://www.youtube.com/watch?v=FcDyaiHO4GQ" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="dms_to_dec" data-video-id="vgeo_2" href="https://www.youtube.com/watch?v=FcDyaiHO4GQ" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>DMS to Decimal Conversion</span>
 </a>
-<a class="check-item video-link" data-practice-id="std_pos_angle" data-video-id="vgeo_3" href="https://www.youtube.com/watch?v=JmLN3QxshlE" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="std_pos_angle" data-video-id="vgeo_3" href="https://www.youtube.com/watch?v=JmLN3QxshlE" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Radians &amp; Degrees Intro</span>
 </a>
-<a class="check-item video-link" data-practice-id="circles" data-video-id="vgeo_4" href="https://www.youtube.com/watch?v=XUus6-9E9sQ" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="circles" data-video-id="vgeo_4" href="https://www.youtube.com/watch?v=XUus6-9E9sQ" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Circle Sectors &amp; Arc Length</span>
 </a>
@@ -1627,7 +1627,7 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Unit 2A</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit2A.pdf" target="_blank" aria-label="Open Unit 2A PDF slides">
+<a class="slide-thumb-wrap" href="slides/Math130Unit2A.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Unit 2A PDF slides">
 <img alt="Thumbnail preview for Math 130 Unit 2A lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit2A.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
@@ -1638,8 +1638,8 @@
 <h3>Math 130 Unit 2A: 4.2 Exponential Functions</h3>
 <p class="slide-subtitle">Covers exponential functions, tables, graphs, growth and decay, and the core algebraic ideas from Section 4.2.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit2A.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit2A.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit2A.pdf" target="_blank" rel="noopener noreferrer"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit2A.pptx" target="_blank" rel="noopener noreferrer"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1647,7 +1647,7 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Unit 2B</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit2B.pdf" target="_blank" aria-label="Open Unit 2B PDF slides">
+<a class="slide-thumb-wrap" href="slides/Math130Unit2B.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Unit 2B PDF slides">
 <img alt="Thumbnail preview for Math 130 Unit 2B lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit2B.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
@@ -1658,8 +1658,8 @@
 <h3>Math 130 Unit 2B: 4.3 Logarithmic Functions</h3>
 <p class="slide-subtitle">Covers logarithmic functions, inverse relationships with exponentials, evaluation, rewriting, and graph interpretation from Section 4.3.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit2B.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit2B.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit2B.pdf" target="_blank" rel="noopener noreferrer"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit2B.pptx" target="_blank" rel="noopener noreferrer"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1667,7 +1667,7 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Unit 2C</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit2C.pdf" target="_blank" aria-label="Open Unit 2C PDF slides">
+<a class="slide-thumb-wrap" href="slides/Math130Unit2C.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Unit 2C PDF slides">
 <img alt="Thumbnail preview for Math 130 Unit 2C lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit2C.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
@@ -1678,8 +1678,8 @@
 <h3>Math 130 Unit 2C: Geometry Angles and Polygons</h3>
 <p class="slide-subtitle">Covers angle relationships, parallel lines, polygon angle sums, and the main geometry vocabulary and problem types for this unit.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit2C.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit2C.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit2C.pdf" target="_blank" rel="noopener noreferrer"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit2C.pptx" target="_blank" rel="noopener noreferrer"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1687,7 +1687,7 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Unit 2D</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit2D.pdf" target="_blank" aria-label="Open Unit 2D PDF slides">
+<a class="slide-thumb-wrap" href="slides/Math130Unit2D.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Unit 2D PDF slides">
 <img alt="Thumbnail preview for Math 130 Unit 2D lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit2D.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
@@ -1698,8 +1698,8 @@
 <h3>Math 130 Unit 2D: Geometry Circles and Solids</h3>
 <p class="slide-subtitle">Covers circle measures, arc and sector ideas, and solid geometry topics such as surface area and volume.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit2D.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit2D.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit2D.pdf" target="_blank" rel="noopener noreferrer"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit2D.pptx" target="_blank" rel="noopener noreferrer"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1707,7 +1707,7 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Unit 2E</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit2E.pdf" target="_blank" aria-label="Open Unit 2E PDF slides">
+<a class="slide-thumb-wrap" href="slides/Math130Unit2E.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Unit 2E PDF slides">
 <img alt="Thumbnail preview for Math 130 Unit 2E lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit2E.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
@@ -1718,8 +1718,8 @@
 <h3>Math 130 Unit 2E: Test Review</h3>
 <p class="slide-subtitle">Consolidates the major skills across exponentials, logarithms, and geometry into a focused review deck for Test 2.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit2E.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit2E.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit2E.pdf" target="_blank" rel="noopener noreferrer"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit2E.pptx" target="_blank" rel="noopener noreferrer"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 </div>
@@ -3166,7 +3166,7 @@
                 div.innerHTML = `
                     <div class="check-box">${item.done ? '<i data-lucide="check" style="width:16px; color:white;"></i>' : ''}</div>
                     <span style="flex: 1;">${item.label}</span>
-                    ${item.videoUrl ? `<a href="${item.videoUrl}" target="_blank" class="practice-link" onclick="event.stopPropagation()" title="Watch Video" aria-label="Watch related video"><i data-lucide="play" style="width:18px; height:18px;"></i></a>` : ''}
+                    ${item.videoUrl ? `<a href="${item.videoUrl}" target="_blank" rel="noopener noreferrer" class="practice-link" onclick="event.stopPropagation()" title="Watch Video" aria-label="Watch related video"><i data-lucide="play" style="width:18px; height:18px;"></i></a>` : ''}
                     ${item.practiceId ? `<div class="practice-link" onclick="goToPractice('${item.practiceId}', event)" title="Jump to Interactive Practice"><i data-lucide="pen-tool" style="width:18px; height:18px;"></i></div>` : ''}
                 `;
                 div.addEventListener('click', () => { 

--- a/130Test3.html
+++ b/130Test3.html
@@ -1485,19 +1485,19 @@
 <div class="checklist-section">
 <h3>Section 5.2: Right-Triangle Trigonometry</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="trig_ratio" data-video-id="v42_1" href="https://www.youtube.com/watch?v=kikGvjKFN8Q" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="trig_ratio" data-video-id="v42_1" href="https://www.youtube.com/watch?v=kikGvjKFN8Q" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Trig Ratios from Right Triangles</span>
 </a>
-<a class="check-item video-link" data-practice-id="trig_ratio" data-video-id="v42_2" href="https://www.youtube.com/watch?v=aix8TLHdKgc" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="trig_ratio" data-video-id="v42_2" href="https://www.youtube.com/watch?v=aix8TLHdKgc" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Calculator Trig Values (Degree/Radian Mode)</span>
 </a>
-<a class="check-item video-link" data-practice-id="angle_unit_conversion" data-video-id="v42_3" href="https://www.youtube.com/watch?v=NCYNXkbTTUo" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="angle_unit_conversion" data-video-id="v42_3" href="https://www.youtube.com/watch?v=NCYNXkbTTUo" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Degree/Radian Unit Conversion</span>
 </a>
-<a class="check-item video-link" data-practice-id="angle_unit_conversion" data-video-id="v42_4" href="https://www.youtube.com/watch?v=2S4vK30dII0" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="angle_unit_conversion" data-video-id="v42_4" href="https://www.youtube.com/watch?v=2S4vK30dII0" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Side Lengths from Trig Ratios</span>
 </a>
@@ -1506,19 +1506,19 @@
 <div class="checklist-section" style="margin-top: 2rem;">
 <h3>Section 5.3: Reference Angles and Signs of Trig Functions</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="reference_angle_deg" data-video-id="v43_1" href="https://www.youtube.com/watch?v=-ZQvz4bc2Eg" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="reference_angle_deg" data-video-id="v43_1" href="https://www.youtube.com/watch?v=-ZQvz4bc2Eg" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Reference Angles (Degrees and Radians)</span>
 </a>
-<a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_2" href="https://www.youtube.com/watch?v=eL2FhO11mf0" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_2" href="https://www.youtube.com/watch?v=eL2FhO11mf0" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Quadrant Signs (ASTC)</span>
 </a>
-<a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_3" href="https://www.youtube.com/watch?v=3Rf8KEhY0ts" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_3" href="https://www.youtube.com/watch?v=3Rf8KEhY0ts" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Reference Angles: Extra Practice</span>
 </a>
-<a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_4" href="https://www.youtube.com/watch?v=fnhFneOz6n8" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_4" href="https://www.youtube.com/watch?v=fnhFneOz6n8" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Trig Values from Quadrant + Reference Angle</span>
 </a>
@@ -1527,19 +1527,19 @@
 <div class="checklist-section" style="margin-top: 2rem;">
 <h3>Geometry &amp; Section 8.4</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="solve_right_triangle" data-video-id="vgeo_1" href="https://www.youtube.com/watch?v=8ysZhPknfYY" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="solve_right_triangle" data-video-id="vgeo_1" href="https://www.youtube.com/watch?v=8ysZhPknfYY" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Solve a Right Triangle</span>
 </a>
-<a class="check-item video-link" data-practice-id="angle_of_elevation" data-video-id="vgeo_2" href="https://www.youtube.com/watch?v=FcDyaiHO4GQ" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="angle_of_elevation" data-video-id="vgeo_2" href="https://www.youtube.com/watch?v=FcDyaiHO4GQ" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Angle of Elevation/Depression</span>
 </a>
-<a class="check-item video-link" data-practice-id="distance_rate_time" data-video-id="vgeo_3" href="https://www.youtube.com/watch?v=JmLN3QxshlE" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="distance_rate_time" data-video-id="vgeo_3" href="https://www.youtube.com/watch?v=JmLN3QxshlE" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Distance-Rate-Time with Trig</span>
 </a>
-<a class="check-item video-link" data-practice-id="vector_magnitude" data-video-id="vgeo_4" href="https://www.youtube.com/watch?v=XUus6-9E9sQ" style="text-decoration: none;" target="_blank">
+<a class="check-item video-link" data-practice-id="vector_magnitude" data-video-id="vgeo_4" href="https://www.youtube.com/watch?v=XUus6-9E9sQ" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Vector Magnitude and Direction</span>
 </a>
@@ -1572,7 +1572,7 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Module 10</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit3A.pdf" target="_blank" aria-label="Open Module 10 PDF slides">
+<a class="slide-thumb-wrap" href="slides/Math130Unit3A.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Module 10 PDF slides">
 <img alt="Thumbnail preview for Math 130 Module 10 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3A.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
@@ -1583,8 +1583,8 @@
 <h3>Trig Foundations (5.1–5.2)</h3>
 <p class="slide-subtitle">Covers angle sketching, coterminal angles, and arc length/central-angle skills from Sections 5.1 and 5.2.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit3A.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit3A.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit3A.pdf" target="_blank" rel="noopener noreferrer"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit3A.pptx" target="_blank" rel="noopener noreferrer"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1592,7 +1592,7 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Module 11</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit3B.pdf" target="_blank" aria-label="Open Module 11 PDF slides">
+<a class="slide-thumb-wrap" href="slides/Math130Unit3B.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Module 11 PDF slides">
 <img alt="Thumbnail preview for Math 130 Module 11 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3B.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
@@ -1603,8 +1603,8 @@
 <h3>Reference Angles and Trig Signs (5.3)</h3>
 <p class="slide-subtitle">Covers reference angles plus trig-function sign/value reasoning from Section 5.3.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit3B.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit3B.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit3B.pdf" target="_blank" rel="noopener noreferrer"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit3B.pptx" target="_blank" rel="noopener noreferrer"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1612,7 +1612,7 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Module 12</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit3C.pdf" target="_blank" aria-label="Open Module 12 PDF slides">
+<a class="slide-thumb-wrap" href="slides/Math130Unit3C.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Module 12 PDF slides">
 <img alt="Thumbnail preview for Math 130 Module 12 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3C.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
@@ -1623,8 +1623,8 @@
 <h3>Right-Triangle Applications (7.1)</h3>
 <p class="slide-subtitle">Covers right-triangle trigonometry applications and modeling problems from Section 7.1.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit3C.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit3C.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit3C.pdf" target="_blank" rel="noopener noreferrer"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit3C.pptx" target="_blank" rel="noopener noreferrer"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1632,7 +1632,7 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Module 13</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit3D.pdf" target="_blank" aria-label="Open Module 13 PDF slides">
+<a class="slide-thumb-wrap" href="slides/Math130Unit3D.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Module 13 PDF slides">
 <img alt="Thumbnail preview for Math 130 Module 13 lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3D.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
@@ -1643,8 +1643,8 @@
 <h3>Vectors (8.4)</h3>
 <p class="slide-subtitle">Covers vector component form, operations, magnitude, and direction from Section 8.4.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit3D.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit3D.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit3D.pdf" target="_blank" rel="noopener noreferrer"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit3D.pptx" target="_blank" rel="noopener noreferrer"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 <div class="slide-card">
@@ -1652,7 +1652,7 @@
 <div class="slide-badge"><i data-lucide="presentation"></i> Unit 3 Review</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit3E.pdf" target="_blank" aria-label="Open Unit 3 Review PDF slides">
+<a class="slide-thumb-wrap" href="slides/Math130Unit3E.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Unit 3 Review PDF slides">
 <img alt="Thumbnail preview for Math 130 Unit 3 Review lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3E.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
@@ -1663,8 +1663,8 @@
 <h3>Math 130 Unit 3: Test 3 Review</h3>
 <p class="slide-subtitle">Consolidates Modules 10–13 into a focused Test 3 review aligned to the Unit 3 checklist.</p>
 <div class="slide-actions">
-<a class="btn-primary" href="slides/Math130Unit3E.pdf" target="_blank"><i data-lucide="file-text"></i><span>View PDF</span></a>
-<a class="btn-secondary" href="slides/Math130Unit3E.pptx" target="_blank"><i data-lucide="download"></i><span>Download PPTX</span></a>
+<a class="btn-primary" href="slides/Math130Unit3E.pdf" target="_blank" rel="noopener noreferrer"><i data-lucide="file-text"></i><span>View PDF</span></a>
+<a class="btn-secondary" href="slides/Math130Unit3E.pptx" target="_blank" rel="noopener noreferrer"><i data-lucide="download"></i><span>Download PPTX</span></a>
 </div>
 </div>
 </div>
@@ -2707,7 +2707,7 @@
                 div.innerHTML = `
                     <div class="check-box">${item.done ? '<i data-lucide="check" style="width:16px; color:white;"></i>' : ''}</div>
                     <span style="flex: 1;">${item.label}</span>
-                    ${item.videoUrl ? `<a href="${item.videoUrl}" target="_blank" class="practice-link" onclick="event.stopPropagation()" title="Watch Video" aria-label="Watch related video"><i data-lucide="play" style="width:18px; height:18px;"></i></a>` : ''}
+                    ${item.videoUrl ? `<a href="${item.videoUrl}" target="_blank" rel="noopener noreferrer" class="practice-link" onclick="event.stopPropagation()" title="Watch Video" aria-label="Watch related video"><i data-lucide="play" style="width:18px; height:18px;"></i></a>` : ''}
                     ${item.practiceId ? `<div class="practice-link" onclick="goToPractice('${item.practiceId}', event)" title="Jump to Interactive Practice"><i data-lucide="pen-tool" style="width:18px; height:18px;"></i></div>` : ''}
                 `;
                 div.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Close a security/privacy gap by ensuring every `target="_blank"` anchor includes `rel="noopener noreferrer"` to prevent reverse tabnabbing and leaking `window.opener`.
- Ensure the fix covers both static HTML anchors (video cards, slide thumbnails/buttons, header external links) and anchors generated dynamically from JS template literals.

### Description
- Updated `130Test2.html` to add `rel="noopener noreferrer"` to all `target="_blank"` anchors, including checklist video links and slide thumbnail/button links.
- Updated `130Test3.html` to make the same additions for its static anchors and slide links.
- Modified the JS template literals that render checklist items (the `item.videoUrl` anchor) in both files so dynamically generated `_blank` links also include `rel="noopener noreferrer"`.

### Testing
- Ran `rg -n 'target="_blank"(?![^\\n>]*rel=)' -P 130Test2.html 130Test3.html` and observed no matches indicating no `_blank` anchors are missing a `rel` attribute.
- Ran `rg -n 'target="_blank"' 130Test2.html 130Test3.html` and inspected the results to confirm each occurrence now includes `rel="noopener noreferrer"`.
- Printed sample regions with `nl` to visually verify the inserted `rel` attributes in both files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b341a4fe208331aaa67e3e7778a69c)