### PR TITLE
Exclude evaluated x from exponential reference table rows

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -2026,10 +2026,18 @@
                 const shift = Math.floor(Math.random() * 9) - 4;
                 const mode = Math.random();
 
+                const ensureXExcludedFromList = (xList, x) => {
+                    if (xList.includes(x)) {
+                        throw new Error('Reference xList must exclude the requested x value.');
+                    }
+                };
+
                 if (mode < 0.5) {
                     const x = Math.floor(Math.random() * 5) - 2;
                     const y = coeff * Math.pow(base, x) + shift;
-                    const xList = [-1, 0, 1];
+                    const xCandidates = [-2, -1, 0, 1, 2];
+                    const xList = xCandidates.filter(v => v !== x).slice(0, 3);
+                    ensureXExcludedFromList(xList, x);
                     const rows = xList.map(v => `(${v}, ${(coeff * Math.pow(base, v) + shift).toFixed(2)})`).join(', ');
 
                     return {


### PR DESCRIPTION
### Motivation
- Prevent the requested evaluation input `x` from appearing among the displayed reference table rows so the table cannot inadvertently reveal the answer. 
- Keep the reference table UI stable by always showing exactly three reference rows.

### Description
- In `130Test2.html` updated the `exp_table_graph` generator so the requested `x` is chosen first in the table-mode branch (`if (mode < 0.5)`).
- Build `xList` from `xCandidates = [-2, -1, 0, 1, 2]` and filter out the selected `x`, then `slice(0, 3)` to keep exactly three rows. 
- Added a small helper `ensureXExcludedFromList(xList, x)` that throws if `x` appears in `xList` before rendering `rows` to assert the invariant. 
- Left all answer/solution math unchanged (`y` and the solution expression remain as before).

### Testing
- Ran a Node one-liner to verify for every `x` in `[-2,2]` that `x` is excluded and `xList.length === 3`, and it passed. 
- Inspected the generated diff to confirm the intended changes were applied to `130Test2.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b39378711883318034b4ea79bb5fd4)