### PR TITLE
Refactor std_pos_angle to use normalized-angle quadrant reference logic

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -1917,6 +1917,86 @@
     }
 
     // --- GENERATORS LOGIC ---
+    function normalizeAngle(theta) {
+        const fullTurn = 2 * Math.PI;
+        return ((theta % fullTurn) + fullTurn) % fullTurn;
+    }
+
+    function computeReferenceAngle(theta) {
+        const thetaNorm = normalizeAngle(theta);
+        const halfTurn = Math.PI;
+        const quarterTurn = Math.PI / 2;
+        let ref;
+
+        if (thetaNorm <= quarterTurn) {
+            // QI
+            ref = thetaNorm;
+        } else if (thetaNorm <= halfTurn) {
+            // QII
+            ref = Math.PI - thetaNorm;
+        } else if (thetaNorm <= 3 * quarterTurn) {
+            // QIII
+            ref = thetaNorm - Math.PI;
+        } else {
+            // QIV
+            ref = 2 * Math.PI - thetaNorm;
+        }
+
+        return { thetaNorm, ref };
+    }
+
+    function gcd(a, b) {
+        let x = Math.abs(a);
+        let y = Math.abs(b);
+        while (y !== 0) {
+            const t = y;
+            y = x % y;
+            x = t;
+        }
+        return x || 1;
+    }
+
+    function formatReferencePiText(ref) {
+        const ratio = ref / Math.PI;
+        const candidates = [1, 2, 3, 4, 6, 12];
+
+        for (const den of candidates) {
+            const numApprox = ratio * den;
+            const num = Math.round(numApprox);
+            if (Math.abs(numApprox - num) < 1e-9) {
+                if (num === 0) return '0';
+                const factor = gcd(num, den);
+                const reducedNum = num / factor;
+                const reducedDen = den / factor;
+                if (reducedDen === 1) {
+                    return reducedNum === 1 ? '\\pi' : `${reducedNum}\\pi`;
+                }
+                return `\\frac{${reducedNum}\\pi}{${reducedDen}}`;
+            }
+        }
+
+        return null;
+    }
+
+    function runStdPosAngleUnitTests() {
+        const canonicalCases = [
+            { theta: Math.PI / 6, expectedRef: Math.PI / 6 },
+            { theta: Math.PI / 4, expectedRef: Math.PI / 4 },
+            { theta: Math.PI / 3, expectedRef: Math.PI / 3 },
+            { theta: 2 * Math.PI / 3, expectedRef: Math.PI / 3 },
+            { theta: 3 * Math.PI / 4, expectedRef: Math.PI / 4 },
+            { theta: 4 * Math.PI / 3, expectedRef: Math.PI / 3 },
+            { theta: 5 * Math.PI / 3, expectedRef: Math.PI / 3 }
+        ];
+
+        canonicalCases.forEach(({ theta, expectedRef }) => {
+            const { ref } = computeReferenceAngle(theta);
+            if (Math.abs(ref - expectedRef) > 1e-10) {
+                throw new Error(`std_pos_angle unit test failed for theta=${theta}: expected ${expectedRef}, got ${ref}`);
+            }
+        });
+    }
+
     const generators = [
         {
             id: 'eval_exp', section: 'Section 4.2',
@@ -2102,10 +2182,10 @@
                 const den = denOptions[Math.floor(Math.random() * denOptions.length)];
                 const num = Math.floor(Math.random() * (2 * den - 1)) + 1;
                 const theta = (num * Math.PI) / den;
-                const refNum = num <= den ? num : (2 * den - num);
-                const ref = (refNum * Math.PI) / den;
+                const { thetaNorm, ref } = computeReferenceAngle(theta);
                 const deg = theta * 180 / Math.PI;
                 const refDeg = ref * 180 / Math.PI;
+                const refPiText = formatReferencePiText(ref);
                 const x2 = 110 + 55 * Math.cos(theta);
                 const y2 = 80 - 55 * Math.sin(theta);
 
@@ -2122,7 +2202,7 @@
                     q: `Sketch/interpret $\\theta = \\frac{${num}\\pi}{${den}}$ in standard position. Find its reference angle in radians (decimal accepted).`,
                     svg,
                     inputType: 'number', a: ref, tol: 0.01,
-                    solution: `$\\theta = \\frac{${num}\\pi}{${den}}$ is ${deg.toFixed(1)}^\\circ. The reference angle is the acute angle to the x-axis: $\\theta_{ref}=\\frac{${refNum}\\pi}{${den}}\\approx ${ref.toFixed(2)}$ rad (${refDeg.toFixed(1)}^\\circ).`
+                    solution: `$\\theta = \\frac{${num}\\pi}{${den}}$ is ${deg.toFixed(1)}^\\circ$, so $\\theta_{norm}=${thetaNorm.toFixed(2)}$ rad. The reference angle is the acute angle to the x-axis: $\\theta_{ref}=${refPiText ? refPiText : ref.toFixed(2)}\\approx ${ref.toFixed(2)}$ rad (${refDeg.toFixed(1)}^\\circ).`
                 };
             }
         },
@@ -3071,6 +3151,7 @@
 
     // --- UI INITIATION & EVENT LISTENERS ---
     document.addEventListener('DOMContentLoaded', () => {
+        runStdPosAngleUnitTests();
         refreshIcons();
         loadState();
         applyTheme(state.theme);


### PR DESCRIPTION
### Motivation
- Ensure reference angles are computed from a normalized angle in `[0, 2π)` and follow quadrant rules so symbolic and decimal outputs are consistent and correct.
- Avoid reusing the original numerator assumptions for the displayed π-fraction and instead derive symbolic π-fraction text from the computed reference angle.

### Description
- Added `normalizeAngle(theta)` and `computeReferenceAngle(theta)` to normalize `theta` into `[0, 2π)` and compute `ref` using QI/QII/QIII/QIV rules, and updated the `std_pos_angle` generator to use these helpers in `130Test2.html`.
- Added `formatReferencePiText(ref)` and `gcd` to derive a simplified π-fraction string from the computed `ref` for symbolic display rather than reusing the original numerator/denominator.
- Updated the `std_pos_angle` solution text to report `θ_norm`, and to display symbolic and decimal `θ_ref` values derived from `ref` so the answer key and display are consistent.
- Added deterministic unit tests in `runStdPosAngleUnitTests()` for canonical angles `π/6, π/4, π/3, 2π/3, 3π/4, 4π/3, 5π/3` and wired the test runner to execute on `DOMContentLoaded` to fail fast on regressions.

### Testing
- Performed a syntax check of the extracted inline script with `node --check` which succeeded.
- Executed the inline script in a Node VM with minimal DOM stubs and ran `runStdPosAngleUnitTests()` which passed all canonical cases.
- Attempted browser-based validation with Playwright but navigation returned `ERR_EMPTY_RESPONSE` in this environment, so validation relied on the Node-based checks which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b395e3ac0c8331933549f35f18834a)