### PR TITLE
Clarify circle_multi prompt: define E as intersection of chords AC and BD

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -2435,8 +2435,9 @@
         </svg>`;
 
         return {
-            q: `$\\overline{AC}$ is a diameter, but $\\overline{BD}$ is <strong>not</strong>. Given $\\angle DBC = ${angleDBC}^\\circ$ and arc $\\widehat{AB} = ${arcAB}^\\circ$, find all four values:`,
+            q: `$\\overline{AC}$ is a diameter, but $\\overline{BD}$ is <strong>not</strong>. Chords $\\overline{AC}$ and $\\overline{BD}$ intersect at $E$. Given $\\angle DBC = ${angleDBC}^\\circ$ and arc $\\widehat{AB} = ${arcAB}^\\circ$, find all four values:`,
             svg: svg,
+            svgAltText: `Circle with $\\overline{AC}$ as a diameter and chord $\\overline{BD}$ (not a diameter). Chords $\\overline{AC}$ and $\\overline{BD}$ intersect at $E$. Given $\\angle DBC = ${angleDBC}^\\circ$ and arc $\\widehat{AB} = ${arcAB}^\\circ$, find $\\angle AEB$, $\\angle AED$, arc $\\widehat{CD}$, and arc $\\widehat{AD}$.`,
             inputType: 'circle_multi',
             a: { c1: angleAEB, c2: angleAED, c3: arcCD, c4: arcAD },
             tol: 0.5,


### PR DESCRIPTION
### Motivation
- Ensure the wording of the `circle_multi` generator matches the solver logic that uses the intersecting-chords relationship at point `E`.
- Provide the same clarification in both the visual SVG context and the text fallback so students and assistive tech see the same geometry.

### Description
- Updated `130Test2.html` to change the `circle_multi` question `q` string to explicitly state: "Chords `\overline{AC}` and `\overline{BD}` intersect at `E`.".
- Added `svgAltText` for the `circle_multi` return object so the text fallback includes the intersection-at-`E` clarification and enumerates the four requested outputs (`\angle AEB`, `\angle AED`, arc `\widehat{CD}`, arc `\widehat{AD}`).
- Preserved all original givens and computed outputs (`AC` diameter, `BD` not a diameter, given `\angle DBC` and arc `\widehat{AB}`, and the same four answers and solution logic).

### Testing
- Verified updated strings are present with `rg -n "circle_multi|intersect at \$E\.|svgAltText" 130Test2.html` which returned the new lines successfully.
- Served the site with `python -m http.server 4173` and captured a visual verification screenshot via Playwright, which completed successfully and produced an artifact.
- Committed the change with a descriptive message and confirmed the file diff shows the single-line prompt update and the added `svgAltText` entry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b397d89fec83318b6ea0c337f7dc4b)