### PR TITLE
Improve SVG label readability for transversals and circle_multi

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -1978,6 +1978,62 @@
         return null;
     }
 
+    function pointToSegmentDistance(px, py, x1, y1, x2, y2) {
+        const dx = x2 - x1;
+        const dy = y2 - y1;
+        const lenSq = dx * dx + dy * dy;
+        const t = lenSq === 0 ? 0 : Math.max(0, Math.min(1, ((px - x1) * dx + (py - y1) * dy) / lenSq));
+        const closestX = x1 + t * dx;
+        const closestY = y1 + t * dy;
+        const offsetX = px - closestX;
+        const offsetY = py - closestY;
+        return {
+            distance: Math.hypot(offsetX, offsetY),
+            closestX,
+            closestY,
+            segDx: dx,
+            segDy: dy
+        };
+    }
+
+    function nudgeLabelFromSegments(point, segments, options = {}) {
+        const minDistance = options.minDistance ?? 12;
+        const nudge = options.nudge ?? 7;
+        const bounds = options.bounds;
+        let x = point.x;
+        let y = point.y;
+
+        segments.forEach(([x1, y1, x2, y2]) => {
+            const hit = pointToSegmentDistance(x, y, x1, y1, x2, y2);
+            if (hit.distance >= minDistance) return;
+
+            let pushX = x - hit.closestX;
+            let pushY = y - hit.closestY;
+            const mag = Math.hypot(pushX, pushY);
+
+            if (mag < 0.001) {
+                pushX = -hit.segDy;
+                pushY = hit.segDx;
+            }
+
+            const unit = Math.hypot(pushX, pushY) || 1;
+            const pushAmt = minDistance - hit.distance + nudge;
+            x += (pushX / unit) * pushAmt;
+            y += (pushY / unit) * pushAmt;
+        });
+
+        if (bounds) {
+            x = Math.min(bounds.maxX, Math.max(bounds.minX, x));
+            y = Math.min(bounds.maxY, Math.max(bounds.minY, y));
+        }
+
+        return { x, y };
+    }
+
+    function svgOutlinedText({ x, y, text, fill = 'var(--text)', fontSize = 14, fontWeight = 'normal', textAnchor = 'middle' }) {
+        return `<text x="${x.toFixed(1)}" y="${y.toFixed(1)}" fill="${fill}" font-size="${fontSize}" font-weight="${fontWeight}" text-anchor="${textAnchor}" stroke="var(--surface2)" stroke-width="4.5" stroke-linejoin="round" paint-order="stroke">${text}</text>`;
+    }
+
     function runStdPosAngleUnitTests() {
         const canonicalCases = [
             { theta: Math.PI / 6, expectedRef: Math.PI / 6 },
@@ -2409,6 +2465,20 @@
         const angleAEB = (arcAB + arcCD) / 2;
         const angleAED = 180 - angleAEB;
 
+        const acLine = [30, 130, 230, 130];
+        const bdLine = [72, 217, 205, 55];
+        const abLine = [30, 130, 72, 217];
+        const bcLine = [230, 130, 72, 217];
+        const cdLine = [230, 130, 205, 55];
+        const circleSegments = [acLine, bdLine, abLine, bcLine, cdLine];
+        const circleBounds = { minX: 12, maxX: 248, minY: 20, maxY: 244 };
+
+        const circleLabels = {
+            E: nudgeLabelFromSegments({ x: 126, y: 118 }, circleSegments, { minDistance: 14, nudge: 9, bounds: circleBounds }),
+            arcAB: nudgeLabelFromSegments({ x: 42, y: 191 }, [abLine], { minDistance: 16, nudge: 8, bounds: circleBounds }),
+            angleDBC: nudgeLabelFromSegments({ x: 179, y: 201 }, [bcLine, bdLine], { minDistance: 15, nudge: 9, bounds: circleBounds })
+        };
+
         const svg = `<svg viewBox="0 0 260 260" class="svg-canvas" width="300" height="300">
             <circle cx="130" cy="130" r="100" fill="none" stroke="var(--text)" stroke-width="2"/>
             <!-- Diameter AC -->
@@ -2424,14 +2494,14 @@
             <line x1="230" y1="130" x2="72" y2="217" stroke="var(--accent)" stroke-width="1.5"/>
             <line x1="230" y1="130" x2="205" y2="55" stroke="var(--accent)" stroke-width="1.5"/>
             <!-- Labels -->
-            <text x="14" y="127" fill="var(--text)" font-size="14" font-weight="bold">A</text>
-            <text x="234" y="127" fill="var(--text)" font-size="14" font-weight="bold">C</text>
-            <text x="56" y="235" fill="var(--text)" font-size="14" font-weight="bold">B</text>
-            <text x="210" y="48" fill="var(--text)" font-size="14" font-weight="bold">D</text>
-            <text x="125" y="123" fill="var(--text-muted)" font-size="12">E</text>
+            ${svgOutlinedText({ x: 14, y: 127, text: 'A', fill: 'var(--text)', fontSize: 15, fontWeight: 'bold', textAnchor: 'start' })}
+            ${svgOutlinedText({ x: 234, y: 127, text: 'C', fill: 'var(--text)', fontSize: 15, fontWeight: 'bold', textAnchor: 'start' })}
+            ${svgOutlinedText({ x: 56, y: 235, text: 'B', fill: 'var(--text)', fontSize: 15, fontWeight: 'bold', textAnchor: 'start' })}
+            ${svgOutlinedText({ x: 210, y: 48, text: 'D', fill: 'var(--text)', fontSize: 15, fontWeight: 'bold', textAnchor: 'start' })}
+            ${svgOutlinedText({ x: circleLabels.E.x, y: circleLabels.E.y, text: 'E', fill: 'var(--text-muted)', fontSize: 15 })}
             <!-- Given values -->
-            <text x="38" y="180" fill="var(--accent)" font-size="12">${arcAB}°</text>
-            <text x="165" y="195" fill="var(--text-muted)" font-size="12">${angleDBC}°</text>
+            ${svgOutlinedText({ x: circleLabels.arcAB.x, y: circleLabels.arcAB.y, text: `${arcAB}°`, fill: 'var(--accent)', fontSize: 14, fontWeight: '600' })}
+            ${svgOutlinedText({ x: circleLabels.angleDBC.x, y: circleLabels.angleDBC.y, text: `${angleDBC}°`, fill: 'var(--text-muted)', fontSize: 14, fontWeight: '600' })}
         </svg>`;
 
         return {
@@ -2839,6 +2909,21 @@
                 const c = Math.floor(Math.random()*15)+10;
                 const x = (b * c) / a;
                 
+                const leftTransversal = [80, 10, 140, 140];
+                const rightTransversal = [220, 10, 160, 140];
+                const upperParallel = [10, 30, 290, 30];
+                const middleParallel = [10, 80, 290, 80];
+                const lowerParallel = [10, 130, 290, 130];
+                const transSegments = [leftTransversal, rightTransversal, upperParallel, middleParallel, lowerParallel];
+                const transBounds = { minX: 14, maxX: 286, minY: 18, maxY: 142 };
+
+                const transLabels = {
+                    a: nudgeLabelFromSegments({ x: 88, y: 58 }, transSegments, { minDistance: 15, nudge: 8, bounds: transBounds }),
+                    b: nudgeLabelFromSegments({ x: 132, y: 116 }, transSegments, { minDistance: 15, nudge: 8, bounds: transBounds }),
+                    c: nudgeLabelFromSegments({ x: 206, y: 58 }, transSegments, { minDistance: 15, nudge: 8, bounds: transBounds }),
+                    x: nudgeLabelFromSegments({ x: 182, y: 116 }, transSegments, { minDistance: 18, nudge: 9, bounds: transBounds })
+                };
+
                 const svg = `<svg viewBox="0 0 300 150" class="svg-canvas" width="500" height="250">
                     <!-- Parallel lines -->
                     <line x1="10" y1="30" x2="290" y2="30" stroke="var(--text)" stroke-width="2"/>
@@ -2848,10 +2933,10 @@
                     <line x1="80" y1="10" x2="140" y2="140" stroke="var(--accent)" stroke-width="2"/>
                     <line x1="220" y1="10" x2="160" y2="140" stroke="var(--accent)" stroke-width="2"/>
                     <!-- Labels -->
-                    <text x="95" y="60" fill="var(--text)" font-size="14">${a}</text>
-                    <text x="125" y="110" fill="var(--text)" font-size="14">${b}</text>
-                    <text x="195" y="60" fill="var(--text)" font-size="14">${c}</text>
-                    <text x="175" y="110" fill="var(--accent)" font-weight="bold" font-size="14">x</text>
+                    ${svgOutlinedText({ x: transLabels.a.x, y: transLabels.a.y, text: `${a}`, fill: 'var(--text)', fontSize: 15, fontWeight: '600' })}
+                    ${svgOutlinedText({ x: transLabels.b.x, y: transLabels.b.y, text: `${b}`, fill: 'var(--text)', fontSize: 15, fontWeight: '600' })}
+                    ${svgOutlinedText({ x: transLabels.c.x, y: transLabels.c.y, text: `${c}`, fill: 'var(--text)', fontSize: 15, fontWeight: '600' })}
+                    ${svgOutlinedText({ x: transLabels.x.x, y: transLabels.x.y, text: 'x', fill: 'var(--accent)', fontSize: 17, fontWeight: 'bold' })}
                 </svg>`;
 
                 return {


### PR DESCRIPTION
### Motivation

- Improve legibility and placement of numeric and letter labels in the `transversals` and `circle_multi` SVG generators by moving anchors away from strokes, enlarging critical fonts, adding readable text backgrounds, and preventing simple collisions while preserving mobile viewBox constraints.

### Description

- Added reusable helpers: `pointToSegmentDistance(px,py,x1,y1,x2,y2)` to measure proximity to segments, `nudgeLabelFromSegments(point,segments,options)` to nudge labels away from nearby lines with optional bounds clamping, and `svgOutlinedText({...})` to render text with a surface-colored stroke halo for contrast.
- Updated the `circle_multi` generator to compute nudged anchors for `E`, the arc-given label, and the angle-given label, increased their font sizes, and switched those labels to `svgOutlinedText` so they remain readable over strokes while staying inside the SVG viewBox.
- Updated the `transversals` generator to define segment geometry and compute nudged anchors for `a`, `b`, `c`, and `x`, increased font sizes (notably `x`), and render all labels via `svgOutlinedText` for improved contrast.
- Added bounding clamps for nudged labels so adjusted anchors remain inside each SVG `viewBox` (helps preserve mobile-width rendering).

### Testing

- Ran a syntax check with `node --check` on the extracted inline script and it passed without errors.
- Attempted automated visual/mobile rendering via a Playwright script to capture screenshots, but the browser/container could not access the served page in this environment, so visual verification was not completed.
- Attempted to start a local `http.server` and validate with `curl -I`, but network/server access failed in this environment, so runtime serving checks are incomplete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b399331a30833187054b6e22c97bfd)