### PR TITLE
Conditionally include rounding instruction for transversals when x is non-integer

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -2928,6 +2928,11 @@
                 const b = Math.floor(Math.random()*15)+10;
                 const c = Math.floor(Math.random()*15)+10;
                 const x = (b * c) / a;
+                const integerEpsilon = 1e-9;
+                const roundedX = Math.round(x);
+                const isIntegerX = Math.abs(x - roundedX) < integerEpsilon;
+                const xDisplay = isIntegerX ? `${roundedX}` : x.toFixed(1);
+                const roundingInstruction = isIntegerX ? '' : ' (Round to 1 decimal place)';
                 
                 const leftTransversal = [80, 10, 140, 140];
                 const rightTransversal = [220, 10, 160, 140];
@@ -2960,10 +2965,10 @@
                 </svg>`;
 
                 return {
-                    q: `Lines $l$, $m$, and $n$ are parallel. Find the length of $x$. (Round to 1 decimal place)`,
+                    q: `Lines $l$, $m$, and $n$ are parallel. Find the length of $x$.${roundingInstruction}`,
                     svg: svg, inputType: 'number', a: x, tol: 0.05,
                     svgAltText: `Three parallel lines l, m, and n are cut by two transversals. On one transversal, adjacent segments are ${a} and ${b}; on the other, corresponding segments are ${c} and x. Use proportional segments to solve for x.`,
-                    solution: `By similar proportions across parallel lines: $\\frac{${a}}{${b}} = \\frac{${c}}{x} \\implies x = \\frac{${b} \\cdot ${c}}{${a}} = ${x.toFixed(1)}$`
+                    solution: `By similar proportions across parallel lines: $\\frac{${a}}{${b}} = \\frac{${c}}{x} \\implies x = \\frac{${b} \\cdot ${c}}{${a}} = ${xDisplay}$`
                 }
             }
         },


### PR DESCRIPTION
### Motivation
- Keep question prompts and worked solutions consistent by only asking to "Round to 1 decimal place" when the computed `x` is not effectively an integer, while still accepting rounded decimal answers broadly.

### Description
- In `130Test2.html` updated the `transversals` generator to compute `x`, use `integerEpsilon = 1e-9` to test `isIntegerX`, derive `xDisplay` and `roundingInstruction`, append `roundingInstruction` to the question `q`, and use `xDisplay` in the `solution` string so the displayed answer format matches the prompt.

### Testing
- Ran `git diff -- 130Test2.html`, `git status --short`, and committed the change with `git commit -m "Adjust transversals rounding prompt for integer results"`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b39dbdad3083318e5deba03526437a)