### PR TITLE
Add Math 130 Home link to top nav in 130 test pages

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -328,6 +328,7 @@
       <a href="index.html">Home</a>
       <a href="CV.html">About Me</a>
       <a href="learn.html">Course Resources</a>
+      <a href="courses/math130.html">Math 130 Home</a>
       <a href="projects.html">Projects</a>
       <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
       <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>

--- a/130Test2.html
+++ b/130Test2.html
@@ -1015,6 +1015,7 @@
       <a href="index.html">Home</a>
       <a href="CV.html">About Me</a>
       <a href="learn.html">Course Resources</a>
+      <a href="courses/math130.html">Math 130 Home</a>
       <a href="projects.html">Projects</a>
       <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
       <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>

--- a/130Test3.html
+++ b/130Test3.html
@@ -1016,6 +1016,7 @@
       <a href="index.html">Home</a>
       <a href="CV.html">About Me</a>
       <a href="learn.html">Course Resources</a>
+      <a href="courses/math130.html">Math 130 Home</a>
       <a href="projects.html">Projects</a>
       <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
       <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>


### PR DESCRIPTION
### Motivation
- Provide a course-specific navigation option next to the global `Course Resources` link so users can choose between site-wide resources and the Math 130 course home.

### Description
- Inserted `<a href="courses/math130.html">Math 130 Home</a>` immediately after `Course Resources` in the top navigation of `130Test1.html`, `130Test2.html`, and `130Test3.html`.
- The new link uses the requested relative URL `courses/math130.html` and preserves the existing nav order and other links.

### Testing
- Verified the updated markup with `rg -n "Course Resources|Math 130 Home" 130Test1.html 130Test2.html 130Test3.html` and confirmed the new links are present and adjacent to `Course Resources`.
- Served the site locally with `python -m http.server 8000` and captured a Playwright screenshot via `page.goto('http://127.0.0.1:8000/130Test1.html', wait_until='networkidle')` to visually validate the top nav.
- All automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b437446f4083319a20182c7a21f9fc)