### PR TITLE
Add accessible Course Resources dropdown to site navigation and styles

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -315,8 +315,22 @@
   .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
   .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
   .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
-  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
-  .top-nav-links a:hover { color: #93c5fd; }
+  .top-nav-links > a,
+  .dropdown-trigger,
+  .dropdown-menu a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
+  .top-nav-links > a:hover,
+  .top-nav-links > a:focus-visible,
+  .dropdown-trigger:hover,
+  .dropdown-trigger:focus-visible,
+  .dropdown-menu a:hover,
+  .dropdown-menu a:focus-visible { color: #93c5fd; outline: none; }
+  .dropdown { position: relative; }
+  .dropdown-trigger { background: transparent; border: none; padding: 0; font: inherit; cursor: pointer; }
+  .dropdown-menu { display: none; position: absolute; top: calc(100% + 0.35rem); left: 0; min-width: 190px; list-style: none; margin: 0; padding: 0.4rem 0; background: rgba(15, 23, 42, 0.98); border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 0.5rem; box-shadow: 0 12px 30px rgba(2, 6, 23, 0.35); }
+  .dropdown-menu li { margin: 0; }
+  .dropdown-menu a { display: block; padding: 0.4rem 0.8rem; }
+  .dropdown:hover .dropdown-menu,
+  .dropdown:focus-within .dropdown-menu { display: block; }
 </style>
 
 </head>
@@ -327,8 +341,13 @@
     <div class="top-nav-links">
       <a href="index.html">Home</a>
       <a href="CV.html">About Me</a>
-      <a href="learn.html">Course Resources</a>
-      <a href="courses/math130.html">Math 130 Home</a>
+      <div class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="learn.html">All Courses</a></li>
+          <li><a href="courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </div>
       <a href="projects.html">Projects</a>
       <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
       <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>

--- a/130Test2.html
+++ b/130Test2.html
@@ -1002,8 +1002,22 @@
   .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
   .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
   .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
-  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
-  .top-nav-links a:hover { color: #93c5fd; }
+  .top-nav-links > a,
+  .dropdown-trigger,
+  .dropdown-menu a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
+  .top-nav-links > a:hover,
+  .top-nav-links > a:focus-visible,
+  .dropdown-trigger:hover,
+  .dropdown-trigger:focus-visible,
+  .dropdown-menu a:hover,
+  .dropdown-menu a:focus-visible { color: #93c5fd; outline: none; }
+  .dropdown { position: relative; }
+  .dropdown-trigger { background: transparent; border: none; padding: 0; font: inherit; cursor: pointer; }
+  .dropdown-menu { display: none; position: absolute; top: calc(100% + 0.35rem); left: 0; min-width: 190px; list-style: none; margin: 0; padding: 0.4rem 0; background: rgba(15, 23, 42, 0.98); border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 0.5rem; box-shadow: 0 12px 30px rgba(2, 6, 23, 0.35); }
+  .dropdown-menu li { margin: 0; }
+  .dropdown-menu a { display: block; padding: 0.4rem 0.8rem; }
+  .dropdown:hover .dropdown-menu,
+  .dropdown:focus-within .dropdown-menu { display: block; }
 </style>
 
 </head>
@@ -1014,8 +1028,13 @@
     <div class="top-nav-links">
       <a href="index.html">Home</a>
       <a href="CV.html">About Me</a>
-      <a href="learn.html">Course Resources</a>
-      <a href="courses/math130.html">Math 130 Home</a>
+      <div class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="learn.html">All Courses</a></li>
+          <li><a href="courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </div>
       <a href="projects.html">Projects</a>
       <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
       <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>

--- a/130Test3.html
+++ b/130Test3.html
@@ -1003,8 +1003,22 @@
   .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
   .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
   .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
-  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
-  .top-nav-links a:hover { color: #93c5fd; }
+  .top-nav-links > a,
+  .dropdown-trigger,
+  .dropdown-menu a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
+  .top-nav-links > a:hover,
+  .top-nav-links > a:focus-visible,
+  .dropdown-trigger:hover,
+  .dropdown-trigger:focus-visible,
+  .dropdown-menu a:hover,
+  .dropdown-menu a:focus-visible { color: #93c5fd; outline: none; }
+  .dropdown { position: relative; }
+  .dropdown-trigger { background: transparent; border: none; padding: 0; font: inherit; cursor: pointer; }
+  .dropdown-menu { display: none; position: absolute; top: calc(100% + 0.35rem); left: 0; min-width: 190px; list-style: none; margin: 0; padding: 0.4rem 0; background: rgba(15, 23, 42, 0.98); border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 0.5rem; box-shadow: 0 12px 30px rgba(2, 6, 23, 0.35); }
+  .dropdown-menu li { margin: 0; }
+  .dropdown-menu a { display: block; padding: 0.4rem 0.8rem; }
+  .dropdown:hover .dropdown-menu,
+  .dropdown:focus-within .dropdown-menu { display: block; }
 </style>
 
 </head>
@@ -1015,8 +1029,13 @@
     <div class="top-nav-links">
       <a href="index.html">Home</a>
       <a href="CV.html">About Me</a>
-      <a href="learn.html">Course Resources</a>
-      <a href="courses/math130.html">Math 130 Home</a>
+      <div class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="learn.html">All Courses</a></li>
+          <li><a href="courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </div>
       <a href="projects.html">Projects</a>
       <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
       <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>

--- a/404.html
+++ b/404.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="index.html">Home</a></li>
       <li><a href="CV.html">About Me</a></li>
-      <li><a href="learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="learn.html">All Courses</a></li>
+          <li><a href="courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank">YouTube</a></li>

--- a/CV.html
+++ b/CV.html
@@ -17,7 +17,13 @@
     <ul class="nav-links">
       <li><a href="index.html">Home</a></li>
       <li><a href="CV.html">About Me</a></li>
-      <li><a href="learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="learn.html">All Courses</a></li>
+          <li><a href="courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank">YouTube</a></li>

--- a/courses/basic-statistical-measures.html
+++ b/courses/basic-statistical-measures.html
@@ -425,7 +425,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/constant-acceleration-lab-manual.html
+++ b/courses/constant-acceleration-lab-manual.html
@@ -10,7 +10,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/data-sheet-for-electric-circuits.html
+++ b/courses/data-sheet-for-electric-circuits.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/density-lab-manual.html
+++ b/courses/density-lab-manual.html
@@ -10,7 +10,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/electrical-circuits-lab-data-sheet.html
+++ b/courses/electrical-circuits-lab-data-sheet.html
@@ -10,7 +10,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/electrical-circuits-lab-manual.html
+++ b/courses/electrical-circuits-lab-manual.html
@@ -34,7 +34,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/engi220.html
+++ b/courses/engi220.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/math100.html
+++ b/courses/math100.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/math105.html
+++ b/courses/math105.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/math110.html
+++ b/courses/math110.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/math114.html
+++ b/courses/math114.html
@@ -19,7 +19,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/math121.html
+++ b/courses/math121.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/math130.html
+++ b/courses/math130.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/phys103.html
+++ b/courses/phys103.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/physlab1.html
+++ b/courses/physlab1.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/courses/physlab2.html
+++ b/courses/physlab2.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
       <li><a href="../CV.html">About Me</a></li>
-      <li><a href="../learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="../learn.html">All Courses</a></li>
+          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="../projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="index.html">Home</a></li>
       <li><a href="CV.html">About Me</a></li>
-      <li><a href="learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="learn.html">All Courses</a></li>
+          <li><a href="courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>

--- a/infographic.html
+++ b/infographic.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="index.html">Home</a></li>
       <li><a href="CV.html">About Me</a></li>
-      <li><a href="learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="learn.html">All Courses</a></li>
+          <li><a href="courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank">YouTube</a></li>

--- a/learn.html
+++ b/learn.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="index.html">Home</a></li>
       <li><a href="CV.html">About Me</a></li>
-      <li><a href="learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="learn.html">All Courses</a></li>
+          <li><a href="courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank">YouTube</a></li>

--- a/projects.html
+++ b/projects.html
@@ -13,7 +13,13 @@
     <ul class="nav-links">
       <li><a href="index.html">Home</a></li>
       <li><a href="CV.html">About Me</a></li>
-      <li><a href="learn.html">Course Resources</a></li>
+      <li class="dropdown">
+        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+        <ul class="dropdown-menu">
+          <li><a href="learn.html">All Courses</a></li>
+          <li><a href="courses/math130.html">MATH 130 Home</a></li>
+        </ul>
+      </li>
       <li><a href="projects.html">Projects</a></li>
       <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank">Math Club</a></li>
       <li><a href="https://www.youtube.com/learnabundantly" target="_blank">YouTube</a></li>

--- a/styles.css
+++ b/styles.css
@@ -694,6 +694,10 @@ section:nth-child(5) { animation-delay: 0.25s; }
     gap: 0.5rem;
 }
 
+.nav-links li {
+    position: relative;
+}
+
 .nav-links a {
     display: block;
     padding: 1rem 0.75rem;
@@ -708,6 +712,53 @@ section:nth-child(5) { animation-delay: 0.25s; }
 .nav-links a:hover {
     background-color: rgba(255, 255, 255, 0.1);
     color: var(--accent-color);
+}
+
+.dropdown-trigger {
+    display: block;
+    padding: 1rem 0.75rem;
+    color: var(--light-text);
+    text-decoration: none;
+    font-weight: 500;
+    transition: var(--transition);
+    border-radius: 4px;
+    font-size: 1rem;
+    background: transparent;
+    border: 0;
+    font-family: inherit;
+    cursor: pointer;
+}
+
+.dropdown-trigger:hover,
+.dropdown-trigger:focus-visible,
+.nav-links .dropdown-menu a:hover,
+.nav-links .dropdown-menu a:focus-visible {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: var(--accent-color);
+}
+
+.nav-links .dropdown-menu {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    left: 0;
+    min-width: 220px;
+    padding: 0.35rem;
+    background-color: var(--secondary-color);
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+    opacity: 0;
+    visibility: hidden;
+}
+
+.nav-links .dropdown:hover .dropdown-menu,
+.nav-links .dropdown:focus-within .dropdown-menu {
+    opacity: 1;
+    visibility: visible;
+}
+
+.nav-links .dropdown-menu a {
+    padding: 0.6rem 0.75rem;
+    white-space: nowrap;
 }
 
 /* Ensure the toggle button aligns perfectly in the new layout */
@@ -727,8 +778,30 @@ section:nth-child(5) { animation-delay: 0.25s; }
         justify-content: center;
         margin-bottom: 0.5rem;
     }
+
+    .nav-links .dropdown-menu {
+        position: static;
+        min-width: 0;
+        width: 100%;
+        opacity: 1;
+        visibility: visible;
+        display: none;
+        margin-top: 0;
+        box-shadow: none;
+        padding: 0;
+    }
+
+    .nav-links .dropdown:hover .dropdown-menu,
+    .nav-links .dropdown:focus-within .dropdown-menu {
+        display: block;
+    }
     
     .nav-links a {
+        padding: 0.5rem;
+        font-size: 0.9rem;
+    }
+
+    .dropdown-trigger {
         padding: 0.5rem;
         font-size: 0.9rem;
     }


### PR DESCRIPTION
### Motivation
- Replace the single "Course Resources" link with a small menu so users can directly access the course index or the Math 130 page from the main navigation. 
- Provide a consistent, accessible dropdown UI across all site pages and test review pages that works with hover and keyboard focus. 
- Add responsive behavior so the dropdown behaves sensibly on small screens and matches the existing theme toggling layout.

### Description
- Replaced occurrences of the standalone `Course Resources` link in many HTML pages (for example `index.html`, `CV.html`, `learn.html`, `404.html`, multiple `courses/*.html`, and `130Test*.html`) with a dropdown markup using a `button` with class `dropdown-trigger` and a sibling `ul.dropdown-menu` containing the course links. 
- Added and updated dropdown styling and positioning in the global `styles.css`, including `.dropdown-trigger`, `.nav-links .dropdown-menu`, focus and hover states, mobile adjustments, and `position: relative` on nav items. 
- Updated inline top-nav styles in the `130Test*.html` files to include dropdown selectors (`.dropdown`, `.dropdown-trigger`, `.dropdown-menu`) and keyboard focus-visible styling to match the global changes. 
- Ensured the dropdown becomes visible on `:hover` and `:focus-within` and made small accessibility improvements such as using `button` for the trigger and adding `:focus-visible` rules.

### Testing
- No automated tests were configured or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b438f110dc8331993ed986961c895a)