### PR TITLE
Add breadcrumbs to Math 130 test review headers

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -57,6 +57,11 @@
   header { text-align: center; padding: 3rem 0 2.5rem; position: relative; }
   header::after { content: ''; position: absolute; bottom: 0; left: 50%; transform: translateX(-50%); width: 60px; height: 3px; background: var(--accent); border-radius: 2px; }
   .course-label { font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; letter-spacing: 3px; text-transform: uppercase; color: var(--accent); margin-bottom: 0.75rem; }
+  .breadcrumb { display: inline-flex; align-items: center; flex-wrap: wrap; gap: 0.35rem; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.85rem; }
+  .breadcrumb a { color: var(--text); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; }
+  .breadcrumb a:hover { color: var(--accent); }
+  .breadcrumb-sep { color: var(--text-muted); }
+  .breadcrumb-current { color: var(--text-muted); }
   h1 { font-family: 'DM Serif Display', serif; font-size: clamp(2rem, 5vw, 3rem); font-weight: 400; letter-spacing: -0.5px; margin-bottom: 0.75rem; background: linear-gradient(135deg, var(--h1-from), var(--h1-to)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
   .subtitle { color: var(--text-muted); font-size: 0.95rem; max-width: 460px; margin: 0 auto; }
 
@@ -363,6 +368,13 @@
       <div class="toggle-track"><div class="toggle-thumb"></div></div>
       <span class="toggle-icon">☀️</span>
     </button>
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a href="learn.html">Course Resources</a>
+      <span class="breadcrumb-sep" aria-hidden="true">›</span>
+      <a href="courses/math130.html">MATH 130</a>
+      <span class="breadcrumb-sep" aria-hidden="true">›</span>
+      <span class="breadcrumb-current">Test 1 Review</span>
+    </nav>
     <div class="course-label">Spring 2026</div>
     <h1>Math 130 — Test 1</h1>
     <p class="subtitle">Interactive study guide covering all tested topics. Review concepts, practice problems, and quiz yourself.</p>

--- a/130Test2.html
+++ b/130Test2.html
@@ -91,6 +91,33 @@
             max-width: 42rem;
         }
 
+
+        .breadcrumb {
+            display: inline-flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 0.35rem;
+            margin-bottom: 0.75rem;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+        }
+
+        .breadcrumb a {
+            color: var(--text);
+            text-decoration: underline;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 2px;
+        }
+
+        .breadcrumb a:hover {
+            color: var(--accent);
+        }
+
+        .breadcrumb-sep,
+        .breadcrumb-current {
+            color: var(--text-muted);
+        }
+
         .header-meta {
             color: var(--text-muted);
             margin-top: 0.35rem;
@@ -1046,6 +1073,13 @@
 <div class="container">
 <header>
 <div class="header-copy">
+<nav class="breadcrumb" aria-label="Breadcrumb">
+<a href="learn.html">Course Resources</a>
+<span aria-hidden="true" class="breadcrumb-sep">›</span>
+<a href="courses/math130.html">MATH 130</a>
+<span aria-hidden="true" class="breadcrumb-sep">›</span>
+<span class="breadcrumb-current">Test 2 Review</span>
+</nav>
 <h1>Math 130 – Test 2 Review</h1>
 <p class="header-meta">Spring 2026 | Prof. Young &amp; Prof. Volk</p>
 <p class="header-subtitle">Topics: Geometry, Exponentials &amp; Logarithms</p>

--- a/130Test3.html
+++ b/130Test3.html
@@ -91,6 +91,33 @@
             max-width: 42rem;
         }
 
+
+        .breadcrumb {
+            display: inline-flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 0.35rem;
+            margin-bottom: 0.75rem;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+        }
+
+        .breadcrumb a {
+            color: var(--text);
+            text-decoration: underline;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 2px;
+        }
+
+        .breadcrumb a:hover {
+            color: var(--accent);
+        }
+
+        .breadcrumb-sep,
+        .breadcrumb-current {
+            color: var(--text-muted);
+        }
+
         .header-meta {
             color: var(--text-muted);
             margin-top: 0.35rem;
@@ -1047,6 +1074,13 @@
 <div class="container">
 <header>
 <div class="header-copy">
+<nav class="breadcrumb" aria-label="Breadcrumb">
+<a href="learn.html">Course Resources</a>
+<span aria-hidden="true" class="breadcrumb-sep">›</span>
+<a href="courses/math130.html">MATH 130</a>
+<span aria-hidden="true" class="breadcrumb-sep">›</span>
+<span class="breadcrumb-current">Test 3 Review</span>
+</nav>
 <h1>Math 130 – Test 3 Review</h1>
 <p class="header-meta">Spring 2026 | Prof. Young &amp; Prof. Volk</p>
 <p class="header-subtitle">Topics: Sections 5.1–5.3, 7.1, and 8.4</p>


### PR DESCRIPTION
### Motivation
- Provide clear page context and a lightweight navigation path on Math 130 test review pages. 
- Make it easy for students to jump back to course listings or the MATH 130 home from each test page. 
- Keep the UI subtle and readable in both dark and light themes with accessible link styling.

### Description
- Inserted a breadcrumb block into the header area of `130Test1.html`, `130Test2.html`, and `130Test3.html` showing `Course Resources` → `MATH 130` → current page label. 
- Added per-page CSS for `.breadcrumb`, `.breadcrumb a`, `.breadcrumb-sep`, and `.breadcrumb-current` to each page so styling is localized to the templates. 
- Link styling uses underlines and an accent hover state while current page label is plain muted text to match the requested trail. 
- Placement is just above or inside the header copy so it sits near the existing `h1` and metadata for consistent visual hierarchy.

### Testing
- Verified breadcrumb markup and CSS exist in all three files using a search for `breadcrumb|Course Resources|MATH 130|Test [123] Review`, which succeeded. 
- Served the site locally with `python -m http.server` and visually inspected the pages, which loaded successfully. 
- Captured a Playwright screenshot of `http://127.0.0.1:4173/130Test2.html` to confirm placement and styling, and the screenshot was produced. 
- Confirmed the three files `130Test1.html`, `130Test2.html`, and `130Test3.html` contain the new breadcrumbs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43d0f81088331bb26e1c5400e475a)