### PR TITLE
Replace placeholder resource anchors with non-clickable "Coming soon" labels and restore MATH 130 Unit 4 link

### DIFF
--- a/courses/math100.html
+++ b/courses/math100.html
@@ -56,9 +56,9 @@
     <section>
       <h2>Resources</h2>
       <ul>
-        <li><a href="#">Course Workbook</a></li>
-        <li><a href="#">Practice Problems</a></li>
-        <li><a href="#">Tutorial Videos</a></li>
+        <li><span>Course Workbook (Coming soon)</span></li>
+        <li><span>Practice Problems (Coming soon)</span></li>
+        <li><span>Tutorial Videos (Coming soon)</span></li>
       </ul>
     </section>
   </main>

--- a/courses/math105.html
+++ b/courses/math105.html
@@ -56,9 +56,9 @@
     <section>
       <h2>Resources</h2>
       <ul>
-        <li><a href="#">Algebra Workbook</a></li>
-        <li><a href="#">Example Problems</a></li>
-        <li><a href="#">Video Tutorials</a></li>
+        <li><span>Algebra Workbook (Coming soon)</span></li>
+        <li><span>Example Problems (Coming soon)</span></li>
+        <li><span>Video Tutorials (Coming soon)</span></li>
       </ul>
     </section>
   </main>

--- a/courses/math110.html
+++ b/courses/math110.html
@@ -56,9 +56,9 @@
     <section>
       <h2>Resources</h2>
       <ul>
-        <li><a href="#">Lecture Notes</a></li>
-        <li><a href="#">Practice Exercises</a></li>
-        <li><a href="#">Interactive Tutorials</a></li>
+        <li><span>Lecture Notes (Coming soon)</span></li>
+        <li><span>Practice Exercises (Coming soon)</span></li>
+        <li><span>Interactive Tutorials (Coming soon)</span></li>
       </ul>
     </section>
   </main>

--- a/courses/math121.html
+++ b/courses/math121.html
@@ -56,9 +56,9 @@
     <section>
       <h2>Resources</h2>
       <ul>
-        <li><a href="#">Lecture Slides</a></li>
-        <li><a href="#">Practice Worksheets</a></li>
-        <li><a href="#">Video Tutorials</a></li>
+        <li><span>Lecture Slides (Coming soon)</span></li>
+        <li><span>Practice Worksheets (Coming soon)</span></li>
+        <li><span>Video Tutorials (Coming soon)</span></li>
       </ul>
     </section>
   </main>

--- a/courses/math130.html
+++ b/courses/math130.html
@@ -75,7 +75,7 @@
         <div class="card-icon">📝</div>
         <h2>Unit 4 (Final Exam)</h2>
         <p>Culminating concepts and comprehensive review materials for the final exam.</p>
-        <a href="#" class="button">Resources Coming Soon</a>
+        <a href="final-exam-review-guide.html" class="button">View Unit 4 Resources</a>
       </div>
 
     </div>

--- a/courses/phys103.html
+++ b/courses/phys103.html
@@ -60,9 +60,9 @@
     <section>
       <h2>Resources</h2>
       <ul>
-        <li><a href="#">Lab Equipment Guides</a></li>
-        <li><a href="#">Instructional Videos</a></li>
-        <li><a href="#">Supplementary Materials</a></li>
+        <li><span>Lab Equipment Guides (Coming soon)</span></li>
+        <li><span>Instructional Videos (Coming soon)</span></li>
+        <li><span>Supplementary Materials (Coming soon)</span></li>
       </ul>
     </section>
   </main>

--- a/courses/physlab1.html
+++ b/courses/physlab1.html
@@ -56,9 +56,9 @@
     <section>
       <h2>Resources</h2>
       <ul>
-        <li><a href="#">Lab Equipment Guides</a></li>
-        <li><a href="#">Instructional Videos</a></li>
-        <li><a href="#">Supplementary Materials</a></li>
+        <li><span>Lab Equipment Guides (Coming soon)</span></li>
+        <li><span>Instructional Videos (Coming soon)</span></li>
+        <li><span>Supplementary Materials (Coming soon)</span></li>
       </ul>
     </section>
   </main>

--- a/courses/physlab2.html
+++ b/courses/physlab2.html
@@ -56,9 +56,9 @@
     <section>
       <h2>Resources</h2>
       <ul>
-        <li><a href="#">Lab Equipment Guides</a></li>
-        <li><a href="#">Instructional Videos</a></li>
-        <li><a href="#">Supplementary Materials</a></li>
+        <li><span>Lab Equipment Guides (Coming soon)</span></li>
+        <li><span>Instructional Videos (Coming soon)</span></li>
+        <li><span>Supplementary Materials (Coming soon)</span></li>
       </ul>
     </section>
   </main>


### PR DESCRIPTION
### Motivation
- Remove fake `href="#"` links used for unfinished course resources so users don't encounter non-functional links and to improve accessibility and clarity.
- Provide a real link for MATH 130 Unit 4 where a matching resource already exists.

### Description
- Replaced placeholder anchors with non-clickable `<span>` elements that include clear `"(Coming soon)"` labels in `courses/math100.html`, `courses/math105.html`, `courses/math110.html`, `courses/math121.html`, `courses/phys103.html`, `courses/physlab1.html`, and `courses/physlab2.html`.
- Updated MATH 130 Unit 4 card in `courses/math130.html` to point to the existing `final-exam-review-guide.html` instead of a placeholder anchor.
- Ensured no lingering `href="#"` placeholders remain in the prioritized files and avoided using `aria-disabled` on anchors without a valid accessibility pattern.
- Files modified: `courses/math100.html`, `courses/math105.html`, `courses/math110.html`, `courses/math121.html`, `courses/math130.html`, `courses/phys103.html`, `courses/physlab1.html`, and `courses/physlab2.html`.

### Testing
- Located all initial placeholder anchors with `rg` and used a Python replacement script to apply updates, which completed successfully.
- Verified post-change there are no remaining `href="#"` anchors in the prioritized files using `rg` (succeeded).
- Attempted a headless validation via `python -m http.server` + Playwright to capture a screenshot, but the Playwright navigation could not load the local server in this environment (validation step failed to produce a screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d53f2dc88331a3de03f2e8765845)