### PR TITLE
Add rel="noopener noreferrer" to external _blank links across site

### DIFF
--- a/404.html
+++ b/404.html
@@ -21,8 +21,8 @@
         </ul>
       </li>
       <li><a href="projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank">YouTube</a></li>
+      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
       <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
     </ul>
     

--- a/CV.html
+++ b/CV.html
@@ -25,8 +25,8 @@
         </ul>
       </li>
       <li><a href="projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank">YouTube</a></li>
+      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
       <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
     </ul>
     
@@ -236,7 +236,7 @@
             <h2>Publications</h2>
             <div class="publications-item">
                 <p>Volk, A. H. (2021, Sep 1). A Practitioner's Review of Visible Learning for Mathematics Classrooms. MathBits. 
-                    <a href="http://www.mctmmathbits.org/?p=3510" target="_blank">
+                    <a href="http://www.mctmmathbits.org/?p=3510" target="_blank" rel="noopener noreferrer">
                         http://www.mctmmathbits.org/?p=3510
                     </a>
                 </p>
@@ -473,7 +473,7 @@
                     mathematics more accessible and connecting mathematical concepts to practical applications.
                 </p>
                 <p>Channel URL: 
-                    <a href="https://www.youtube.com/learnabundantly" target="_blank">
+                    <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">
                         https://www.youtube.com/learnabundantly
                     </a>
                 </p>

--- a/infographic.html
+++ b/infographic.html
@@ -21,8 +21,8 @@
         </ul>
       </li>
       <li><a href="projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank">YouTube</a></li>
+      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
       <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
     </ul>
     

--- a/learn.html
+++ b/learn.html
@@ -21,8 +21,8 @@
         </ul>
       </li>
       <li><a href="projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank">YouTube</a></li>
+      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
       <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
     </ul>
     

--- a/projects.html
+++ b/projects.html
@@ -21,8 +21,8 @@
         </ul>
       </li>
       <li><a href="projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank">YouTube</a></li>
+      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
       <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
     </ul>
     

--- a/projects/TaskApp/TaskAppV1/index.html
+++ b/projects/TaskApp/TaskAppV1/index.html
@@ -19,15 +19,15 @@
     <div class="ai-tools">
       <h2>AI Tools</h2>
       <ul>
-        <li><a href="https://chat.openai.com" target="_blank">ChatGPT</a></li>
-        <li><a href="https://chat.deepseek.com/" target="_blank">DeepSeek</a></li>
-        <li><a href="https://claude.ai/" target="_blank">Claude</a></li>
-        <li><a href="https://notebooklm.google.com/" target="_blank">NotebookLM</a></li>
-        <li><a href="https://gemini.google.com/app" target="_blank">Google Gemini</a></li>
-        <li><a href="https://www.perplexity.ai" target="_blank">Perplexity</a></li>
-        <li><a href="https://chat.mistral.ai" target="_blank">Mistral</a></li>
-        <li><a href="https://chat.qwen.ai/" target="_blank">Qwen</a></li>
-        <li><a href="https://aistudio.google.com/" target="_blank">AI Studio</a></li>
+        <li><a href="https://chat.openai.com" target="_blank" rel="noopener noreferrer">ChatGPT</a></li>
+        <li><a href="https://chat.deepseek.com/" target="_blank" rel="noopener noreferrer">DeepSeek</a></li>
+        <li><a href="https://claude.ai/" target="_blank" rel="noopener noreferrer">Claude</a></li>
+        <li><a href="https://notebooklm.google.com/" target="_blank" rel="noopener noreferrer">NotebookLM</a></li>
+        <li><a href="https://gemini.google.com/app" target="_blank" rel="noopener noreferrer">Google Gemini</a></li>
+        <li><a href="https://www.perplexity.ai" target="_blank" rel="noopener noreferrer">Perplexity</a></li>
+        <li><a href="https://chat.mistral.ai" target="_blank" rel="noopener noreferrer">Mistral</a></li>
+        <li><a href="https://chat.qwen.ai/" target="_blank" rel="noopener noreferrer">Qwen</a></li>
+        <li><a href="https://aistudio.google.com/" target="_blank" rel="noopener noreferrer">AI Studio</a></li>
       </ul>
     </div>
   </div>

--- a/projects/TaskApp/TaskAppV2/index.html
+++ b/projects/TaskApp/TaskAppV2/index.html
@@ -64,29 +64,29 @@
       <div class="grid grid-cols-2 md:grid-cols-4 gap-1 text-xs">
         <!-- General Chat & Coding -->
         <h3 class="col-span-2 md:col-span-4 font-semibold text-gray-700 dark:text-gray-300 mt-2 mb-1 border-b border-gray-200 dark:border-gray-600 pb-1">General Chat & Coding</h3>
-        <a href="https://chat.openai.com" target="_blank" class="text-blue-600 hover:underline">ChatGPT</a>
-        <a href="https://claude.ai/" target="_blank" class="text-blue-600 hover:underline">Claude</a>
-        <a href="https://gemini.google.com/app" target="_blank" class="text-blue-600 hover:underline">Gemini</a>
-        <a href="https://copilot.microsoft.com" target="_blank" class="text-blue-600 hover:underline">Copilot</a>
-        <a href="https://www.perplexity.ai" target="_blank" class="text-blue-600 hover:underline">Perplexity</a>
-        <a href="https://you.com/chat" target="_blank" class="text-blue-600 hover:underline">You.com</a>
-        <a href="https://www.phind.com" target="_blank" class="text-blue-600 hover:underline">Phind</a>
+        <a href="https://chat.openai.com" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">ChatGPT</a>
+        <a href="https://claude.ai/" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">Claude</a>
+        <a href="https://gemini.google.com/app" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">Gemini</a>
+        <a href="https://copilot.microsoft.com" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">Copilot</a>
+        <a href="https://www.perplexity.ai" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">Perplexity</a>
+        <a href="https://you.com/chat" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">You.com</a>
+        <a href="https://www.phind.com" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">Phind</a>
 
         <!-- Research & Summarization -->
         <h3 class="col-span-2 md:col-span-4 font-semibold text-gray-700 dark:text-gray-300 mt-2 mb-1 border-b border-gray-200 dark:border-gray-600 pb-1">Research & Summarization</h3>
-        <a href="https://notebooklm.google.com/" target="_blank" class="text-blue-600 hover:underline">NotebookLM</a>
-        <a href="https://chat.deepseek.com/" target="_blank" class="text-blue-600 hover:underline">DeepSeek</a>
-        <a href="https://huggingface.co/chat/" target="_blank" class="text-blue-600 hover:underline">HuggingChat</a>
-        <a href="https://reka.ai" target="_blank" class="text-blue-600 hover:underline">Reka.ai</a>
-        <a href="https://pi.ai" target="_blank" class="text-blue-600 hover:underline">Pi.ai</a>
+        <a href="https://notebooklm.google.com/" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">NotebookLM</a>
+        <a href="https://chat.deepseek.com/" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">DeepSeek</a>
+        <a href="https://huggingface.co/chat/" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">HuggingChat</a>
+        <a href="https://reka.ai" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">Reka.ai</a>
+        <a href="https://pi.ai" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">Pi.ai</a>
 
         <!-- Model Playground & APIs -->
         <h3 class="col-span-2 md:col-span-4 font-semibold text-gray-700 dark:text-gray-300 mt-2 mb-1 border-b border-gray-200 dark:border-gray-600 pb-1">Model Playground & APIs</h3>
-        <a href="https://openrouter.ai/chat" target="_blank" class="text-blue-600 hover:underline">OpenRouter</a>
-        <a href="https://llama.meta.com" target="_blank" class="text-blue-600 hover:underline">Llama 2</a>
-        <a href="https://chat.qwen.ai/" target="_blank" class="text-blue-600 hover:underline">Qwen</a>
-        <a href="https://chat.mistral.ai" target="_blank" class="text-blue-600 hover:underline">Mistral</a>
-        <a href="https://aistudio.google.com/" target="_blank" class="text-blue-600 hover:underline">AI Studio</a>
+        <a href="https://openrouter.ai/chat" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">OpenRouter</a>
+        <a href="https://llama.meta.com" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">Llama 2</a>
+        <a href="https://chat.qwen.ai/" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">Qwen</a>
+        <a href="https://chat.mistral.ai" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">Mistral</a>
+        <a href="https://aistudio.google.com/" target="_blank" class="text-blue-600 hover:underline" rel="noopener noreferrer">AI Studio</a>
       </div>
     </section>
 


### PR DESCRIPTION
### Motivation
- Harden external links opened in new tabs by preventing potential `window.opener` attacks and referrer leakage. 
- Apply a consistent policy: retain `target="_blank"` only for links that intentionally open in a new tab and always pair them with `rel="noopener noreferrer"`.
- Bring all site HTML files into alignment with modern security/best-practices for external anchors.

### Description
- Updated HTML pages so any anchor using `target="_blank"` now includes `rel="noopener noreferrer"` when missing; changes span 7 files across the site. 
- Files modified include `CV.html`, `projects.html`, `learn.html`, `404.html`, `infographic.html`, `projects/TaskApp/TaskAppV1/index.html`, and `projects/TaskApp/TaskAppV2/index.html`. 
- No behavioral changes to JavaScript or internal navigation were made beyond adding the `rel` attributes.

### Testing
- Scanned the specified files with `rg -n 'target="_blank"'` to show updated matches include `rel=` and confirmed modified lines. 
- Ran a repository-wide verification script (Python) that checked every `*.html` file for any `<a ... target="_blank" ...>` missing a `rel=` attribute and returned `OK: all target="_blank" anchors include rel=` indicating success. 
- All automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5da97a2b083318b4a2f2861f7d99a)