### PR TITLE
Update Math130 Unit 4 link to blank 130Test4 scaffold

### DIFF
--- a/130Test4.html
+++ b/130Test4.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MATH 130 Test 4</title>
+</head>
+<body>
+</body>
+</html>

--- a/courses/math130.html
+++ b/courses/math130.html
@@ -75,7 +75,7 @@
         <div class="card-icon">📝</div>
         <h2>Unit 4 (Final Exam)</h2>
         <p>Culminating concepts and comprehensive review materials for the final exam.</p>
-        <a href="final-exam-review-guide.html" class="button">View Unit 4 Resources</a>
+        <a href="../130Test4.html" class="button">View Unit 4 Resources</a>
       </div>
 
     </div>


### PR DESCRIPTION
### Motivation
- Replace the current Unit 4 resource link with a placeholder page so the course home points to a blank `130Test4.html` that can be filled in later.

### Description
- Updated the Unit 4 anchor in `courses/math130.html` to use `../130Test4.html` instead of `final-exam-review-guide.html`.
- Added a minimal scaffold file `130Test4.html` containing basic HTML boilerplate for future content.

### Testing
- Ran `rg -n "130Test4|final-exam-review-guide" courses/math130.html 130Test4.html` and confirmed the Unit 4 link now points to `../130Test4.html` (success).
- Ran `git diff -- courses/math130.html 130Test4.html` to inspect the change and new file (success).
- Ran `git status --short` and verified the updated `courses/math130.html` and new `130Test4.html` are present in the working tree (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e424f8508331b5a86242596ef630)