### PR TITLE
Standardize MATH 114 course-home information architecture

### DIFF
--- a/courses/math114.html
+++ b/courses/math114.html
@@ -31,23 +31,44 @@
   </div>
 </nav>
 
+  <!--
+    Maintainer note: standard course-home IA for future adoption (including courses/math130.html).
+    Keep sections in this order:
+    1) Hero/header
+    2) Course overview
+    3) Instructor/course logistics
+    4) Syllabus / policies
+    5) Current or featured unit
+    6) Unit/module navigation cards
+    7) Quick start / common tools
+    8) Footer
+  -->
+  <!-- 1. Hero/header with course title, subtitle, term, and section labels -->
   <header class="course-header course-header--home">
     <div class="container">
       <h1>MATH 114: Quantitative Reasoning</h1>
-      <p class="subtitle">Enhancing data interpretation, logical reasoning, and real‐world problem solving.</p>
-      <p><strong>Spring R 2025 | Section 002 and 003</strong></p>
+      <p class="subtitle">Enhancing data interpretation, logical reasoning, and real-world problem solving.</p>
+      <p><strong>Term:</strong> Spring R 2025</p>
+      <p><strong>Sections:</strong> 002 and 003</p>
     </div>
   </header>
 
   <main class="container course-page">
+    <!-- 2. Course overview -->
     <section>
       <h2>Course Overview</h2>
-      <p>This course applies mathematical tools and analysis to practical contexts. Emphasis is placed on using proportions, ratios, and basic statistics to solve real‐world problems, with a focus on financial applications and data interpretation.</p>
+      <p>This course applies mathematical tools and analysis to practical contexts. Emphasis is placed on using proportions, ratios, and basic statistics to solve real-world problems, with a focus on financial applications and data interpretation.</p>
+      <p>Use this course home as the central starting point for expectations, key logistics, featured course content, and the unit pages that organize assignments, lecture slides, videos, review items, and practice tools.</p>
+    </section>
+
+    <!-- 3. Instructor/course logistics -->
+    <section>
+      <h2>Instructor &amp; Course Logistics</h2>
       <div class="course-meta-grid">
         <div class="course-meta-card">
           <h3>Meeting Times</h3>
-          <p><strong>Section 2:</strong> Monday, Wednesday, Friday, 9:20 AM – 10:10 AM (DH 2443)</p>
-          <p><strong>Section 3:</strong> Monday, Wednesday, Friday, 12:00 PM – 12:50 PM (DH 2446)</p>
+          <p><strong>Section 002:</strong> Monday, Wednesday, Friday, 9:20 AM – 10:10 AM (DH 2443)</p>
+          <p><strong>Section 003:</strong> Monday, Wednesday, Friday, 12:00 PM – 12:50 PM (DH 2446)</p>
         </div>
         <div class="course-meta-card">
           <h3>Instructor &amp; Office</h3>
@@ -64,14 +85,37 @@
       </div>
     </section>
 
+    <!-- 4. Syllabus / policies -->
     <section>
-      <h2>Syllabus &amp; Course Schedule</h2>
-      <p>For a complete outline of topics, assignments, policies, and grading, please review the full syllabus.</p>
+      <h2>Syllabus &amp; Policies</h2>
+      <p>For the complete outline of topics, assignments, grading, attendance expectations, and course policies, review the syllabus before working through the unit materials.</p>
       <p><a href="../pdfs/Quantitative_Reasoning_MATH_114_Spring_R_2025.pdf" target="_blank" rel="noopener noreferrer" class="button">Download Syllabus for Spring 2025</a></p>
     </section>
 
+    <!-- 5. Current or featured unit -->
     <section class="welcome-section">
-      <h2>Course Modules &amp; Study Materials</h2>
+      <h2>Current / Featured Unit</h2>
+      <p>The featured area highlights the latest archive module grouping so returning students can quickly continue where the course most recently ended.</p>
+      <div class="quick-link-grid">
+        <div class="quick-link-card">
+          <h3>Final Review &amp; Exam</h3>
+          <p>Module 13, Module 14, and final exam links gathered in one place for the last unit and cumulative course wrap-up.</p>
+          <a href="math114-final-review.html" class="button">Open Featured Unit</a>
+        </div>
+        <div class="quick-link-card">
+          <h3>What You Will Find</h3>
+          <ul>
+            <li>Final review materials and practice resources</li>
+            <li>End-of-course module links</li>
+            <li>Exam preparation and wrap-up materials</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- 6. Unit/module navigation cards -->
+    <section class="welcome-section">
+      <h2>Unit / Module Navigation</h2>
       <p>Use the pages below to move through the course by unit. Each page groups together assignments, lecture slides, videos, review items, and helpful tools so the course home stays focused on navigation.</p>
     </section>
 
@@ -126,8 +170,9 @@
       </div>
     </div>
 
+    <!-- 7. Quick start / common tools -->
     <section>
-      <h2>Quick Start</h2>
+      <h2>Quick Start / Common Tools</h2>
       <p>Start here for the most frequently used course links.</p>
       <div class="quick-link-grid">
         <div class="quick-link-card">
@@ -136,8 +181,8 @@
           <a href="../pdfs/Quantitative_Reasoning_MATH_114_Spring_R_2025.pdf" target="_blank" rel="noopener noreferrer" class="button">Open Syllabus</a>
         </div>
         <div class="quick-link-card">
-          <h3>Current Module</h3>
-          <p>Jump to the most recent set of posted materials in this Spring 2025 archive.</p>
+          <h3>Featured Unit</h3>
+          <p>Jump directly to the current featured archive unit for the fastest path back into course materials.</p>
           <a href="math114-final-review.html" class="button">Open Final Review &amp; Exam</a>
         </div>
         <div class="quick-link-card">
@@ -152,6 +197,7 @@
     </section>
   </main>
 
+  <!-- 8. Footer -->
   <footer>
     <div class="container">
       <p>&copy; 2025 - All Rights Reserved</p>


### PR DESCRIPTION
### Motivation
- Provide a consistent course-home information architecture so course pages share a predictable section order and are easier to maintain. 
- Use `courses/math114.html` as the reference implementation for future adoption (e.g., `courses/math130.html`) and document the pattern in-place.

### Description
- Add a maintainer note and inline HTML comments listing the canonical section order and numbering for future pages. 
- Reorder and structure `courses/math114.html` to the requested sequence: hero/header, course overview, instructor/course logistics, syllabus/policies, current/featured unit, unit/module navigation cards, quick start/common tools, and footer. 
- Surface explicit `Term` and `Sections` fields in the hero and split logistics into their own section, add a dedicated featured-unit area, and rename/clarify the quick-start block while preserving existing resource links. 
- Preserve existing cards, links, and visual elements; changes are content/structure-focused and do not alter styling assets.

### Testing
- Ran `git diff --check` and it returned no whitespace/patch errors. 
- Verified repository status with `git status --short` and inspected updated `courses/math114.html` content with `sed`/`nl` commands to confirm the new structure. 
- All automated checks executed in the environment completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf21fc83cc833188ef180f5aa569e3)