### PR TITLE
Add shared course-identity component and insert into MATH 114 unit pages

### DIFF
--- a/courses/math114-final-review.html
+++ b/courses/math114-final-review.html
@@ -36,6 +36,34 @@
       <p class="subtitle">Modules 13–14 and final exam materials for the closing unit and cumulative review.</p>
     </div>
   </header>
+
+  <div class="course-identity-wrap">
+    <div class="container">
+      <div class="course-identity" aria-label="Course identity">
+        <div class="course-identity__item">
+          <span class="course-identity__label">Course</span>
+          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Term</span>
+          <p class="course-identity__value">Spring R 2025</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Instructor</span>
+          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Home Page</span>
+          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Current Unit</span>
+          <p class="course-identity__value"><span class="course-identity__pill">Modules 13–14 / Final Exam</span></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <main class="container course-page">
 
     <section class="unit-overview-block"><h2>Final Unit Overview</h2><p>Use this page to finish the course: it groups the final chapter homework and quizzes with the cumulative review and the final exam links.</p></section>

--- a/courses/math114-financial-math.html
+++ b/courses/math114-financial-math.html
@@ -36,6 +36,34 @@
       <p class="subtitle">Modules 5–7 resources for percentages, finance, and pre-Test 2 practice.</p>
     </div>
   </header>
+
+  <div class="course-identity-wrap">
+    <div class="container">
+      <div class="course-identity" aria-label="Course identity">
+        <div class="course-identity__item">
+          <span class="course-identity__label">Course</span>
+          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Term</span>
+          <p class="course-identity__value">Spring R 2025</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Instructor</span>
+          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Home Page</span>
+          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Current Unit</span>
+          <p class="course-identity__value"><span class="course-identity__pill">Modules 5–7</span></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <main class="container course-page">
 
     <section class="unit-overview-block"><h2>Unit Overview</h2><p>These modules focus on financial applications and percent-based reasoning. Use this page for the homework, quizzes, lecture media, and calculator links that support the lead-up to Test 2.</p></section>

--- a/courses/math114-foundations.html
+++ b/courses/math114-foundations.html
@@ -36,6 +36,34 @@
       <p class="subtitle">Modules 1–3 resources, assignments, and study tools for the opening unit.</p>
     </div>
   </header>
+
+  <div class="course-identity-wrap">
+    <div class="container">
+      <div class="course-identity" aria-label="Course identity">
+        <div class="course-identity__item">
+          <span class="course-identity__label">Course</span>
+          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Term</span>
+          <p class="course-identity__value">Spring R 2025</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Instructor</span>
+          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Home Page</span>
+          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Current Unit</span>
+          <p class="course-identity__value"><span class="course-identity__pill">Modules 1–3</span></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <main class="container course-page">
 
     <section class="unit-overview-block">

--- a/courses/math114-statistics.html
+++ b/courses/math114-statistics.html
@@ -36,6 +36,34 @@
       <p class="subtitle">Modules 9–11 resources for descriptive statistics, normal models, and spreadsheets.</p>
     </div>
   </header>
+
+  <div class="course-identity-wrap">
+    <div class="container">
+      <div class="course-identity" aria-label="Course identity">
+        <div class="course-identity__item">
+          <span class="course-identity__label">Course</span>
+          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Term</span>
+          <p class="course-identity__value">Spring R 2025</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Instructor</span>
+          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Home Page</span>
+          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Current Unit</span>
+          <p class="course-identity__value"><span class="course-identity__pill">Modules 9–11</span></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <main class="container course-page">
 
     <section class="unit-overview-block"><h2>Unit Overview</h2><p>This section groups the statistics modules so students can quickly find homework, quizzes, slides, and reference tools for data summaries and normal distribution topics.</p></section>

--- a/courses/math114-test1.html
+++ b/courses/math114-test1.html
@@ -36,6 +36,34 @@
       <p class="subtitle">Module 4 review, project, and exam resources for Chapters 2 and 3.</p>
     </div>
   </header>
+
+  <div class="course-identity-wrap">
+    <div class="container">
+      <div class="course-identity" aria-label="Course identity">
+        <div class="course-identity__item">
+          <span class="course-identity__label">Course</span>
+          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Term</span>
+          <p class="course-identity__value">Spring R 2025</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Instructor</span>
+          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Home Page</span>
+          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Current Unit</span>
+          <p class="course-identity__value"><span class="course-identity__pill">Module 4</span></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <main class="container course-page">
 
     <section class="unit-overview-block"><h2>Test 1 Overview</h2><p>This page collects the first major assessment materials, including the review assignment, the exam links, Project 1, and the supporting media posted for the unit.</p></section>

--- a/courses/math114-test2.html
+++ b/courses/math114-test2.html
@@ -36,6 +36,34 @@
       <p class="subtitle">Module 8 review, project, and exam materials for Chapters 4 and 5.</p>
     </div>
   </header>
+
+  <div class="course-identity-wrap">
+    <div class="container">
+      <div class="course-identity" aria-label="Course identity">
+        <div class="course-identity__item">
+          <span class="course-identity__label">Course</span>
+          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Term</span>
+          <p class="course-identity__value">Spring R 2025</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Instructor</span>
+          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Home Page</span>
+          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Current Unit</span>
+          <p class="course-identity__value"><span class="course-identity__pill">Module 8</span></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <main class="container course-page">
 
     <section class="unit-overview-block"><h2>Test 2 Overview</h2><p>Use this page for the second exam cycle, including the review, Project 2, the formula sheet, and tools commonly used for the unit.</p></section>

--- a/courses/math114-test3.html
+++ b/courses/math114-test3.html
@@ -36,6 +36,34 @@
       <p class="subtitle">Module 12 review, project, and exam resources for Chapters 6 and 8.</p>
     </div>
   </header>
+
+  <div class="course-identity-wrap">
+    <div class="container">
+      <div class="course-identity" aria-label="Course identity">
+        <div class="course-identity__item">
+          <span class="course-identity__label">Course</span>
+          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Term</span>
+          <p class="course-identity__value">Spring R 2025</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Instructor</span>
+          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Home Page</span>
+          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
+        </div>
+        <div class="course-identity__item">
+          <span class="course-identity__label">Current Unit</span>
+          <p class="course-identity__value"><span class="course-identity__pill">Module 12</span></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <main class="container course-page">
 
     <section class="unit-overview-block"><h2>Test 3 Overview</h2><p>This page combines the third exam materials so students can find the review assignment, Project 3 help, and the common technology links used in the unit.</p></section>

--- a/styles.css
+++ b/styles.css
@@ -379,6 +379,69 @@ section h2 {
     margin-right: auto;
 }
 
+.course-identity-wrap {
+    margin-top: -1.25rem;
+    margin-bottom: 0.75rem;
+    position: relative;
+    z-index: 2;
+}
+
+.course-identity {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    align-items: stretch;
+    background: var(--card-background);
+    border: 1px solid rgba(52, 152, 219, 0.18);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow);
+    padding: 1rem 1.25rem;
+}
+
+.course-identity__item {
+    min-width: 0;
+}
+
+.course-identity__label {
+    display: block;
+    margin-bottom: 0.2rem;
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--primary-color);
+}
+
+.course-identity__value {
+    margin: 0;
+    color: var(--secondary-color);
+    font-weight: 600;
+    overflow-wrap: anywhere;
+}
+
+.course-identity__value--link a {
+    font-weight: 700;
+}
+
+.course-identity__pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.3rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(52, 152, 219, 0.12);
+    color: var(--secondary-color);
+    font-size: 0.95rem;
+    font-weight: 700;
+}
+
+:root[data-theme="dark"] .course-identity {
+    border-color: rgba(240, 240, 240, 0.12);
+}
+
+:root[data-theme="dark"] .course-identity__pill {
+    background: rgba(52, 152, 219, 0.22);
+}
+
 .course-meta-grid,
 .quick-link-grid {
     display: grid;


### PR DESCRIPTION
### Motivation
- Provide a compact, reusable course identity block (course, term, instructor, home link, optional current-unit) that sits below the page header and above main content for MATH 114 unit pages and can be reused by other course pages (e.g., MATH 130). 

### Description
- Add a responsive `.course-identity` component to `styles.css` with grid layout, label/value styles, home-link treatment, unit "pill" styling, and dark-theme tweaks. 
- Insert the `course-identity` markup immediately below the header and above `<main>` on the seven MATH 114 pages: `courses/math114-foundations.html`, `courses/math114-test1.html`, `courses/math114-financial-math.html`, `courses/math114-test2.html`, `courses/math114-statistics.html`, `courses/math114-test3.html`, and `courses/math114-final-review.html`. 
- Populate the shared fields with course metadata (`MATH 114: Quantitative Reasoning`, `Spring R 2025`, `Mr. Andrew Harrison Volk`, `MATH 114 Home`) and a page-specific `Current Unit` label.

### Testing
- Ran a small Python validation that checks each target page contains the `.course-identity` element and the five expected labels, which completed successfully for all 7 pages. 
- Verified selectors and content with `rg` searches for `course-identity`, `Current Unit`, `MATH 114 Home`, `Spring R 2025`, and `Mr. Andrew Harrison Volk`, which returned expected matches. 
- No visual screenshot was produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf23824ef88331b39402acd638140c)