### PR TITLE
Refactor MATH 114 unit pages to scannable module cards

### DIFF
--- a/courses/math114-final-review.html
+++ b/courses/math114-final-review.html
@@ -1,86 +1,350 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MATH 114 Final Review</title>
-  <link rel="stylesheet" href="../styles.css">
-  <script src="../theme.js"></script>
-</head>
-<body>
-<nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="../learn.html">All Courses</a></li>
-          <li><a href="math114.html">MATH 114 Home</a></li>
-          <li><a href="math130.html">MATH 130 Home</a></li>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MATH 114 Final Review</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <script src="../theme.js"></script>
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="container nav-container">
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../CV.html">About Me</a></li>
+          <li class="dropdown">
+            <button class="dropdown-trigger" type="button" aria-haspopup="true">
+              Course Resources ▾
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="../learn.html">All Courses</a></li>
+              <li><a href="math114.html">MATH 114 Home</a></li>
+              <li><a href="math130.html">MATH 130 Home</a></li>
+            </ul>
+          </li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li>
+            <a
+              href="https://andrewhvolk.github.io/LibertyMathClub/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Math Club</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.youtube.com/learnabundantly"
+              target="_blank"
+              rel="noopener noreferrer"
+              >YouTube</a
+            >
+          </li>
+          <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
         </ul>
-      </li>
-      <li><a href="../projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
-  </div>
-</nav>
-  <header class="course-header course-header--unit">
-    <div class="container">
-      <h1>MATH 114: Final Review & Exam</h1>
-      <p class="subtitle">Modules 13–14 and final exam materials for the closing unit and cumulative review.</p>
-    </div>
-  </header>
-
-  <div class="course-identity-wrap">
-    <div class="container">
-      <div class="course-identity" aria-label="Course identity">
-        <div class="course-identity__item">
-          <span class="course-identity__label">Course</span>
-          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Term</span>
-          <p class="course-identity__value">Spring R 2025</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Instructor</span>
-          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Home Page</span>
-          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Current Unit</span>
-          <p class="course-identity__value"><span class="course-identity__pill">Modules 13–14 / Final Exam</span></p>
+        <button
+          id="theme-toggle-btn"
+          class="theme-toggle"
+          aria-label="Toggle Theme"
+        ></button>
+      </div>
+    </nav>
+    <header class="course-header course-header--unit">
+      <div class="container">
+        <h1>MATH 114: Final Review &amp; Exam</h1>
+        <p class="subtitle">
+          Modules 13–14 and final exam materials for the closing unit and
+          cumulative review.
+        </p>
+      </div>
+    </header>
+    <div class="course-identity-wrap">
+      <div class="container">
+        <div class="course-identity" aria-label="Course identity">
+          <div class="course-identity__item">
+            <span class="course-identity__label">Course</span>
+            <p class="course-identity__value">
+              MATH 114: Quantitative Reasoning
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Term</span>
+            <p class="course-identity__value">Spring R 2025</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Instructor</span>
+            <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Home Page</span>
+            <p class="course-identity__value course-identity__value--link">
+              <a href="math114.html">MATH 114 Home</a>
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Current Unit</span>
+            <p class="course-identity__value">
+              <span class="course-identity__pill"
+                >Modules 13–14 / Final Exam</span
+              >
+            </p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-
-  <main class="container course-page">
-
-    <section class="unit-overview-block"><h2>Final Unit Overview</h2><p>Use this page to finish the course: it groups the final chapter homework and quizzes with the cumulative review and the final exam links.</p></section>
-    <section><h2>Module 13</h2><table class="assignment-resource-table"><thead><tr><th>Assignment</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody><tr><td>Module 13 Homework (9A &amp; 9B)</td><td>Apr 20, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455404">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455405">Section 3</a></td></tr><tr><td>Module 13 Quiz (9A &amp; 9B)</td><td>Apr 21, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455408">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455409">Section 3</a></td></tr></tbody></table></section>
-    <section><h2>Module 14</h2><table class="assignment-resource-table"><thead><tr><th>Assignment</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody><tr><td>Module 14 Homework (9B &amp; 9C)</td><td>Apr 27, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455412">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455413">Section 3</a></td></tr><tr><td>Module 14 Quiz (9B &amp; 9C)</td><td>Apr 28, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455416">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455417">Section 3</a></td></tr></tbody></table><table class="assignment-resource-table"><thead><tr><th>Tools</th></tr></thead><tbody><tr><td><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a><br><a href="https://www.microsoft365.com/launch/excel?">Excel Online</a></td></tr></tbody></table></section>
-    <section><h2>Final Exam</h2><table class="assignment-resource-table"><thead><tr><th>Exam</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody><tr><td>Final Exam Review</td><td>Apr 30, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455364">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455365">Section 3</a></td></tr><tr><td>Final Exam</td><td>May 1, 11:59pm</td><td>140</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455361">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455360">Section 3</a></td></tr></tbody></table><table class="assignment-resource-table"><thead><tr><th>Tools</th></tr></thead><tbody><tr><td><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a><br><a href="https://www.microsoft365.com/launch/excel?">Excel Online</a></td></tr></tbody></table><div class="course-back-row">
+    <main class="container course-page">
+      <section class="unit-overview-block">
+        <h2>Final Review &amp; Exam Overview</h2>
+        <p>
+          This final unit keeps the end-of-course workflow scannable by
+          separating each module’s to-do list from the closing tools and by
+          giving the cumulative exam its own focused section.
+        </p>
+      </section>
+      <div class="unit-module-stack">
+        <section class="unit-module-card">
+          <h2>Module 13</h2>
+          <p class="unit-module-summary">
+            Begin the closing unit with the first final stretch of chapter
+            homework and quiz work before moving into Module 14 and the
+            cumulative exam review.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Module 13 Homework (9A &amp; 9B)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Apr 20, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455404"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455405"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 13 Quiz (9A &amp; 9B)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Apr 21, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455408"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455409"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section class="unit-module-card">
+          <h2>Module 14</h2>
+          <p class="unit-module-summary">
+            Continue the final content review with the last homework and quiz
+            pair before students turn their attention fully to cumulative exam
+            preparation.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Module 14 Homework (9B &amp; 9C)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Apr 27, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455412"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455413"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 14 Quiz (9B &amp; 9C)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Apr 28, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455416"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455417"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="unit-resource-grid">
+            <article class="unit-resource-card">
+              <h3>Tools</h3>
+              <ul>
+                <li>
+                  <a href="https://www.desmos.com/scientific"
+                    >Desmos Scientific Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.desmos.com/graphing"
+                    >Desmos Graphing Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.microsoft365.com/launch/excel?"
+                    >Excel Online</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section class="unit-module-card">
+          <h2>Final Exam</h2>
+          <p class="unit-module-summary">
+            Use this section for the cumulative review and the final exam
+            submission links so the last major course tasks stay visible and
+            easy to find.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Final Exam Review</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Apr 30, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455364"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455365"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Final Exam</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> May 1, 11:59pm</li>
+                <li><strong>Points:</strong> 140</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455361"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455360"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="unit-resource-grid">
+            <article class="unit-resource-card">
+              <h3>Tools</h3>
+              <ul>
+                <li>
+                  <a href="https://www.desmos.com/scientific"
+                    >Desmos Scientific Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.desmos.com/graphing"
+                    >Desmos Graphing Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.microsoft365.com/launch/excel?"
+                    >Excel Online</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <details class="unit-detail-toggle">
+            <summary>Show detailed final exam table</summary>
+            <table class="assignment-resource-table">
+              <thead>
+                <tr>
+                  <th>Exam</th>
+                  <th>Due Date</th>
+                  <th>Points</th>
+                  <th>Links</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Final Exam Review</td>
+                  <td>Apr 30, 11:59pm</td>
+                  <td>20</td>
+                  <td>
+                    <a
+                      href="https://canvas.liberty.edu/courses/735702/assignments/11455364"
+                      >Section 2</a
+                    >
+                    |
+                    <a
+                      href="https://canvas.liberty.edu/courses/735705/assignments/11455365"
+                      >Section 3</a
+                    >
+                  </td>
+                </tr>
+                <tr>
+                  <td>Final Exam</td>
+                  <td>May 1, 11:59pm</td>
+                  <td>140</td>
+                  <td>
+                    <a
+                      href="https://canvas.liberty.edu/courses/735702/assignments/11455361"
+                      >Section 2</a
+                    >
+                    |
+                    <a
+                      href="https://canvas.liberty.edu/courses/735705/assignments/11455360"
+                      >Section 3</a
+                    >
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </details>
+        </section>
+      </div>
+      <div class="course-back-row">
         <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div></section>
-
-  </main>
-  <footer>
-    <div class="container">
-      <p>&copy; 2025 - All Rights Reserved</p>
-      <div class="social-links">
-        <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">📺</a>
       </div>
-    </div>
-  </footer>
-</body>
+    </main>
+    <footer>
+      <div class="container">
+        <p>&copy; 2025 - All Rights Reserved</p>
+        <div class="social-links">
+          <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube"
+            >📺</a
+          >
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/courses/math114-financial-math.html
+++ b/courses/math114-financial-math.html
@@ -1,86 +1,347 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MATH 114 Financial Math Unit</title>
-  <link rel="stylesheet" href="../styles.css">
-  <script src="../theme.js"></script>
-</head>
-<body>
-<nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="../learn.html">All Courses</a></li>
-          <li><a href="math114.html">MATH 114 Home</a></li>
-          <li><a href="math130.html">MATH 130 Home</a></li>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MATH 114 Financial Math Unit</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <script src="../theme.js"></script>
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="container nav-container">
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../CV.html">About Me</a></li>
+          <li class="dropdown">
+            <button class="dropdown-trigger" type="button" aria-haspopup="true">
+              Course Resources ▾
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="../learn.html">All Courses</a></li>
+              <li><a href="math114.html">MATH 114 Home</a></li>
+              <li><a href="math130.html">MATH 130 Home</a></li>
+            </ul>
+          </li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li>
+            <a
+              href="https://andrewhvolk.github.io/LibertyMathClub/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Math Club</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.youtube.com/learnabundantly"
+              target="_blank"
+              rel="noopener noreferrer"
+              >YouTube</a
+            >
+          </li>
+          <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
         </ul>
-      </li>
-      <li><a href="../projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
-  </div>
-</nav>
-  <header class="course-header course-header--unit">
-    <div class="container">
-      <h1>MATH 114: Financial Math Unit</h1>
-      <p class="subtitle">Modules 5–7 resources for percentages, finance, and pre-Test 2 practice.</p>
-    </div>
-  </header>
-
-  <div class="course-identity-wrap">
-    <div class="container">
-      <div class="course-identity" aria-label="Course identity">
-        <div class="course-identity__item">
-          <span class="course-identity__label">Course</span>
-          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Term</span>
-          <p class="course-identity__value">Spring R 2025</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Instructor</span>
-          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Home Page</span>
-          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Current Unit</span>
-          <p class="course-identity__value"><span class="course-identity__pill">Modules 5–7</span></p>
+        <button
+          id="theme-toggle-btn"
+          class="theme-toggle"
+          aria-label="Toggle Theme"
+        ></button>
+      </div>
+    </nav>
+    <header class="course-header course-header--unit">
+      <div class="container">
+        <h1>MATH 114: Financial Math Unit</h1>
+        <p class="subtitle">
+          Modules 5–7 resources for percentages, finance, and pre-Test 2
+          practice.
+        </p>
+      </div>
+    </header>
+    <div class="course-identity-wrap">
+      <div class="container">
+        <div class="course-identity" aria-label="Course identity">
+          <div class="course-identity__item">
+            <span class="course-identity__label">Course</span>
+            <p class="course-identity__value">
+              MATH 114: Quantitative Reasoning
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Term</span>
+            <p class="course-identity__value">Spring R 2025</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Instructor</span>
+            <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Home Page</span>
+            <p class="course-identity__value course-identity__value--link">
+              <a href="math114.html">MATH 114 Home</a>
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Current Unit</span>
+            <p class="course-identity__value">
+              <span class="course-identity__pill">Modules 5–7</span>
+            </p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-
-  <main class="container course-page">
-
-    <section class="unit-overview-block"><h2>Unit Overview</h2><p>These modules focus on financial applications and percent-based reasoning. Use this page for the homework, quizzes, lecture media, and calculator links that support the lead-up to Test 2.</p></section>
-    <section><h2>Module 5</h2><table class="assignment-resource-table"><thead><tr><th>Assignment</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody><tr><td>Module 5 Homework (4A, 4B, 4C, 4D)</td><td>Feb 18, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455447">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455450">Section 3</a></td></tr><tr><td>Module 5 Quiz (4A, 4B, 4C, 4D)</td><td>Feb 19, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455452">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455454">Section 3</a></td></tr></tbody></table><table class="assignment-resource-table"><thead><tr><th>Slides</th><th>Prof. Volk&apos;s Videos</th><th>Tools</th></tr></thead><tbody><tr><td><a href="../pdfs/114Module5Spring25.pdf">Lecture Slides</a></td><td><a href="https://youtu.be/jIGUzHvs25g">Lecture Video</a><br><a href="https://youtu.be/HFo9cDZW2X0">Loan Payment #Short</a></td><td><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a></td></tr></tbody></table></section>
-    <section><h2>Module 6</h2><table class="assignment-resource-table"><thead><tr><th>Assignment</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody><tr><td>Module 6 Homework (5A, 5B, 5C)</td><td>Feb 23, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455456">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455458">Section 3</a></td></tr><tr><td>Module 6 Quiz (5A, 5B, 5C)</td><td>Feb 24, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455460">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455462">Section 3</a></td></tr></tbody></table><table class="assignment-resource-table"><thead><tr><th>Slides</th><th>Prof. Volk&apos;s Videos</th><th>Tools</th></tr></thead><tbody><tr><td>Slides will be posted as available.</td><td><a href="https://youtu.be/AVUpJVBRsfI">Lecture Video</a></td><td><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a></td></tr></tbody></table></section>
-    <section><h2>Module 7</h2><table class="assignment-resource-table"><thead><tr><th>Assignment</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody><tr><td>Module 7 Homework (5D &amp; 5E)</td><td>Mar 2, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455464">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455466">Section 3</a></td></tr><tr><td>Module 7 Quiz (5D &amp; 5E)</td><td>Mar 3, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455468">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455470">Section 3</a></td></tr></tbody></table><table class="assignment-resource-table"><thead><tr><th>Slides</th><th>Videos</th><th>Tools</th></tr></thead><tbody><tr><td>Slides will be posted as available.</td><td>Additional videos will be posted as available.</td><td><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a></td></tr></tbody></table><div class="course-back-row">
+    <main class="container course-page">
+      <section class="unit-overview-block">
+        <h2>Financial Math Overview</h2>
+        <p>
+          This unit follows the same scannable structure as the MATH 114 home
+          cards by separating the module to-do items from the slides, videos,
+          and calculator tools students use before Test 2.
+        </p>
+      </section>
+      <div class="unit-module-stack">
+        <section class="unit-module-card">
+          <h2>Module 5</h2>
+          <p class="unit-module-summary">
+            Begin the financial math sequence with percentage and finance
+            practice, including the first homework and quiz set tied to Chapter
+            4 topics.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Module 5 Homework (4A, 4B, 4C, 4D)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Feb 18, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455447"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455450"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 5 Quiz (4A, 4B, 4C, 4D)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Feb 19, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455452"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455454"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="unit-resource-grid">
+            <article class="unit-resource-card">
+              <h3>Slides</h3>
+              <ul>
+                <li>
+                  <a href="../pdfs/114Module5Spring25.pdf">Lecture slides</a>
+                </li>
+              </ul>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Videos</h3>
+              <ul>
+                <li>
+                  <a href="https://youtu.be/jIGUzHvs25g">Lecture Video</a>
+                </li>
+                <li>
+                  <a href="https://youtu.be/HFo9cDZW2X0">Loan Payment #Short</a>
+                </li>
+              </ul>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Tools</h3>
+              <ul>
+                <li>
+                  <a href="https://www.desmos.com/scientific"
+                    >Desmos Scientific Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.desmos.com/graphing"
+                    >Desmos Graphing Calculator</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section class="unit-module-card">
+          <h2>Module 6</h2>
+          <p class="unit-module-summary">
+            Continue the finance applications with the next homework and quiz
+            set, plus lecture support for students practicing the Chapter 5
+            ideas.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Module 6 Homework (5A, 5B, 5C)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Feb 23, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455456"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455458"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 6 Quiz (5A, 5B, 5C)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Feb 24, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455460"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455462"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="unit-resource-grid">
+            <article class="unit-resource-card">
+              <h3>Slides</h3>
+              <p>Slides will be posted as available.</p>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Videos</h3>
+              <ul>
+                <li>
+                  <a href="https://youtu.be/AVUpJVBRsfI">Lecture Video</a>
+                </li>
+              </ul>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Tools</h3>
+              <ul>
+                <li>
+                  <a href="https://www.desmos.com/scientific"
+                    >Desmos Scientific Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.desmos.com/graphing"
+                    >Desmos Graphing Calculator</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section class="unit-module-card">
+          <h2>Module 7</h2>
+          <p class="unit-module-summary">
+            Finish the pre-Test 2 financial math work with the last homework and
+            quiz set in this unit before transitioning into the second exam
+            module.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Module 7 Homework (5D &amp; 5E)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Mar 2, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455464"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455466"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 7 Quiz (5D &amp; 5E)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Mar 3, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455468"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455470"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="unit-resource-grid">
+            <article class="unit-resource-card">
+              <h3>Slides</h3>
+              <p>Slides will be posted as available.</p>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Videos</h3>
+              <p>Additional videos will be posted as available.</p>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Tools</h3>
+              <ul>
+                <li>
+                  <a href="https://www.desmos.com/scientific"
+                    >Desmos Scientific Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.desmos.com/graphing"
+                    >Desmos Graphing Calculator</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+      </div>
+      <div class="course-back-row">
         <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div></section>
-
-  </main>
-  <footer>
-    <div class="container">
-      <p>&copy; 2025 - All Rights Reserved</p>
-      <div class="social-links">
-        <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">📺</a>
       </div>
-    </div>
-  </footer>
-</body>
+    </main>
+    <footer>
+      <div class="container">
+        <p>&copy; 2025 - All Rights Reserved</p>
+        <div class="social-links">
+          <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube"
+            >📺</a
+          >
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/courses/math114-foundations.html
+++ b/courses/math114-foundations.html
@@ -1,136 +1,423 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MATH 114 Foundations</title>
-  <link rel="stylesheet" href="../styles.css">
-  <script src="../theme.js"></script>
-</head>
-<body>
-<nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="../learn.html">All Courses</a></li>
-          <li><a href="math114.html">MATH 114 Home</a></li>
-          <li><a href="math130.html">MATH 130 Home</a></li>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MATH 114 Foundations</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <script src="../theme.js"></script>
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="container nav-container">
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../CV.html">About Me</a></li>
+          <li class="dropdown">
+            <button class="dropdown-trigger" type="button" aria-haspopup="true">
+              Course Resources ▾
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="../learn.html">All Courses</a></li>
+              <li><a href="math114.html">MATH 114 Home</a></li>
+              <li><a href="math130.html">MATH 130 Home</a></li>
+            </ul>
+          </li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li>
+            <a
+              href="https://andrewhvolk.github.io/LibertyMathClub/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Math Club</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.youtube.com/learnabundantly"
+              target="_blank"
+              rel="noopener noreferrer"
+              >YouTube</a
+            >
+          </li>
+          <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
         </ul>
-      </li>
-      <li><a href="../projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
 
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
-  </div>
-</nav>
-  <header class="course-header course-header--unit">
-    <div class="container">
-      <h1>MATH 114: Orientation & Foundations</h1>
-      <p class="subtitle">Modules 1–3 resources, assignments, and study tools for the opening unit.</p>
-    </div>
-  </header>
+        <button
+          id="theme-toggle-btn"
+          class="theme-toggle"
+          aria-label="Toggle Theme"
+        ></button>
+      </div>
+    </nav>
+    <header class="course-header course-header--unit">
+      <div class="container">
+        <h1>MATH 114: Orientation &amp; Foundations</h1>
+        <p class="subtitle">
+          Modules 1–3 resources, assignments, and study tools for the opening
+          unit.
+        </p>
+      </div>
+    </header>
 
-  <div class="course-identity-wrap">
-    <div class="container">
-      <div class="course-identity" aria-label="Course identity">
-        <div class="course-identity__item">
-          <span class="course-identity__label">Course</span>
-          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Term</span>
-          <p class="course-identity__value">Spring R 2025</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Instructor</span>
-          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Home Page</span>
-          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Current Unit</span>
-          <p class="course-identity__value"><span class="course-identity__pill">Modules 1–3</span></p>
+    <div class="course-identity-wrap">
+      <div class="container">
+        <div class="course-identity" aria-label="Course identity">
+          <div class="course-identity__item">
+            <span class="course-identity__label">Course</span>
+            <p class="course-identity__value">
+              MATH 114: Quantitative Reasoning
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Term</span>
+            <p class="course-identity__value">Spring R 2025</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Instructor</span>
+            <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Home Page</span>
+            <p class="course-identity__value course-identity__value--link">
+              <a href="math114.html">MATH 114 Home</a>
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Current Unit</span>
+            <p class="course-identity__value">
+              <span class="course-identity__pill">Modules 1–3</span>
+            </p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <main class="container course-page">
+    <main class="container course-page">
+      <section class="unit-overview-block">
+        <h2>Orientation &amp; Foundations Overview</h2>
+        <p>
+          This opening unit mirrors the course-home card language by bundling
+          the introductions, early quantitative reasoning practice, and starter
+          tools into one scannable place for Modules 1–3.
+        </p>
+        <ul class="unit-overview-links">
+          <li>
+            <a
+              href="../pdfs/Quantitative_Reasoning_MATH_114_Spring_R_2025.pdf"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Course syllabus</a
+            >
+          </li>
+          <li><a href="114-module1-summary.html">Module 1 summary sheet</a></li>
+          <li>
+            <a
+              href="https://www.desmos.com/scientific"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Desmos Scientific Calculator</a
+            >
+          </li>
+        </ul>
+      </section>
 
-    <section class="unit-overview-block">
-      <h2>What&apos;s on this page</h2>
-      <p>This unit gathers the opening course checklist, introductions, early homework and quizzes, lecture slides, and the core tools students need to build confidence in quantitative reasoning.</p>
-      <ul class="unit-overview-links">
-        <li><a href="../pdfs/Quantitative_Reasoning_MATH_114_Spring_R_2025.pdf" target="_blank" rel="noopener noreferrer">Course syllabus</a></li>
-        <li><a href="114-module1-summary.html">Module 1 summary sheet</a></li>
-        <li><a href="https://www.desmos.com/scientific" target="_blank" rel="noopener noreferrer">Desmos Scientific Calculator</a></li>
-      </ul>
-    </section>
-    <section>
-      <h2>Module 1</h2>
-      <table class="assignment-resource-table">
-        <thead><tr><th>Assignment</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead>
-        <tbody>
-          <tr><td>Course Requirements Checklist</td><td>Jan 17, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455349">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455348">Section 3</a></td></tr>
-          <tr><td>Module 1 Homework</td><td>Jan 19, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455368">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455369">Section 3</a></td></tr>
-          <tr><td>Module 1 Quiz</td><td>Jan 20, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455372">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455373">Section 3</a></td></tr>
-          <tr><td>Math Autobiography</td><td>Jan 24, 11:59pm</td><td>5</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/12119641">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/12119877">Section 3</a></td></tr>
-        </tbody>
-      </table>
-      <table class="assignment-resource-table">
-        <thead><tr><th>Slides</th><th>Prof. Volk&apos;s Videos</th><th>Tools</th></tr></thead>
-        <tbody><tr><td><a href="../pdfs/114Module1Spring25.pdf">Lecture Slides</a></td><td><a href="https://youtu.be/sYTCd1L2Rps">Welcome to Math 114!</a><br><a href="https://youtu.be/T_xHzUHMRQI">Homework 1 Help</a><br><a href="https://youtu.be/mHV3Yqk7QwA">Math 114 HW 1 #8</a></td><td><a href="114-module1-summary.html">Module 1 Summary</a><br><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a></td></tr></tbody>
-      </table>
-    </section>
-    <section>
-      <h2>Module 2</h2>
-      <table class="assignment-resource-table">
-        <thead><tr><th>Assignment</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead>
-        <tbody>
-          <tr><td>Module 2 Homework (2A, 2B, 2C)</td><td>Jan 26, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455420">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455421">Section 3</a></td></tr>
-          <tr><td>Module 2 Quiz (2A, 2B, 2C)</td><td>Jan 27, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455424">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455425">Section 3</a></td></tr>
-        </tbody>
-      </table>
-      <table class="assignment-resource-table">
-        <thead><tr><th>Slides</th><th>Videos</th><th>Tools</th></tr></thead>
-        <tbody><tr><td><a href="../pdfs/114Module2Spring25.pdf">Lecture Slides</a></td><td>Additional videos will be posted as available.</td><td><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a></td></tr></tbody>
-      </table>
-    </section>
-    <section>
-      <h2>Module 3</h2>
-      <table class="assignment-resource-table">
-        <thead><tr><th>Assignment</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead>
-        <tbody>
-          <tr><td>Module 3 Homework (3A &amp; 3B)</td><td>Feb 2, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455428">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455429">Section 3</a></td></tr>
-          <tr><td>Module 3 Quiz (3A &amp; 3B)</td><td>Feb 3, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455432">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455434">Section 3</a></td></tr>
-        </tbody>
-      </table>
-      <table class="assignment-resource-table">
-        <thead><tr><th>Slides</th><th>Prof. Volk&apos;s Videos</th><th>Tools</th></tr></thead>
-        <tbody><tr><td><a href="../pdfs/114Module3Spring25.pdf">Lecture Slides</a></td><td><a href="https://youtu.be/wpSkYpF03BE">Homework 3 Help</a></td><td><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a></td></tr></tbody>
-      </table>
+      <div class="unit-module-stack">
+        <section class="unit-module-card">
+          <h2>Module 1</h2>
+          <p class="unit-module-summary">
+            Start the semester with the course checklist, first homework and
+            quiz, and a short reflection that helps students connect their math
+            background to the course.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Course Requirements Checklist</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Jan 17, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455349"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455348"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 1 Homework</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Jan 19, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455368"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455369"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 1 Quiz</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Jan 20, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455372"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455373"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Math Autobiography</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Jan 24, 11:59pm</li>
+                <li><strong>Points:</strong> 5</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/12119641"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/12119877"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="unit-resource-grid">
+            <article class="unit-resource-card">
+              <h3>Slides &amp; summaries</h3>
+              <ul>
+                <li>
+                  <a href="../pdfs/114Module1Spring25.pdf">Lecture slides</a>
+                </li>
+                <li><a href="114-module1-summary.html">Module 1 summary</a></li>
+              </ul>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Videos</h3>
+              <ul>
+                <li>
+                  <a href="https://youtu.be/sYTCd1L2Rps"
+                    >Welcome to Math 114!</a
+                  >
+                </li>
+                <li>
+                  <a href="https://youtu.be/T_xHzUHMRQI">Homework 1 Help</a>
+                </li>
+                <li>
+                  <a href="https://youtu.be/mHV3Yqk7QwA">Math 114 HW 1 #8</a>
+                </li>
+              </ul>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Tools</h3>
+              <ul>
+                <li>
+                  <a href="https://www.desmos.com/scientific"
+                    >Desmos Scientific Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.desmos.com/graphing"
+                    >Desmos Graphing Calculator</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="unit-module-card">
+          <h2>Module 2</h2>
+          <p class="unit-module-summary">
+            Continue building quantitative reasoning habits with the first full
+            multi-part homework and quiz set, along with the lecture slides and
+            everyday calculator tools.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Module 2 Homework (2A, 2B, 2C)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Jan 26, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455420"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455421"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 2 Quiz (2A, 2B, 2C)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Jan 27, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455424"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455425"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="unit-resource-grid">
+            <article class="unit-resource-card">
+              <h3>Slides</h3>
+              <ul>
+                <li>
+                  <a href="../pdfs/114Module2Spring25.pdf">Lecture slides</a>
+                </li>
+              </ul>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Videos</h3>
+              <p>Additional videos will be posted as available.</p>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Tools</h3>
+              <ul>
+                <li>
+                  <a href="https://www.desmos.com/scientific"
+                    >Desmos Scientific Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.desmos.com/graphing"
+                    >Desmos Graphing Calculator</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="unit-module-card">
+          <h2>Module 3</h2>
+          <p class="unit-module-summary">
+            Wrap up the foundations sequence with homework and quiz practice on
+            the next set of concepts before students move into the first test
+            unit.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Module 3 Homework (3A &amp; 3B)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Feb 2, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455428"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455429"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 3 Quiz (3A &amp; 3B)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Feb 3, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455432"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455434"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="unit-resource-grid">
+            <article class="unit-resource-card">
+              <h3>Slides</h3>
+              <ul>
+                <li>
+                  <a href="../pdfs/114Module3Spring25.pdf">Lecture slides</a>
+                </li>
+              </ul>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Videos</h3>
+              <ul>
+                <li>
+                  <a href="https://youtu.be/wpSkYpF03BE">Homework 3 Help</a>
+                </li>
+              </ul>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Tools</h3>
+              <ul>
+                <li>
+                  <a href="https://www.desmos.com/scientific"
+                    >Desmos Scientific Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.desmos.com/graphing"
+                    >Desmos Graphing Calculator</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+      </div>
+
       <div class="course-back-row">
         <a href="math114.html" class="button">Back to MATH 114 Home</a>
       </div>
-    </section>
-
-  </main>
-  <footer>
-    <div class="container">
-      <p>&copy; 2025 - All Rights Reserved</p>
-      <div class="social-links">
-        <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">📺</a>
+    </main>
+    <footer>
+      <div class="container">
+        <p>&copy; 2025 - All Rights Reserved</p>
+        <div class="social-links">
+          <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube"
+            >📺</a
+          >
+        </div>
       </div>
-    </div>
-  </footer>
-</body>
+    </footer>
+  </body>
 </html>

--- a/courses/math114-statistics.html
+++ b/courses/math114-statistics.html
@@ -1,86 +1,363 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MATH 114 Statistics Unit</title>
-  <link rel="stylesheet" href="../styles.css">
-  <script src="../theme.js"></script>
-</head>
-<body>
-<nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="../learn.html">All Courses</a></li>
-          <li><a href="math114.html">MATH 114 Home</a></li>
-          <li><a href="math130.html">MATH 130 Home</a></li>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MATH 114 Statistics Unit</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <script src="../theme.js"></script>
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="container nav-container">
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../CV.html">About Me</a></li>
+          <li class="dropdown">
+            <button class="dropdown-trigger" type="button" aria-haspopup="true">
+              Course Resources ▾
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="../learn.html">All Courses</a></li>
+              <li><a href="math114.html">MATH 114 Home</a></li>
+              <li><a href="math130.html">MATH 130 Home</a></li>
+            </ul>
+          </li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li>
+            <a
+              href="https://andrewhvolk.github.io/LibertyMathClub/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Math Club</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.youtube.com/learnabundantly"
+              target="_blank"
+              rel="noopener noreferrer"
+              >YouTube</a
+            >
+          </li>
+          <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
         </ul>
-      </li>
-      <li><a href="../projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
-  </div>
-</nav>
-  <header class="course-header course-header--unit">
-    <div class="container">
-      <h1>MATH 114: Statistics Unit</h1>
-      <p class="subtitle">Modules 9–11 resources for descriptive statistics, normal models, and spreadsheets.</p>
-    </div>
-  </header>
-
-  <div class="course-identity-wrap">
-    <div class="container">
-      <div class="course-identity" aria-label="Course identity">
-        <div class="course-identity__item">
-          <span class="course-identity__label">Course</span>
-          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Term</span>
-          <p class="course-identity__value">Spring R 2025</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Instructor</span>
-          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Home Page</span>
-          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Current Unit</span>
-          <p class="course-identity__value"><span class="course-identity__pill">Modules 9–11</span></p>
+        <button
+          id="theme-toggle-btn"
+          class="theme-toggle"
+          aria-label="Toggle Theme"
+        ></button>
+      </div>
+    </nav>
+    <header class="course-header course-header--unit">
+      <div class="container">
+        <h1>MATH 114: Statistics Unit</h1>
+        <p class="subtitle">
+          Modules 9–11 resources for descriptive statistics, normal models, and
+          spreadsheets.
+        </p>
+      </div>
+    </header>
+    <div class="course-identity-wrap">
+      <div class="container">
+        <div class="course-identity" aria-label="Course identity">
+          <div class="course-identity__item">
+            <span class="course-identity__label">Course</span>
+            <p class="course-identity__value">
+              MATH 114: Quantitative Reasoning
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Term</span>
+            <p class="course-identity__value">Spring R 2025</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Instructor</span>
+            <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Home Page</span>
+            <p class="course-identity__value course-identity__value--link">
+              <a href="math114.html">MATH 114 Home</a>
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Current Unit</span>
+            <p class="course-identity__value">
+              <span class="course-identity__pill">Modules 9–11</span>
+            </p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-
-  <main class="container course-page">
-
-    <section class="unit-overview-block"><h2>Unit Overview</h2><p>This section groups the statistics modules so students can quickly find homework, quizzes, slides, and reference tools for data summaries and normal distribution topics.</p></section>
-    <section><h2>Module 9</h2><table class="assignment-resource-table"><thead><tr><th>Assignment</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody><tr><td>Module 9 Homework (6A &amp; 6B)</td><td>Mar 23, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455483">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455486">Section 3</a></td></tr><tr><td>Module 9 Quiz (6A &amp; 6B)</td><td>Mar 24, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455488">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455489">Section 3</a></td></tr></tbody></table><table class="assignment-resource-table"><thead><tr><th>Slides</th><th>Tools</th></tr></thead><tbody><tr><td><a href="../pdfs/114Module9Spring25.pdf">Lecture Slides</a></td><td><a href="basic-statistical-measures.html">One Page Summary</a><br><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a><br><a href="https://www.microsoft365.com/launch/excel?">Excel Online</a></td></tr></tbody></table></section>
-    <section><h2>Module 10</h2><table class="assignment-resource-table"><thead><tr><th>Assignment</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody><tr><td>Module 10 Homework (6C &amp; 8A)</td><td>Mar 30, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455376">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455377">Section 3</a></td></tr><tr><td>Module 10 Quiz (6C &amp; 8A)</td><td>Mar 31, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455380">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455381">Section 3</a></td></tr></tbody></table><table class="assignment-resource-table"><thead><tr><th>Slides</th><th>Prof. Volk&apos;s Videos</th><th>Tools</th></tr></thead><tbody><tr><td><a href="../pdfs/114Module10Spring25.pdf">Lecture Slides</a></td><td><a href="https://youtu.be/rWprz1MvhOI">How to use the 68-95-99.7 rule</a><br><a href="https://youtu.be/j9V6rJrq-6s">Old Lecture Video</a></td><td><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a><br><a href="https://www.microsoft365.com/launch/excel?">Excel Online</a></td></tr></tbody></table></section>
-    <section><h2>Module 11</h2><table class="assignment-resource-table"><thead><tr><th>Assignment</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody><tr><td>Module 11 Homework (8B &amp; 8C)</td><td>Apr 6, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455384">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455385">Section 3</a></td></tr><tr><td>Module 11 Quiz (8B &amp; 8C)</td><td>Apr 7, 11:59pm</td><td>10</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455388">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455389">Section 3</a></td></tr></tbody></table><table class="assignment-resource-table"><thead><tr><th>Slides</th><th>Videos</th><th>Tools</th></tr></thead><tbody><tr><td>Slides will be posted as available.</td><td>Additional videos will be posted as available.</td><td><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a><br><a href="https://www.microsoft365.com/launch/excel?">Excel Online</a></td></tr></tbody></table><div class="course-back-row">
+    <main class="container course-page">
+      <section class="unit-overview-block">
+        <h2>Statistics Overview</h2>
+        <p>
+          This unit keeps the statistics modules aligned with the MATH 114
+          home-page navigation cards by highlighting what to do next and placing
+          slides, summaries, videos, and tools in a separate resources area.
+        </p>
+      </section>
+      <div class="unit-module-stack">
+        <section class="unit-module-card">
+          <h2>Module 9</h2>
+          <p class="unit-module-summary">
+            Start the statistics unit with descriptive statistics practice,
+            including the homework and quiz set plus a one-page summary and
+            spreadsheet-friendly tools.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Module 9 Homework (6A &amp; 6B)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Mar 23, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455483"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455486"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 9 Quiz (6A &amp; 6B)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Mar 24, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455488"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455489"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="unit-resource-grid">
+            <article class="unit-resource-card">
+              <h3>Slides &amp; summaries</h3>
+              <ul>
+                <li>
+                  <a href="../pdfs/114Module9Spring25.pdf">Lecture slides</a>
+                </li>
+                <li>
+                  <a href="basic-statistical-measures.html">One Page Summary</a>
+                </li>
+              </ul>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Tools</h3>
+              <ul>
+                <li>
+                  <a href="https://www.desmos.com/scientific"
+                    >Desmos Scientific Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.desmos.com/graphing"
+                    >Desmos Graphing Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.microsoft365.com/launch/excel?"
+                    >Excel Online</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section class="unit-module-card">
+          <h2>Module 10</h2>
+          <p class="unit-module-summary">
+            Move into normal models and empirical-rule applications with the
+            next homework and quiz set, supported by slides and walkthrough
+            videos.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Module 10 Homework (6C &amp; 8A)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Mar 30, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455376"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455377"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 10 Quiz (6C &amp; 8A)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Mar 31, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455380"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455381"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="unit-resource-grid">
+            <article class="unit-resource-card">
+              <h3>Slides</h3>
+              <ul>
+                <li>
+                  <a href="../pdfs/114Module10Spring25.pdf">Lecture slides</a>
+                </li>
+              </ul>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Videos</h3>
+              <ul>
+                <li>
+                  <a href="https://youtu.be/rWprz1MvhOI"
+                    >How to use the 68-95-99.7 rule</a
+                  >
+                </li>
+                <li>
+                  <a href="https://youtu.be/j9V6rJrq-6s">Old Lecture Video</a>
+                </li>
+              </ul>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Tools</h3>
+              <ul>
+                <li>
+                  <a href="https://www.desmos.com/scientific"
+                    >Desmos Scientific Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.desmos.com/graphing"
+                    >Desmos Graphing Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.microsoft365.com/launch/excel?"
+                    >Excel Online</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+        <section class="unit-module-card">
+          <h2>Module 11</h2>
+          <p class="unit-module-summary">
+            Complete the statistics content before Test 3 with the final
+            homework and quiz pair in this unit, while keeping the core tools
+            ready for spreadsheet and calculator work.
+          </p>
+          <div class="unit-task-grid">
+            <article class="unit-task-card">
+              <h3>Module 11 Homework (8B &amp; 8C)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Apr 6, 11:59pm</li>
+                <li><strong>Points:</strong> 20</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455384"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455385"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+            <article class="unit-task-card">
+              <h3>Module 11 Quiz (8B &amp; 8C)</h3>
+              <ul class="unit-task-meta">
+                <li><strong>Due:</strong> Apr 7, 11:59pm</li>
+                <li><strong>Points:</strong> 10</li>
+                <li>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455388"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455389"
+                    >Section 3</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="unit-resource-grid">
+            <article class="unit-resource-card">
+              <h3>Slides</h3>
+              <p>Slides will be posted as available.</p>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Videos</h3>
+              <p>Additional videos will be posted as available.</p>
+            </article>
+            <article class="unit-resource-card">
+              <h3>Tools</h3>
+              <ul>
+                <li>
+                  <a href="https://www.desmos.com/scientific"
+                    >Desmos Scientific Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.desmos.com/graphing"
+                    >Desmos Graphing Calculator</a
+                  >
+                </li>
+                <li>
+                  <a href="https://www.microsoft365.com/launch/excel?"
+                    >Excel Online</a
+                  >
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+      </div>
+      <div class="course-back-row">
         <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div></section>
-
-  </main>
-  <footer>
-    <div class="container">
-      <p>&copy; 2025 - All Rights Reserved</p>
-      <div class="social-links">
-        <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">📺</a>
       </div>
-    </div>
-  </footer>
-</body>
+    </main>
+    <footer>
+      <div class="container">
+        <p>&copy; 2025 - All Rights Reserved</p>
+        <div class="social-links">
+          <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube"
+            >📺</a
+          >
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/courses/math114-test1.html
+++ b/courses/math114-test1.html
@@ -1,92 +1,291 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MATH 114 Test 1 Unit</title>
-  <link rel="stylesheet" href="../styles.css">
-  <script src="../theme.js"></script>
-</head>
-<body>
-<nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="../learn.html">All Courses</a></li>
-          <li><a href="math114.html">MATH 114 Home</a></li>
-          <li><a href="math130.html">MATH 130 Home</a></li>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MATH 114 Test 1 Unit</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <script src="../theme.js"></script>
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="container nav-container">
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../CV.html">About Me</a></li>
+          <li class="dropdown">
+            <button class="dropdown-trigger" type="button" aria-haspopup="true">
+              Course Resources ▾
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="../learn.html">All Courses</a></li>
+              <li><a href="math114.html">MATH 114 Home</a></li>
+              <li><a href="math130.html">MATH 130 Home</a></li>
+            </ul>
+          </li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li>
+            <a
+              href="https://andrewhvolk.github.io/LibertyMathClub/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Math Club</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.youtube.com/learnabundantly"
+              target="_blank"
+              rel="noopener noreferrer"
+              >YouTube</a
+            >
+          </li>
+          <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
         </ul>
-      </li>
-      <li><a href="../projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
-  </div>
-</nav>
-  <header class="course-header course-header--unit">
-    <div class="container">
-      <h1>MATH 114: Test 1 Unit</h1>
-      <p class="subtitle">Module 4 review, project, and exam resources for Chapters 2 and 3.</p>
-    </div>
-  </header>
-
-  <div class="course-identity-wrap">
-    <div class="container">
-      <div class="course-identity" aria-label="Course identity">
-        <div class="course-identity__item">
-          <span class="course-identity__label">Course</span>
-          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Term</span>
-          <p class="course-identity__value">Spring R 2025</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Instructor</span>
-          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Home Page</span>
-          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Current Unit</span>
-          <p class="course-identity__value"><span class="course-identity__pill">Module 4</span></p>
+        <button
+          id="theme-toggle-btn"
+          class="theme-toggle"
+          aria-label="Toggle Theme"
+        ></button>
+      </div>
+    </nav>
+    <header class="course-header course-header--unit">
+      <div class="container">
+        <h1>MATH 114: Test 1 Unit</h1>
+        <p class="subtitle">
+          Module 4 review, project, and exam resources for Chapters 2 and 3.
+        </p>
+      </div>
+    </header>
+    <div class="course-identity-wrap">
+      <div class="container">
+        <div class="course-identity" aria-label="Course identity">
+          <div class="course-identity__item">
+            <span class="course-identity__label">Course</span>
+            <p class="course-identity__value">
+              MATH 114: Quantitative Reasoning
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Term</span>
+            <p class="course-identity__value">Spring R 2025</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Instructor</span>
+            <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Home Page</span>
+            <p class="course-identity__value course-identity__value--link">
+              <a href="math114.html">MATH 114 Home</a>
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Current Unit</span>
+            <p class="course-identity__value">
+              <span class="course-identity__pill">Module 4</span>
+            </p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-
-  <main class="container course-page">
-
-    <section class="unit-overview-block"><h2>Test 1 Overview</h2><p>This page collects the first major assessment materials, including the review assignment, the exam links, Project 1, and the supporting media posted for the unit.</p></section>
-    <section><h2>Module 4</h2>
-      <table class="assignment-resource-table"><thead><tr><th>Assignment / Project</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody>
-        <tr><td>Module 4 Test 1 Review (Ch 2 &amp; Ch 3)</td><td>Feb 9, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455440">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455442">Section 3</a></td></tr>
-        <tr><td>Module 4 Test 1 (Ch 2 &amp; Ch 3)</td><td>Feb 10, 11:59pm</td><td>125</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455436">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455438">Section 3</a></td></tr>
-        <tr><td>Project 1</td><td>Feb 7, 11:59pm</td><td>25</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455446">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455448">Section 3</a></td></tr>
-      </tbody></table>
-      <table class="assignment-resource-table"><thead><tr><th>Slides</th><th>Prof. Volk&apos;s Videos</th><th>Tools</th></tr></thead><tbody><tr><td><a href="../pdfs/114Module4Spring25.pdf">Lecture Slides</a></td><td><a href="https://youtu.be/m4i2FI82RPs">28 Math Problems (HW 8 Help)</a><br><a href="https://youtu.be/d0QyrtXzmfQ">How to complete a frequency table</a><br><a href="https://youtu.be/2T34DvLslhg">Project 1 Instructions</a><br><a href="https://youtu.be/HFo9cDZW2X0">Loan Payment #Short</a></td><td><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a></td></tr></tbody></table>
+    <main class="container course-page">
+      <section class="unit-overview-block">
+        <h2>Test 1 Overview</h2>
+        <p>
+          This assessment page keeps the Test 1 workflow scannable: students can
+          see the review work, Project 1, the exam itself, and the supporting
+          media for the first major checkpoint.
+        </p>
+      </section>
+      <section class="unit-module-card">
+        <h2>Module 4</h2>
+        <p class="unit-module-summary">
+          Use this unit to prepare for and complete the first exam cycle on
+          Chapters 2 and 3, with a review assignment, project submission, and
+          the full test all grouped together.
+        </p>
+        <div class="unit-task-grid">
+          <article class="unit-task-card">
+            <h3>Project 1</h3>
+            <ul class="unit-task-meta">
+              <li><strong>Due:</strong> Feb 7, 11:59pm</li>
+              <li><strong>Points:</strong> 25</li>
+              <li>
+                <a
+                  href="https://canvas.liberty.edu/courses/735702/assignments/11455446"
+                  >Section 2</a
+                >
+                |
+                <a
+                  href="https://canvas.liberty.edu/courses/735705/assignments/11455448"
+                  >Section 3</a
+                >
+              </li>
+            </ul>
+          </article>
+          <article class="unit-task-card">
+            <h3>Test 1 Review (Ch. 2 &amp; 3)</h3>
+            <ul class="unit-task-meta">
+              <li><strong>Due:</strong> Feb 9, 11:59pm</li>
+              <li><strong>Points:</strong> 20</li>
+              <li>
+                <a
+                  href="https://canvas.liberty.edu/courses/735702/assignments/11455440"
+                  >Section 2</a
+                >
+                |
+                <a
+                  href="https://canvas.liberty.edu/courses/735705/assignments/11455442"
+                  >Section 3</a
+                >
+              </li>
+            </ul>
+          </article>
+          <article class="unit-task-card">
+            <h3>Test 1 (Ch. 2 &amp; 3)</h3>
+            <ul class="unit-task-meta">
+              <li><strong>Due:</strong> Feb 10, 11:59pm</li>
+              <li><strong>Points:</strong> 125</li>
+              <li>
+                <a
+                  href="https://canvas.liberty.edu/courses/735702/assignments/11455436"
+                  >Section 2</a
+                >
+                |
+                <a
+                  href="https://canvas.liberty.edu/courses/735705/assignments/11455438"
+                  >Section 3</a
+                >
+              </li>
+            </ul>
+          </article>
+        </div>
+        <div class="unit-resource-grid">
+          <article class="unit-resource-card">
+            <h3>Slides</h3>
+            <ul>
+              <li>
+                <a href="../pdfs/114Module4Spring25.pdf">Lecture slides</a>
+              </li>
+            </ul>
+          </article>
+          <article class="unit-resource-card">
+            <h3>Videos</h3>
+            <ul>
+              <li>
+                <a href="https://youtu.be/m4i2FI82RPs"
+                  >28 Math Problems (HW 8 Help)</a
+                >
+              </li>
+              <li>
+                <a href="https://youtu.be/d0QyrtXzmfQ"
+                  >How to complete a frequency table</a
+                >
+              </li>
+              <li>
+                <a href="https://youtu.be/2T34DvLslhg"
+                  >Project 1 Instructions</a
+                >
+              </li>
+              <li>
+                <a href="https://youtu.be/HFo9cDZW2X0">Loan Payment #Short</a>
+              </li>
+            </ul>
+          </article>
+          <article class="unit-resource-card">
+            <h3>Tools</h3>
+            <ul>
+              <li>
+                <a href="https://www.desmos.com/scientific"
+                  >Desmos Scientific Calculator</a
+                >
+              </li>
+              <li>
+                <a href="https://www.desmos.com/graphing"
+                  >Desmos Graphing Calculator</a
+                >
+              </li>
+            </ul>
+          </article>
+        </div>
+        <details class="unit-detail-toggle">
+          <summary>Show detailed assignment table</summary>
+          <table class="assignment-resource-table">
+            <thead>
+              <tr>
+                <th>Assignment / Project</th>
+                <th>Due Date</th>
+                <th>Points</th>
+                <th>Links</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Module 4 Test 1 Review (Ch 2 &amp; Ch 3)</td>
+                <td>Feb 9, 11:59pm</td>
+                <td>20</td>
+                <td>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455440"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455442"
+                    >Section 3</a
+                  >
+                </td>
+              </tr>
+              <tr>
+                <td>Module 4 Test 1 (Ch 2 &amp; Ch 3)</td>
+                <td>Feb 10, 11:59pm</td>
+                <td>125</td>
+                <td>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455436"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455438"
+                    >Section 3</a
+                  >
+                </td>
+              </tr>
+              <tr>
+                <td>Project 1</td>
+                <td>Feb 7, 11:59pm</td>
+                <td>25</td>
+                <td>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455446"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455448"
+                    >Section 3</a
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </details>
+      </section>
       <div class="course-back-row">
         <a href="math114.html" class="button">Back to MATH 114 Home</a>
       </div>
-    </section>
-
-  </main>
-  <footer>
-    <div class="container">
-      <p>&copy; 2025 - All Rights Reserved</p>
-      <div class="social-links">
-        <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">📺</a>
+    </main>
+    <footer>
+      <div class="container">
+        <p>&copy; 2025 - All Rights Reserved</p>
+        <div class="social-links">
+          <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube"
+            >📺</a
+          >
+        </div>
       </div>
-    </div>
-  </footer>
-</body>
+    </footer>
+  </body>
 </html>

--- a/courses/math114-test2.html
+++ b/courses/math114-test2.html
@@ -1,84 +1,286 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MATH 114 Test 2 Unit</title>
-  <link rel="stylesheet" href="../styles.css">
-  <script src="../theme.js"></script>
-</head>
-<body>
-<nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="../learn.html">All Courses</a></li>
-          <li><a href="math114.html">MATH 114 Home</a></li>
-          <li><a href="math130.html">MATH 130 Home</a></li>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MATH 114 Test 2 Unit</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <script src="../theme.js"></script>
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="container nav-container">
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../CV.html">About Me</a></li>
+          <li class="dropdown">
+            <button class="dropdown-trigger" type="button" aria-haspopup="true">
+              Course Resources ▾
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="../learn.html">All Courses</a></li>
+              <li><a href="math114.html">MATH 114 Home</a></li>
+              <li><a href="math130.html">MATH 130 Home</a></li>
+            </ul>
+          </li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li>
+            <a
+              href="https://andrewhvolk.github.io/LibertyMathClub/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Math Club</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.youtube.com/learnabundantly"
+              target="_blank"
+              rel="noopener noreferrer"
+              >YouTube</a
+            >
+          </li>
+          <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
         </ul>
-      </li>
-      <li><a href="../projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
-  </div>
-</nav>
-  <header class="course-header course-header--unit">
-    <div class="container">
-      <h1>MATH 114: Test 2 Unit</h1>
-      <p class="subtitle">Module 8 review, project, and exam materials for Chapters 4 and 5.</p>
-    </div>
-  </header>
-
-  <div class="course-identity-wrap">
-    <div class="container">
-      <div class="course-identity" aria-label="Course identity">
-        <div class="course-identity__item">
-          <span class="course-identity__label">Course</span>
-          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Term</span>
-          <p class="course-identity__value">Spring R 2025</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Instructor</span>
-          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Home Page</span>
-          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Current Unit</span>
-          <p class="course-identity__value"><span class="course-identity__pill">Module 8</span></p>
+        <button
+          id="theme-toggle-btn"
+          class="theme-toggle"
+          aria-label="Toggle Theme"
+        ></button>
+      </div>
+    </nav>
+    <header class="course-header course-header--unit">
+      <div class="container">
+        <h1>MATH 114: Test 2 Unit</h1>
+        <p class="subtitle">
+          Module 8 review, project, and exam materials for Chapters 4 and 5.
+        </p>
+      </div>
+    </header>
+    <div class="course-identity-wrap">
+      <div class="container">
+        <div class="course-identity" aria-label="Course identity">
+          <div class="course-identity__item">
+            <span class="course-identity__label">Course</span>
+            <p class="course-identity__value">
+              MATH 114: Quantitative Reasoning
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Term</span>
+            <p class="course-identity__value">Spring R 2025</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Instructor</span>
+            <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Home Page</span>
+            <p class="course-identity__value course-identity__value--link">
+              <a href="math114.html">MATH 114 Home</a>
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Current Unit</span>
+            <p class="course-identity__value">
+              <span class="course-identity__pill">Module 8</span>
+            </p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-
-  <main class="container course-page">
-
-    <section class="unit-overview-block"><h2>Test 2 Overview</h2><p>Use this page for the second exam cycle, including the review, Project 2, the formula sheet, and tools commonly used for the unit.</p></section>
-    <section><h2>Module 8</h2><table class="assignment-resource-table"><thead><tr><th>Assignment / Project</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody><tr><td>Module 8 Test 2 (Ch 4 &amp; 5)</td><td>Mar 19, 11:59pm</td><td>125</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455472">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455474">Section 3</a></td></tr><tr><td>Module 8 Test 2 Review</td><td>Mar 7, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455476">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455479">Section 3</a></td></tr><tr><td>Project 2</td><td>Mar 7, 11:59pm</td><td>25</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455481">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455485">Section 3</a></td></tr></tbody></table><table class="assignment-resource-table"><thead><tr><th>Videos</th><th>Tools</th></tr></thead><tbody><tr><td><a href="https://youtu.be/3TJFd5SLkFE">37 Math Problems (HW 8 Help)</a><br><a href="https://youtu.be/d0QyrtXzmfQ">How to complete a frequency table</a><br><a href="https://youtu.be/AqI10auGYWU">Help with Project 2</a></td><td><a href="../pdfs/FormulaSheet.pdf">Formula Sheet for Test 2</a><br><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a><br><a href="https://www.microsoft365.com/launch/excel?">Excel Online</a></td></tr></tbody></table><div class="course-back-row">
+    <main class="container course-page">
+      <section class="unit-overview-block">
+        <h2>Test 2 Overview</h2>
+        <p>
+          This page keeps the second exam cycle easy to scan by separating the
+          to-do items from the videos, formula sheet, and technology links used
+          for Chapters 4 and 5.
+        </p>
+      </section>
+      <section class="unit-module-card">
+        <h2>Module 8</h2>
+        <p class="unit-module-summary">
+          Finish the financial math stretch with the Test 2 review, Project 2,
+          and the full exam, while keeping the formula sheet and calculator
+          tools nearby.
+        </p>
+        <div class="unit-task-grid">
+          <article class="unit-task-card">
+            <h3>Project 2</h3>
+            <ul class="unit-task-meta">
+              <li><strong>Due:</strong> Mar 7, 11:59pm</li>
+              <li><strong>Points:</strong> 25</li>
+              <li>
+                <a
+                  href="https://canvas.liberty.edu/courses/735702/assignments/11455481"
+                  >Section 2</a
+                >
+                |
+                <a
+                  href="https://canvas.liberty.edu/courses/735705/assignments/11455485"
+                  >Section 3</a
+                >
+              </li>
+            </ul>
+          </article>
+          <article class="unit-task-card">
+            <h3>Test 2 Review</h3>
+            <ul class="unit-task-meta">
+              <li><strong>Due:</strong> Mar 7, 11:59pm</li>
+              <li><strong>Points:</strong> 20</li>
+              <li>
+                <a
+                  href="https://canvas.liberty.edu/courses/735702/assignments/11455476"
+                  >Section 2</a
+                >
+                |
+                <a
+                  href="https://canvas.liberty.edu/courses/735705/assignments/11455479"
+                  >Section 3</a
+                >
+              </li>
+            </ul>
+          </article>
+          <article class="unit-task-card">
+            <h3>Test 2 (Ch. 4 &amp; 5)</h3>
+            <ul class="unit-task-meta">
+              <li><strong>Due:</strong> Mar 19, 11:59pm</li>
+              <li><strong>Points:</strong> 125</li>
+              <li>
+                <a
+                  href="https://canvas.liberty.edu/courses/735702/assignments/11455472"
+                  >Section 2</a
+                >
+                |
+                <a
+                  href="https://canvas.liberty.edu/courses/735705/assignments/11455474"
+                  >Section 3</a
+                >
+              </li>
+            </ul>
+          </article>
+        </div>
+        <div class="unit-resource-grid">
+          <article class="unit-resource-card">
+            <h3>Videos</h3>
+            <ul>
+              <li>
+                <a href="https://youtu.be/3TJFd5SLkFE"
+                  >37 Math Problems (HW 8 Help)</a
+                >
+              </li>
+              <li>
+                <a href="https://youtu.be/d0QyrtXzmfQ"
+                  >How to complete a frequency table</a
+                >
+              </li>
+              <li>
+                <a href="https://youtu.be/AqI10auGYWU">Help with Project 2</a>
+              </li>
+            </ul>
+          </article>
+          <article class="unit-resource-card">
+            <h3>Formula sheet &amp; tools</h3>
+            <ul>
+              <li>
+                <a href="../pdfs/FormulaSheet.pdf">Formula Sheet for Test 2</a>
+              </li>
+              <li>
+                <a href="https://www.desmos.com/scientific"
+                  >Desmos Scientific Calculator</a
+                >
+              </li>
+              <li>
+                <a href="https://www.desmos.com/graphing"
+                  >Desmos Graphing Calculator</a
+                >
+              </li>
+              <li>
+                <a href="https://www.microsoft365.com/launch/excel?"
+                  >Excel Online</a
+                >
+              </li>
+            </ul>
+          </article>
+        </div>
+        <details class="unit-detail-toggle">
+          <summary>Show detailed assignment table</summary>
+          <table class="assignment-resource-table">
+            <thead>
+              <tr>
+                <th>Assignment / Project</th>
+                <th>Due Date</th>
+                <th>Points</th>
+                <th>Links</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Module 8 Test 2 (Ch 4 &amp; 5)</td>
+                <td>Mar 19, 11:59pm</td>
+                <td>125</td>
+                <td>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455472"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455474"
+                    >Section 3</a
+                  >
+                </td>
+              </tr>
+              <tr>
+                <td>Module 8 Test 2 Review</td>
+                <td>Mar 7, 11:59pm</td>
+                <td>20</td>
+                <td>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455476"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455479"
+                    >Section 3</a
+                  >
+                </td>
+              </tr>
+              <tr>
+                <td>Project 2</td>
+                <td>Mar 7, 11:59pm</td>
+                <td>25</td>
+                <td>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455481"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455485"
+                    >Section 3</a
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </details>
+      </section>
+      <div class="course-back-row">
         <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div></section>
-
-  </main>
-  <footer>
-    <div class="container">
-      <p>&copy; 2025 - All Rights Reserved</p>
-      <div class="social-links">
-        <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">📺</a>
       </div>
-    </div>
-  </footer>
-</body>
+    </main>
+    <footer>
+      <div class="container">
+        <p>&copy; 2025 - All Rights Reserved</p>
+        <div class="social-links">
+          <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube"
+            >📺</a
+          >
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/courses/math114-test3.html
+++ b/courses/math114-test3.html
@@ -1,84 +1,273 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MATH 114 Test 3 Unit</title>
-  <link rel="stylesheet" href="../styles.css">
-  <script src="../theme.js"></script>
-</head>
-<body>
-<nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="../learn.html">All Courses</a></li>
-          <li><a href="math114.html">MATH 114 Home</a></li>
-          <li><a href="math130.html">MATH 130 Home</a></li>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MATH 114 Test 3 Unit</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <script src="../theme.js"></script>
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="container nav-container">
+        <ul class="nav-links">
+          <li><a href="../index.html">Home</a></li>
+          <li><a href="../CV.html">About Me</a></li>
+          <li class="dropdown">
+            <button class="dropdown-trigger" type="button" aria-haspopup="true">
+              Course Resources ▾
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="../learn.html">All Courses</a></li>
+              <li><a href="math114.html">MATH 114 Home</a></li>
+              <li><a href="math130.html">MATH 130 Home</a></li>
+            </ul>
+          </li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li>
+            <a
+              href="https://andrewhvolk.github.io/LibertyMathClub/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Math Club</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://www.youtube.com/learnabundantly"
+              target="_blank"
+              rel="noopener noreferrer"
+              >YouTube</a
+            >
+          </li>
+          <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
         </ul>
-      </li>
-      <li><a href="../projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
-  </div>
-</nav>
-  <header class="course-header course-header--unit">
-    <div class="container">
-      <h1>MATH 114: Test 3 Unit</h1>
-      <p class="subtitle">Module 12 review, project, and exam resources for Chapters 6 and 8.</p>
-    </div>
-  </header>
-
-  <div class="course-identity-wrap">
-    <div class="container">
-      <div class="course-identity" aria-label="Course identity">
-        <div class="course-identity__item">
-          <span class="course-identity__label">Course</span>
-          <p class="course-identity__value">MATH 114: Quantitative Reasoning</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Term</span>
-          <p class="course-identity__value">Spring R 2025</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Instructor</span>
-          <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Home Page</span>
-          <p class="course-identity__value course-identity__value--link"><a href="math114.html">MATH 114 Home</a></p>
-        </div>
-        <div class="course-identity__item">
-          <span class="course-identity__label">Current Unit</span>
-          <p class="course-identity__value"><span class="course-identity__pill">Module 12</span></p>
+        <button
+          id="theme-toggle-btn"
+          class="theme-toggle"
+          aria-label="Toggle Theme"
+        ></button>
+      </div>
+    </nav>
+    <header class="course-header course-header--unit">
+      <div class="container">
+        <h1>MATH 114: Test 3 Unit</h1>
+        <p class="subtitle">
+          Module 12 review, project, and exam resources for Chapters 6 and 8.
+        </p>
+      </div>
+    </header>
+    <div class="course-identity-wrap">
+      <div class="container">
+        <div class="course-identity" aria-label="Course identity">
+          <div class="course-identity__item">
+            <span class="course-identity__label">Course</span>
+            <p class="course-identity__value">
+              MATH 114: Quantitative Reasoning
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Term</span>
+            <p class="course-identity__value">Spring R 2025</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Instructor</span>
+            <p class="course-identity__value">Mr. Andrew Harrison Volk</p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Home Page</span>
+            <p class="course-identity__value course-identity__value--link">
+              <a href="math114.html">MATH 114 Home</a>
+            </p>
+          </div>
+          <div class="course-identity__item">
+            <span class="course-identity__label">Current Unit</span>
+            <p class="course-identity__value">
+              <span class="course-identity__pill">Module 12</span>
+            </p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-
-  <main class="container course-page">
-
-    <section class="unit-overview-block"><h2>Test 3 Overview</h2><p>This page combines the third exam materials so students can find the review assignment, Project 3 help, and the common technology links used in the unit.</p></section>
-    <section><h2>Module 12</h2><table class="assignment-resource-table"><thead><tr><th>Assignment / Project</th><th>Due Date</th><th>Points</th><th>Links</th></tr></thead><tbody><tr><td>Module 12 Test 3 (Ch 6 &amp; 8)</td><td>Apr 14, 11:59pm</td><td>125</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455392">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455393">Section 3</a></td></tr><tr><td>Module 12 Test 3 Review</td><td>Apr 13, 11:59pm</td><td>20</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455396">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455397">Section 3</a></td></tr><tr><td>Project 3</td><td>Apr 11, 11:59pm</td><td>25</td><td><a href="https://canvas.liberty.edu/courses/735702/assignments/11455401">Section 2</a> | <a href="https://canvas.liberty.edu/courses/735705/assignments/11455403">Section 3</a></td></tr></tbody></table><table class="assignment-resource-table"><thead><tr><th>Videos</th><th>Tools</th></tr></thead><tbody><tr><td><a href="https://youtu.be/RUz9L_W9Mp4">Help with Project 3</a></td><td><a href="https://www.desmos.com/scientific">Desmos Scientific Calculator</a><br><a href="https://www.desmos.com/graphing">Desmos Graphing Calculator</a><br><a href="https://www.microsoft365.com/launch/excel?">Excel Online</a></td></tr></tbody></table><div class="course-back-row">
+    <main class="container course-page">
+      <section class="unit-overview-block">
+        <h2>Test 3 Overview</h2>
+        <p>
+          This page combines the third exam checkpoint into a clear to-do list
+          plus a separate resources area, so students can move from Project 3 to
+          review and then into the exam.
+        </p>
+      </section>
+      <section class="unit-module-card">
+        <h2>Module 12</h2>
+        <p class="unit-module-summary">
+          Close the statistics assessment cycle with Project 3 support, the
+          review assignment, and the third test on Chapters 6 and 8, all
+          collected in one module page.
+        </p>
+        <div class="unit-task-grid">
+          <article class="unit-task-card">
+            <h3>Project 3</h3>
+            <ul class="unit-task-meta">
+              <li><strong>Due:</strong> Apr 11, 11:59pm</li>
+              <li><strong>Points:</strong> 25</li>
+              <li>
+                <a
+                  href="https://canvas.liberty.edu/courses/735702/assignments/11455401"
+                  >Section 2</a
+                >
+                |
+                <a
+                  href="https://canvas.liberty.edu/courses/735705/assignments/11455403"
+                  >Section 3</a
+                >
+              </li>
+            </ul>
+          </article>
+          <article class="unit-task-card">
+            <h3>Test 3 Review</h3>
+            <ul class="unit-task-meta">
+              <li><strong>Due:</strong> Apr 13, 11:59pm</li>
+              <li><strong>Points:</strong> 20</li>
+              <li>
+                <a
+                  href="https://canvas.liberty.edu/courses/735702/assignments/11455396"
+                  >Section 2</a
+                >
+                |
+                <a
+                  href="https://canvas.liberty.edu/courses/735705/assignments/11455397"
+                  >Section 3</a
+                >
+              </li>
+            </ul>
+          </article>
+          <article class="unit-task-card">
+            <h3>Test 3 (Ch. 6 &amp; 8)</h3>
+            <ul class="unit-task-meta">
+              <li><strong>Due:</strong> Apr 14, 11:59pm</li>
+              <li><strong>Points:</strong> 125</li>
+              <li>
+                <a
+                  href="https://canvas.liberty.edu/courses/735702/assignments/11455392"
+                  >Section 2</a
+                >
+                |
+                <a
+                  href="https://canvas.liberty.edu/courses/735705/assignments/11455393"
+                  >Section 3</a
+                >
+              </li>
+            </ul>
+          </article>
+        </div>
+        <div class="unit-resource-grid">
+          <article class="unit-resource-card">
+            <h3>Videos</h3>
+            <ul>
+              <li>
+                <a href="https://youtu.be/RUz9L_W9Mp4">Help with Project 3</a>
+              </li>
+            </ul>
+          </article>
+          <article class="unit-resource-card">
+            <h3>Tools</h3>
+            <ul>
+              <li>
+                <a href="https://www.desmos.com/scientific"
+                  >Desmos Scientific Calculator</a
+                >
+              </li>
+              <li>
+                <a href="https://www.desmos.com/graphing"
+                  >Desmos Graphing Calculator</a
+                >
+              </li>
+              <li>
+                <a href="https://www.microsoft365.com/launch/excel?"
+                  >Excel Online</a
+                >
+              </li>
+            </ul>
+          </article>
+        </div>
+        <details class="unit-detail-toggle">
+          <summary>Show detailed assignment table</summary>
+          <table class="assignment-resource-table">
+            <thead>
+              <tr>
+                <th>Assignment / Project</th>
+                <th>Due Date</th>
+                <th>Points</th>
+                <th>Links</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Module 12 Test 3 (Ch 6 &amp; 8)</td>
+                <td>Apr 14, 11:59pm</td>
+                <td>125</td>
+                <td>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455392"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455393"
+                    >Section 3</a
+                  >
+                </td>
+              </tr>
+              <tr>
+                <td>Module 12 Test 3 Review</td>
+                <td>Apr 13, 11:59pm</td>
+                <td>20</td>
+                <td>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455396"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455397"
+                    >Section 3</a
+                  >
+                </td>
+              </tr>
+              <tr>
+                <td>Project 3</td>
+                <td>Apr 11, 11:59pm</td>
+                <td>25</td>
+                <td>
+                  <a
+                    href="https://canvas.liberty.edu/courses/735702/assignments/11455401"
+                    >Section 2</a
+                  >
+                  |
+                  <a
+                    href="https://canvas.liberty.edu/courses/735705/assignments/11455403"
+                    >Section 3</a
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </details>
+      </section>
+      <div class="course-back-row">
         <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div></section>
-
-  </main>
-  <footer>
-    <div class="container">
-      <p>&copy; 2025 - All Rights Reserved</p>
-      <div class="social-links">
-        <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">📺</a>
       </div>
-    </div>
-  </footer>
-</body>
+    </main>
+    <footer>
+      <div class="container">
+        <p>&copy; 2025 - All Rights Reserved</p>
+        <div class="social-links">
+          <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube"
+            >📺</a
+          >
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -4,1034 +4,1164 @@
 
 /* CSS Variables for consistent theming */
 :root {
-    --primary-color: #3498db;
-    --secondary-color: #2c3e50;
-    --accent-color: #f39c12;
-    --text-color: #333;
-    --light-text: #fff;
-    --background-color: #f8f9fa;
-    --card-background: #fff;
-    --shadow: 0 4px 8px rgba(0,0,0,0.1);
-    --shadow-hover: 0 8px 16px rgba(0,0,0,0.15);
-    --border-radius: 8px;
-    --transition: all 0.3s ease;
+  --primary-color: #3498db;
+  --secondary-color: #2c3e50;
+  --accent-color: #f39c12;
+  --text-color: #333;
+  --light-text: #fff;
+  --background-color: #f8f9fa;
+  --card-background: #fff;
+  --shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  --shadow-hover: 0 8px 16px rgba(0, 0, 0, 0.15);
+  --border-radius: 8px;
+  --transition: all 0.3s ease;
 }
 /* No bullet points */
 ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
 
 /* Base styles */
 body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    line-height: 1.6;
-    margin: 0;
-    padding: 0;
-    color: var(--text-color);
-    background-color: var(--background-color);
-    transition: background-color 0.3s ease, color 0.3s ease; /* Add this line! */
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0;
+  color: var(--text-color);
+  background-color: var(--background-color);
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease; /* Add this line! */
 }
 
 /* Layout containers */
 .container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
-    width: 100%;
-    box-sizing: border-box;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 /* Typography */
-h1, h2, h3, h4, h5, h6 {
-    margin-top: 0;
-    color: var(--secondary-color);
-    line-height: 1.3;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 0;
+  color: var(--secondary-color);
+  line-height: 1.3;
 }
 
 a {
-    color: var(--primary-color);
-    text-decoration: none;
-    transition: var(--transition);
+  color: var(--primary-color);
+  text-decoration: none;
+  transition: var(--transition);
 }
 
 a:hover {
-    color: var(--accent-color);
+  color: var(--accent-color);
 }
 
 /* Header styling */
 header {
-    background-color: var(--secondary-color);
-    color: var(--light-text);
-    text-align: center;
-    padding: 2.5rem 0;
-    position: relative;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  background-color: var(--secondary-color);
+  color: var(--light-text);
+  text-align: center;
+  padding: 2.5rem 0;
+  position: relative;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
 header h1 {
-    margin: 0;
-    font-size: 2.5rem;
-    color: var(--light-text);
+  margin: 0;
+  font-size: 2.5rem;
+  color: var(--light-text);
 }
 
 .subtitle {
-    font-size: 1.2rem;
-    opacity: 0.9;
-    margin-top: 0.5rem;
+  font-size: 1.2rem;
+  opacity: 0.9;
+  margin-top: 0.5rem;
 }
 
 /* Profile image styling */
 .profile-image {
-    width: 150px;
-    height: 150px;
-    border-radius: 50%;
-    object-fit: cover;
-    border: 5px solid var(--light-text);
-    margin-bottom: 1rem;
-    box-shadow: var(--shadow);
-    margin: 0 auto 1rem;
-    overflow: hidden;
-    background-color: #eee;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 5px solid var(--light-text);
+  margin-bottom: 1rem;
+  box-shadow: var(--shadow);
+  margin: 0 auto 1rem;
+  overflow: hidden;
+  background-color: #eee;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .profile-image img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 /* Contact info styling */
 .contact-info {
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-    margin-top: 1.5rem;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
 }
 
 .contact-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    color: var(--light-text);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--light-text);
 }
 
 /* Navigation styling */
 nav.navbar {
-    position: sticky;
-    top: 0;
-    background-color: var(--secondary-color);
-    z-index: 999;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  position: sticky;
+  top: 0;
+  background-color: var(--secondary-color);
+  z-index: 999;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
 nav.navbar ul {
-    display: flex;
-    justify-content: center;
-    list-style: none;
-    margin: 0;
-    padding: 0;
+  display: flex;
+  justify-content: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 nav.navbar li {
-    position: relative;
+  position: relative;
 }
 
 nav.navbar a {
-    display: block;
-    padding: 1rem 1.5rem;
-    color: var(--light-text);
-    text-decoration: none;
-    transition: var(--transition);
+  display: block;
+  padding: 1rem 1.5rem;
+  color: var(--light-text);
+  text-decoration: none;
+  transition: var(--transition);
 }
 
 nav.navbar a:hover {
-    background-color: var(--primary-color);
+  background-color: var(--primary-color);
 }
 
 /* Dropdown menu styling - Updated */
 .dropdown-menu {
-    position: absolute;
-    top: calc(100% - 2px);
-    left: 0;
-    background-color: var(--secondary-color);
-    min-width: 200px;
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.3s ease, visibility 0.3s ease;
-    box-shadow: var(--shadow);
-    z-index: 1000;
+  position: absolute;
+  top: calc(100% - 2px);
+  left: 0;
+  background-color: var(--secondary-color);
+  min-width: 200px;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 0.3s ease,
+    visibility 0.3s ease;
+  box-shadow: var(--shadow);
+  z-index: 1000;
 }
 
 nav.navbar li:hover .dropdown-menu {
-    opacity: 1;
-    visibility: visible;
+  opacity: 1;
+  visibility: visible;
 }
 
 .dropdown-menu li {
-    width: 100%;
+  width: 100%;
 }
 
 .dropdown-menu a {
-    padding: 0.75rem 1.5rem;
-    white-space: nowrap;
+  padding: 0.75rem 1.5rem;
+  white-space: nowrap;
 }
 
 /* Hamburger menu for mobile */
 .menu-toggle {
-    display: none;
-    background-color: var(--secondary-color);
-    color: var(--light-text);
-    border: none;
-    font-size: 1.5rem;
-    padding: 0.5rem 1rem;
-    cursor: pointer;
+  display: none;
+  background-color: var(--secondary-color);
+  color: var(--light-text);
+  border: none;
+  font-size: 1.5rem;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
 }
 
 /* Main content area */
 main {
-    padding: 3rem 0;
+  padding: 3rem 0;
 }
 
 /* Section styling */
 section {
-    background-color: var(--card-background);
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-    padding: 2rem;
-    margin-bottom: 2rem;
-    transition: var(--transition);
+  background-color: var(--card-background);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow);
+  padding: 2rem;
+  margin-bottom: 2rem;
+  transition: var(--transition);
 }
 
 section:hover {
-    box-shadow: var(--shadow-hover);
+  box-shadow: var(--shadow-hover);
 }
 
 section h2 {
-    border-bottom: 2px solid var(--primary-color);
-    padding-bottom: 0.5rem;
-    margin-top: 0;
+  border-bottom: 2px solid var(--primary-color);
+  padding-bottom: 0.5rem;
+  margin-top: 0;
 }
 
 /* Two-column layout */
 .two-column {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 2rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
 }
 
 /* Experience and education items */
 .experience-item,
 .education-item {
-    margin-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
 .item-header {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 0.5rem;
-    flex-wrap: wrap;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .item-title {
-    font-weight: bold;
-    color: var(--secondary-color);
+  font-weight: bold;
+  color: var(--secondary-color);
 }
 
 .item-date {
-    color: #666;
+  color: #666;
 }
 
 .item-subtitle {
-    font-style: italic;
-    margin-bottom: 0.5rem;
+  font-style: italic;
+  margin-bottom: 0.5rem;
 }
 
 /* Publications styling */
 .publications-item {
-    margin-bottom: 1rem;
-    padding-left: 1rem;
-    border-left: 3px solid var(--primary-color);
-    transition: var(--transition);
+  margin-bottom: 1rem;
+  padding-left: 1rem;
+  border-left: 3px solid var(--primary-color);
+  transition: var(--transition);
 }
 
 .publications-item:hover {
-    transform: translateX(5px);
-    border-left-color: var(--accent-color);
+  transform: translateX(5px);
+  border-left-color: var(--accent-color);
 }
 
 /* Button styles */
 .button,
 .download-btn {
-    display: inline-block;
-    background-color: var(--primary-color);
-    color: var(--light-text);
-    padding: 0.75rem 1.5rem;
-    border-radius: 4px;
-    text-decoration: none;
-    font-weight: bold;
-    transition: var(--transition);
-    border: none;
-    cursor: pointer;
-    text-align: center;
+  display: inline-block;
+  background-color: var(--primary-color);
+  color: var(--light-text);
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: bold;
+  transition: var(--transition);
+  border: none;
+  cursor: pointer;
+  text-align: center;
 }
 
 .button:hover,
 .download-btn:hover {
-    background-color: var(--accent-color);
-    transform: translateY(-2px);
+  background-color: var(--accent-color);
+  transform: translateY(-2px);
 }
 
 .download-container {
-    text-align: center;
-    margin-bottom: 1.5rem;
+  text-align: center;
+  margin-bottom: 1.5rem;
 }
 
 /* YouTube-specific styles */
 .youtube-button {
-    background-color: #ff0000;
+  background-color: #ff0000;
 }
 
 .youtube-button:hover {
-    background-color: #cc0000;
+  background-color: #cc0000;
 }
 
 /* Card layout and styling */
 .card-container {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2rem;
 }
 
 .card {
-    background-color: var(--card-background);
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-    padding: 1.5rem;
-    width: 100%;
-    max-width: 300px;
-    transition: var(--transition);
+  background-color: var(--card-background);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 300px;
+  transition: var(--transition);
 }
 
 .card:hover {
-    transform: translateY(-5px);
-    box-shadow: var(--shadow-hover);
+  transform: translateY(-5px);
+  box-shadow: var(--shadow-hover);
 }
 
 .card h2 {
-    color: var(--secondary-color);
-    margin-top: 0;
+  color: var(--secondary-color);
+  margin-top: 0;
 }
 
 .card p {
-    margin-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
 .card-icon {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
-    color: var(--primary-color);
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--primary-color);
 }
-
-
 
 /* Reusable course page styles */
 .course-page {
-    padding: 3rem 0;
+  padding: 3rem 0;
 }
 
 .course-header {
-    position: relative;
-    overflow: hidden;
+  position: relative;
+  overflow: hidden;
 }
 
 .course-header::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(52, 152, 219, 0.2), rgba(243, 156, 18, 0.14));
-    pointer-events: none;
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    rgba(52, 152, 219, 0.2),
+    rgba(243, 156, 18, 0.14)
+  );
+  pointer-events: none;
 }
 
 .course-header .container {
-    position: relative;
-    z-index: 1;
+  position: relative;
+  z-index: 1;
 }
 
 .course-header--home {
-    padding: 3.25rem 0;
+  padding: 3.25rem 0;
 }
 
 .course-header--unit {
-    padding: 2.75rem 0;
+  padding: 2.75rem 0;
 }
 
 .course-header--home .subtitle,
 .course-header--unit .subtitle {
-    max-width: 52rem;
-    margin-left: auto;
-    margin-right: auto;
+  max-width: 52rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .course-identity-wrap {
-    margin-top: -1.25rem;
-    margin-bottom: 0.75rem;
-    position: relative;
-    z-index: 2;
+  margin-top: -1.25rem;
+  margin-bottom: 0.75rem;
+  position: relative;
+  z-index: 2;
 }
 
 .course-identity {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 1rem;
-    align-items: stretch;
-    background: var(--card-background);
-    border: 1px solid rgba(52, 152, 219, 0.18);
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-    padding: 1rem 1.25rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  align-items: stretch;
+  background: var(--card-background);
+  border: 1px solid rgba(52, 152, 219, 0.18);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow);
+  padding: 1rem 1.25rem;
 }
 
 .course-identity__item {
-    min-width: 0;
+  min-width: 0;
 }
 
 .course-identity__label {
-    display: block;
-    margin-bottom: 0.2rem;
-    font-size: 0.76rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--primary-color);
+  display: block;
+  margin-bottom: 0.2rem;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--primary-color);
 }
 
 .course-identity__value {
-    margin: 0;
-    color: var(--secondary-color);
-    font-weight: 600;
-    overflow-wrap: anywhere;
+  margin: 0;
+  color: var(--secondary-color);
+  font-weight: 600;
+  overflow-wrap: anywhere;
 }
 
 .course-identity__value--link a {
-    font-weight: 700;
+  font-weight: 700;
 }
 
 .course-identity__pill {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.3rem 0.75rem;
-    border-radius: 999px;
-    background: rgba(52, 152, 219, 0.12);
-    color: var(--secondary-color);
-    font-size: 0.95rem;
-    font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(52, 152, 219, 0.12);
+  color: var(--secondary-color);
+  font-size: 0.95rem;
+  font-weight: 700;
 }
 
 :root[data-theme="dark"] .course-identity {
-    border-color: rgba(240, 240, 240, 0.12);
+  border-color: rgba(240, 240, 240, 0.12);
 }
 
 :root[data-theme="dark"] .course-identity__pill {
-    background: rgba(52, 152, 219, 0.22);
+  background: rgba(52, 152, 219, 0.22);
 }
 
 .course-meta-grid,
 .quick-link-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1rem;
-    margin-top: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
 }
 
 .course-meta-card,
 .quick-link-card,
 .unit-overview-block {
-    background: var(--card-background);
-    border: 1px solid rgba(52, 152, 219, 0.18);
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-    padding: 1.25rem;
+  background: var(--card-background);
+  border: 1px solid rgba(52, 152, 219, 0.18);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow);
+  padding: 1.25rem;
 }
 
 .course-meta-card p:last-child,
 .quick-link-card p:last-child,
 .unit-overview-block > *:last-child {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .quick-link-card ul,
 .unit-overview-links {
-    list-style: disc;
-    margin: 0.75rem 0 0 1.25rem;
-    padding: 0;
+  list-style: disc;
+  margin: 0.75rem 0 0 1.25rem;
+  padding: 0;
 }
 
 .quick-link-card li + li,
 .unit-overview-links li + li {
-    margin-top: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .unit-overview-block {
-    margin-bottom: 2rem;
+  margin-bottom: 2rem;
 }
 
 .course-unit-card {
-    max-width: 330px;
+  max-width: 330px;
 }
 
 .course-unit-card .button {
-    width: 100%;
-    box-sizing: border-box;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.unit-module-stack {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.unit-module-card {
+  background: var(--card-background);
+  border: 1px solid rgba(52, 152, 219, 0.18);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+}
+
+.unit-module-card + .unit-module-card {
+  margin-top: 0;
+}
+
+.unit-module-card h2,
+.unit-module-card h3 {
+  margin-top: 0;
+}
+
+.unit-module-summary {
+  margin-bottom: 1.25rem;
+}
+
+.unit-task-grid,
+.unit-resource-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0 0;
+}
+
+.unit-task-card,
+.unit-resource-card {
+  background: rgba(52, 152, 219, 0.08);
+  border: 1px solid rgba(52, 152, 219, 0.16);
+  border-radius: var(--border-radius);
+  padding: 1rem;
+}
+
+.unit-task-card h3,
+.unit-resource-card h3 {
+  margin-bottom: 0.5rem;
+}
+
+.unit-task-meta {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+}
+
+.unit-task-meta li + li,
+.unit-resource-card li + li {
+  margin-top: 0.45rem;
+}
+
+.unit-task-meta strong {
+  color: var(--secondary-color);
+}
+
+.unit-resource-card ul {
+  list-style: disc;
+  margin: 0.75rem 0 0 1.25rem;
+  padding: 0;
+}
+
+.unit-detail-toggle {
+  margin-top: 1.25rem;
+  border-top: 1px solid rgba(44, 62, 80, 0.12);
+  padding-top: 1rem;
+}
+
+.unit-detail-toggle summary {
+  cursor: pointer;
+  font-weight: 700;
+  color: var(--secondary-color);
+}
+
+.unit-detail-toggle summary + * {
+  margin-top: 1rem;
+}
+
+:root[data-theme="dark"] .unit-task-card,
+:root[data-theme="dark"] .unit-resource-card {
+  background: rgba(52, 152, 219, 0.14);
+  border-color: rgba(240, 240, 240, 0.12);
+}
+
+:root[data-theme="dark"] .unit-detail-toggle {
+  border-top-color: rgba(240, 240, 240, 0.12);
 }
 
 .assignment-resource-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin: 1rem 0 2rem;
-    background-color: var(--card-background);
-    overflow: hidden;
-    border-radius: var(--border-radius);
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0 2rem;
+  background-color: var(--card-background);
+  overflow: hidden;
+  border-radius: var(--border-radius);
 }
 
 .assignment-resource-table th,
 .assignment-resource-table td {
-    border: 1px solid rgba(44, 62, 80, 0.18);
-    padding: 0.75em;
-    text-align: left;
-    vertical-align: top;
+  border: 1px solid rgba(44, 62, 80, 0.18);
+  padding: 0.75em;
+  text-align: left;
+  vertical-align: top;
 }
 
 .assignment-resource-table th {
-    background-color: rgba(52, 152, 219, 0.12);
-    color: var(--secondary-color);
+  background-color: rgba(52, 152, 219, 0.12);
+  color: var(--secondary-color);
 }
 
 .course-back-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
 }
 
 .course-back-row .button {
-    margin: 0;
+  margin: 0;
 }
 
 a[aria-disabled="true"] {
-    pointer-events: none;
-    color: #777;
-    text-decoration: none;
-    font-style: italic;
+  pointer-events: none;
+  color: #777;
+  text-decoration: none;
+  font-style: italic;
 }
 
 :root[data-theme="dark"] .assignment-resource-table th {
-    background-color: rgba(52, 152, 219, 0.22);
+  background-color: rgba(52, 152, 219, 0.22);
 }
 
 :root[data-theme="dark"] .assignment-resource-table th,
 :root[data-theme="dark"] .assignment-resource-table td {
-    border-color: rgba(240, 240, 240, 0.12);
+  border-color: rgba(240, 240, 240, 0.12);
 }
 
 /* Footer styling */
 footer {
-    background-color: var(--secondary-color);
-    color: var(--light-text);
-    text-align: center;
-    padding: 1.5rem 0;
-    margin-top: 3rem;
+  background-color: var(--secondary-color);
+  color: var(--light-text);
+  text-align: center;
+  padding: 1.5rem 0;
+  margin-top: 3rem;
 }
 
 /* Social links */
 .social-links {
-    margin-top: 1rem;
-    display: flex;
-    justify-content: center;
-    gap: 1rem;
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
 }
 
 .social-links a {
-    color: var(--light-text);
-    font-size: 1.5rem;
-    text-decoration: none;
-    transition: var(--transition);
+  color: var(--light-text);
+  font-size: 1.5rem;
+  text-decoration: none;
+  transition: var(--transition);
 }
 
 .social-links a:hover {
-    color: var(--accent-color);
-    transform: translateY(-3px);
+  color: var(--accent-color);
+  transform: translateY(-3px);
 }
 
 /* 404 error page styling */
 .error-container {
-    background-color: var(--card-background);
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-    padding: 2.5rem;
-    width: 100%;
-    max-width: 500px;
-    text-align: center;
+  background-color: var(--card-background);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow);
+  padding: 2.5rem;
+  width: 100%;
+  max-width: 500px;
+  text-align: center;
 }
 
 .error-icon {
-    font-size: 4rem;
-    color: var(--primary-color);
-    margin-bottom: 1rem;
+  font-size: 4rem;
+  color: var(--primary-color);
+  margin-bottom: 1rem;
 }
 
 .error-code {
-    font-size: 3rem;
-    font-weight: bold;
-    color: var(--secondary-color);
-    margin: 0;
+  font-size: 3rem;
+  font-weight: bold;
+  color: var(--secondary-color);
+  margin: 0;
 }
 
 .error-message {
-    font-size: 1.2rem;
-    margin: 1rem 0 2rem;
+  font-size: 1.2rem;
+  margin: 1rem 0 2rem;
 }
 
 /* Special layout for error page */
 main.error-main {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-    min-height: 60vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  min-height: 60vh;
 }
 
 /* Highlights list styling */
 .highlights-list {
-    list-style: none;
-    margin: 1rem 0 2rem;
-    padding: 0;
+  list-style: none;
+  margin: 1rem 0 2rem;
+  padding: 0;
 }
 
 .highlights-list li {
-    margin-bottom: 0.8rem;
-    padding-left: 1.5rem;
-    position: relative;
+  margin-bottom: 0.8rem;
+  padding-left: 1.5rem;
+  position: relative;
 }
 
 .highlights-list li:before {
-    content: "▹";
-    color: var(--primary-color);
-    position: absolute;
-    left: 0;
-    font-size: 1.2rem;
+  content: "▹";
+  color: var(--primary-color);
+  position: absolute;
+  left: 0;
+  font-size: 1.2rem;
 }
 
 /* Skill badges */
 .skills-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .skill-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.3rem;
-    background-color: var(--primary-color);
-    color: var(--light-text);
-    padding: 0.3rem 0.8rem;
-    border-radius: 50px;
-    font-size: 0.9rem;
-    transition: var(--transition);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background-color: var(--primary-color);
+  color: var(--light-text);
+  padding: 0.3rem 0.8rem;
+  border-radius: 50px;
+  font-size: 0.9rem;
+  transition: var(--transition);
 }
 
 .skill-badge:hover {
-    background-color: var(--accent-color);
-    transform: translateY(-2px);
+  background-color: var(--accent-color);
+  transform: translateY(-2px);
 }
 
 /* Print styles */
 @media print {
-    nav, 
-    .download-container, 
-    .menu-toggle,
-    footer {
-        display: none !important;
-    }
-    
-    body {
-        background-color: white;
-        font-size: 12pt;
-        color: black;
-    }
-    
-    section, 
-    .container {
-        margin: 0;
-        padding: 0.5in;
-        box-shadow: none;
-        break-inside: avoid;
-    }
-    
-    a {
-        color: black;
-        text-decoration: none;
-    }
-    
-    .two-column {
-        grid-template-columns: 1fr 1fr;
-        gap: 0.5in;
-    }
-    
-    @page {
-        margin: 0.5in;
-        size: portrait;
-    }
-    
-    .card-container {
-        display: block;
-    }
-    
-    .card {
-        page-break-inside: avoid;
-        max-width: 100%;
-        box-shadow: none;
-        margin-bottom: 1rem;
-    }
-}
+  nav,
+  .download-container,
+  .menu-toggle,
+  footer {
+    display: none !important;
+  }
 
+  body {
+    background-color: white;
+    font-size: 12pt;
+    color: black;
+  }
+
+  section,
+  .container {
+    margin: 0;
+    padding: 0.5in;
+    box-shadow: none;
+    break-inside: avoid;
+  }
+
+  a {
+    color: black;
+    text-decoration: none;
+  }
+
+  .two-column {
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5in;
+  }
+
+  @page {
+    margin: 0.5in;
+    size: portrait;
+  }
+
+  .card-container {
+    display: block;
+  }
+
+  .card {
+    page-break-inside: avoid;
+    max-width: 100%;
+    box-shadow: none;
+    margin-bottom: 1rem;
+  }
+}
 
 /* Dark Theme Variables applied via JS */
 :root[data-theme="dark"] {
-    --text-color: #f0f0f0;
-    --background-color: #121212;
-    --card-background: #1e1e1e;
-    --shadow: 0 4px 8px rgba(0,0,0,0.3);
-    --shadow-hover: 0 8px 16px rgba(0,0,0,0.4);
+  --text-color: #f0f0f0;
+  --background-color: #121212;
+  --card-background: #1e1e1e;
+  --shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  --shadow-hover: 0 8px 16px rgba(0, 0, 0, 0.4);
 }
 
 :root[data-theme="dark"] .profile-image {
-    border-color: var(--secondary-color);
+  border-color: var(--secondary-color);
 }
 
 :root[data-theme="dark"] .item-date {
-    color: #aaa;
+  color: #aaa;
 }
 
 /* Theme Toggle Button Styling */
 .theme-toggle {
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-size: 1.5rem;
-    margin-left: auto; /* Pushes the button to the far right of the flex container */
-    margin-right: 1rem;
-    color: var(--light-text);
-    border-radius: 50%;
-    background-color: rgba(255, 255, 255, 0.2);
-    width: 40px;
-    height: 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: var(--transition);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.5rem;
+  margin-left: auto; /* Pushes the button to the far right of the flex container */
+  margin-right: 1rem;
+  color: var(--light-text);
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.2);
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition);
 }
 
 .theme-toggle:hover {
-    background-color: rgba(255, 255, 255, 0.3);
-    transform: scale(1.1);
+  background-color: rgba(255, 255, 255, 0.3);
+  transform: scale(1.1);
 }
 /* Accessibility improvements */
 :focus {
-    outline: 2px solid var(--primary-color);
-    outline-offset: 2px;
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
 }
 
 /* Animations */
 @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @-webkit-keyframes fadeIn {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 section {
-    -webkit-animation: fadeIn 0.5s ease-out forwards;
-    animation: fadeIn 0.5s ease-out forwards;
-    opacity: 0;
+  -webkit-animation: fadeIn 0.5s ease-out forwards;
+  animation: fadeIn 0.5s ease-out forwards;
+  opacity: 0;
 }
 
 /* Stagger section animations for smoother page load */
-section:nth-child(1) { animation-delay: 0.05s; }
-section:nth-child(2) { animation-delay: 0.1s; }
-section:nth-child(3) { animation-delay: 0.15s; }
-section:nth-child(4) { animation-delay: 0.2s; }
-section:nth-child(5) { animation-delay: 0.25s; }
+section:nth-child(1) {
+  animation-delay: 0.05s;
+}
+section:nth-child(2) {
+  animation-delay: 0.1s;
+}
+section:nth-child(3) {
+  animation-delay: 0.15s;
+}
+section:nth-child(4) {
+  animation-delay: 0.2s;
+}
+section:nth-child(5) {
+  animation-delay: 0.25s;
+}
 
 /* Media queries for responsive design */
 @media (max-width: 768px) {
-    /* Hamburger menu toggle */
-    .menu-toggle {
-        display: flex;
-        width: 100%;
-        text-align: left;
-        padding: 0.75rem 1rem;
-        justify-content: space-between;
-        align-items: center;
-    }
-    
-    /* Mobile navigation structure */
-    nav.navbar ul#nav-menu {
-        display: none;
-        flex-direction: column;
-        width: 100%;
-    }
-    
-    nav.navbar ul#nav-menu.open {
-        display: flex;
-    }
-    
-    /* Consistent dropdown handling - Updated for mobile */
-    .dropdown-menu {
-        position: static;
-        width: 100%;
-        box-shadow: none;
-        overflow: hidden;
-        max-height: 0;
-        opacity: 0;
-        visibility: hidden;
-        transition: max-height 0.3s ease-out, opacity 0.2s ease-out, visibility 0.2s ease-out;
-    }
-    
-    .dropdown-open {
-        max-height: 500px;
-        opacity: 1;
-        visibility: visible;
-        transition: max-height 0.5s ease-in, opacity 0.3s ease-in, visibility 0.3s ease-in;
-    }
-    
-    /* Dropdown menu styling for mobile */
-    .dropdown-menu a {
-        padding-left: 2.5rem;
-    }
-    
-    /* Fix responsive layout */
-    .two-column {
-        grid-template-columns: 1fr;
-    }
-    
-    .item-header {
-        flex-direction: column;
-    }
-    
-    .container {
-        padding: 0 1rem;
-    }
-    
-    section {
-        padding: 1.5rem;
-    }
-    
-    .card-container {
-        flex-direction: column;
-        align-items: center;
-    }
-    
-    .card {
-        max-width: 100%;
-    }
-    
-    .contact-info {
-        flex-direction: column;
-        gap: 0.5rem;
-        align-items: center;
-    }
+  /* Hamburger menu toggle */
+  .menu-toggle {
+    display: flex;
+    width: 100%;
+    text-align: left;
+    padding: 0.75rem 1rem;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  /* Mobile navigation structure */
+  nav.navbar ul#nav-menu {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  nav.navbar ul#nav-menu.open {
+    display: flex;
+  }
+
+  /* Consistent dropdown handling - Updated for mobile */
+  .dropdown-menu {
+    position: static;
+    width: 100%;
+    box-shadow: none;
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+    transition:
+      max-height 0.3s ease-out,
+      opacity 0.2s ease-out,
+      visibility 0.2s ease-out;
+  }
+
+  .dropdown-open {
+    max-height: 500px;
+    opacity: 1;
+    visibility: visible;
+    transition:
+      max-height 0.5s ease-in,
+      opacity 0.3s ease-in,
+      visibility 0.3s ease-in;
+  }
+
+  /* Dropdown menu styling for mobile */
+  .dropdown-menu a {
+    padding-left: 2.5rem;
+  }
+
+  /* Fix responsive layout */
+  .two-column {
+    grid-template-columns: 1fr;
+  }
+
+  .item-header {
+    flex-direction: column;
+  }
+
+  .container {
+    padding: 0 1rem;
+  }
+
+  section {
+    padding: 1.5rem;
+  }
+
+  .card-container {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .card {
+    max-width: 100%;
+  }
+
+  .contact-info {
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+  }
 }
 
 /* High contrast mode support */
 @media (forced-colors: active) {
-    :root {
-        --primary-color: CanvasText;
-        --secondary-color: Canvas;
-        --accent-color: Highlight;
-        --text-color: CanvasText;
-        --light-text: Canvas;
-        --background-color: Canvas;
-        --card-background: Canvas;
-    }
-    
-    .skill-badge,
-    .button,
-    .download-btn {
-        border: 1px solid CanvasText;
-    }
+  :root {
+    --primary-color: CanvasText;
+    --secondary-color: Canvas;
+    --accent-color: Highlight;
+    --text-color: CanvasText;
+    --light-text: Canvas;
+    --background-color: Canvas;
+    --card-background: Canvas;
+  }
+
+  .skill-badge,
+  .button,
+  .download-btn {
+    border: 1px solid CanvasText;
+  }
 }
 /* Modern Standard Navbar */
 .navbar {
-    background-color: var(--secondary-color);
-    position: sticky;
-    top: 0;
-    z-index: 1000;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+  background-color: var(--secondary-color);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
 }
 
 .nav-container {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.5rem;
 }
 
 .nav-links {
-    display: flex;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    gap: 0.5rem;
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 0.5rem;
 }
 
 .nav-links li {
-    position: relative;
+  position: relative;
 }
 
 .nav-links a {
-    display: block;
-    padding: 1rem 0.75rem;
-    color: var(--light-text);
-    text-decoration: none;
-    font-weight: 500;
-    transition: var(--transition);
-    border-radius: 4px;
-    font-size: 1rem;
+  display: block;
+  padding: 1rem 0.75rem;
+  color: var(--light-text);
+  text-decoration: none;
+  font-weight: 500;
+  transition: var(--transition);
+  border-radius: 4px;
+  font-size: 1rem;
 }
 
 .nav-links a:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-    color: var(--accent-color);
+  background-color: rgba(255, 255, 255, 0.1);
+  color: var(--accent-color);
 }
 
 .dropdown-trigger {
-    display: block;
-    padding: 1rem 0.75rem;
-    color: var(--light-text);
-    text-decoration: none;
-    font-weight: 500;
-    transition: var(--transition);
-    border-radius: 4px;
-    font-size: 1rem;
-    background: transparent;
-    border: 0;
-    font-family: inherit;
-    cursor: pointer;
+  display: block;
+  padding: 1rem 0.75rem;
+  color: var(--light-text);
+  text-decoration: none;
+  font-weight: 500;
+  transition: var(--transition);
+  border-radius: 4px;
+  font-size: 1rem;
+  background: transparent;
+  border: 0;
+  font-family: inherit;
+  cursor: pointer;
 }
 
 .dropdown-trigger:hover,
 .dropdown-trigger:focus-visible,
 .nav-links .dropdown-menu a:hover,
 .nav-links .dropdown-menu a:focus-visible {
-    background-color: rgba(255, 255, 255, 0.1);
-    color: var(--accent-color);
+  background-color: rgba(255, 255, 255, 0.1);
+  color: var(--accent-color);
 }
 
 .nav-links .dropdown-menu {
-    position: absolute;
-    top: calc(100% + 0.25rem);
-    left: 0;
-    min-width: 220px;
-    padding: 0.35rem;
-    background-color: var(--secondary-color);
-    border-radius: 8px;
-    box-shadow: var(--shadow);
-    opacity: 0;
-    visibility: hidden;
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  min-width: 220px;
+  padding: 0.35rem;
+  background-color: var(--secondary-color);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  opacity: 0;
+  visibility: hidden;
 }
 
 .nav-links .dropdown:hover .dropdown-menu,
 .nav-links .dropdown:focus-within .dropdown-menu {
-    opacity: 1;
-    visibility: visible;
+  opacity: 1;
+  visibility: visible;
 }
 
 .nav-links .dropdown-menu a {
-    padding: 0.6rem 0.75rem;
-    white-space: nowrap;
+  padding: 0.6rem 0.75rem;
+  white-space: nowrap;
 }
 
 /* Ensure the toggle button aligns perfectly in the new layout */
 .navbar .theme-toggle {
-    margin: 0; 
+  margin: 0;
 }
 
 /* Mobile responsiveness: stack the nav links neatly on small screens */
 @media (max-width: 768px) {
-    .nav-container {
-        flex-direction: column;
-        padding: 0.5rem;
-    }
-    
-    .nav-links {
-        flex-wrap: wrap;
-        justify-content: center;
-        margin-bottom: 0.5rem;
-    }
+  .nav-container {
+    flex-direction: column;
+    padding: 0.5rem;
+  }
 
-    .nav-links .dropdown-menu {
-        position: static;
-        min-width: 0;
-        width: 100%;
-        opacity: 1;
-        visibility: visible;
-        display: none;
-        margin-top: 0;
-        box-shadow: none;
-        padding: 0;
-    }
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 0.5rem;
+  }
 
-    .nav-links .dropdown:hover .dropdown-menu,
-    .nav-links .dropdown:focus-within .dropdown-menu {
-        display: block;
-    }
-    
-    .nav-links a {
-        padding: 0.5rem;
-        font-size: 0.9rem;
-    }
+  .nav-links .dropdown-menu {
+    position: static;
+    min-width: 0;
+    width: 100%;
+    opacity: 1;
+    visibility: visible;
+    display: none;
+    margin-top: 0;
+    box-shadow: none;
+    padding: 0;
+  }
 
-    .dropdown-trigger {
-        padding: 0.5rem;
-        font-size: 0.9rem;
-    }
+  .nav-links .dropdown:hover .dropdown-menu,
+  .nav-links .dropdown:focus-within .dropdown-menu {
+    display: block;
+  }
+
+  .nav-links a {
+    padding: 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .dropdown-trigger {
+    padding: 0.5rem;
+    font-size: 0.9rem;
+  }
 }
 .shortcut-bar {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: var(--secondary-color);
-    padding: 0.5rem;
-    position: sticky;
-    top: 0;
-    z-index: 1000;
-  }  
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--secondary-color);
+  padding: 0.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
 
 .shortcut-bar a {
-    margin: 0 1rem;
-    color: var(--light-text);
-    font-size: 1.5rem;
-    text-decoration: none;
-    transition: var(--transition);
-    background-color: rgba(255, 255, 255, 0.2);
-    padding: 0.5rem;
-    border-radius: 50%;
-  }
-  
-  .shortcut-bar a:hover {
-    color: var(--accent-color);
-    background-color: rgba(255, 255, 255, 0.3);
-  }
-  
-  
+  margin: 0 1rem;
+  color: var(--light-text);
+  font-size: 1.5rem;
+  text-decoration: none;
+  transition: var(--transition);
+  background-color: rgba(255, 255, 255, 0.2);
+  padding: 0.5rem;
+  border-radius: 50%;
+}
+
+.shortcut-bar a:hover {
+  color: var(--accent-color);
+  background-color: rgba(255, 255, 255, 0.3);
+}


### PR DESCRIPTION
### Motivation
- Improve student discoverability by replacing dense, table-heavy unit pages with a scannable module/card-first layout. 
- Keep navigation, unit language, and links consistent with the existing `courses/math114.html` home cards. 
- Provide a reusable pattern for other unit pages (tasks, resources, optional detailed tables) to simplify future updates.

### Description
- Added reusable unit-page styles to `styles.css` (new classes: `unit-module-stack`, `unit-module-card`, `unit-task-grid`, `unit-task-card`, `unit-resource-grid`, `unit-resource-card`, and `unit-detail-toggle`) to support stacked module cards, to-do cards, resource areas, and optional collapsible detail sections. 
- Refactored unit HTML pages to the new pattern and preserved detailed tables inside collapsible sections where useful: `courses/math114-foundations.html`, `courses/math114-test1.html`, `courses/math114-test2.html`, `courses/math114-test3.html`, `courses/math114-financial-math.html`, `courses/math114-statistics.html`, and `courses/math114-final-review.html`. 
- Kept existing header/nav/identity blocks and unit terminology intact so unit cards stay consistent with the MATH 114 home page. 
- Normalized document formatting and doctype across updated files and applied code-style formatting via `prettier`.

### Testing
- Ran `prettier --write styles.css courses/math114-*.html` to format the CSS and updated unit pages, which completed successfully. 
- Verified formatting with `prettier --check styles.css courses/math114-*.html` and confirmed files match the configured code style. 
- Performed local repository status checks to confirm the updated files are present and ready for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf2869fea08331a407a03ff7cc3055)