### PR TITLE
Standardize course navigation dropdown (add MATH 114 Home)

### DIFF
--- a/learn.html
+++ b/learn.html
@@ -17,6 +17,7 @@
         <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
         <ul class="dropdown-menu">
           <li><a href="learn.html">All Courses</a></li>
+          <li><a href="courses/math114.html">MATH 114 Home</a></li>
           <li><a href="courses/math130.html">MATH 130 Home</a></li>
         </ul>
       </li>


### PR DESCRIPTION
### Motivation
- Ensure the "Course Resources" dropdown uses a consistent ordering and naming (`All Courses`, `MATH 114 Home`, `MATH 130 Home`) across the learning page and MATH 114 pages so navigation is predictable for students.  

### Description
- Add the missing `MATH 114 Home` entry to the `Course Resources` dropdown in `learn.html`, aligning the dropdown order with `courses/math114.html` and the `courses/math114-*.html` unit pages while leaving `courses/math130.html` unchanged.  

### Testing
- Verified the change with `git diff -- learn.html`, inspected all dropdown blocks with a small Python script that extracts `<ul class="dropdown-menu">` from `learn.html`, `courses/math114.html`, and `courses/math114-*.html`, and checked line locations with `nl`; all automated checks show the dropdowns now share the same naming and ordering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf308355588331a61f1ece9bdb10de)