### PR TITLE
Add reusable MATH 114 unit navigation

### DIFF
--- a/courses/math114-final-review.html
+++ b/courses/math114-final-review.html
@@ -332,9 +332,11 @@
           </details>
         </section>
       </div>
-      <div class="course-back-row">
-        <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div>
+      <nav class="course-sequence-nav" aria-label="Course unit navigation">
+        <a href="math114-test3.html" class="button course-sequence-nav__link">&larr; Previous Unit</a>
+        <a href="math114.html" class="button course-sequence-nav__link">Course Home</a>
+        <a class="button course-sequence-nav__link" aria-disabled="true">Next Unit &rarr;</a>
+      </nav>
     </main>
     <footer>
       <div class="container">

--- a/courses/math114-financial-math.html
+++ b/courses/math114-financial-math.html
@@ -329,9 +329,11 @@
           </div>
         </section>
       </div>
-      <div class="course-back-row">
-        <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div>
+      <nav class="course-sequence-nav" aria-label="Course unit navigation">
+        <a href="math114-test1.html" class="button course-sequence-nav__link">&larr; Previous Unit</a>
+        <a href="math114.html" class="button course-sequence-nav__link">Course Home</a>
+        <a href="math114-test2.html" class="button course-sequence-nav__link">Next Unit &rarr;</a>
+      </nav>
     </main>
     <footer>
       <div class="container">

--- a/courses/math114-foundations.html
+++ b/courses/math114-foundations.html
@@ -404,10 +404,11 @@
           </div>
         </section>
       </div>
-
-      <div class="course-back-row">
-        <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div>
+      <nav class="course-sequence-nav" aria-label="Course unit navigation">
+        <a class="button course-sequence-nav__link" aria-disabled="true">&larr; Previous Unit</a>
+        <a href="math114.html" class="button course-sequence-nav__link">Course Home</a>
+        <a href="math114-test1.html" class="button course-sequence-nav__link">Next Unit &rarr;</a>
+      </nav>
     </main>
     <footer>
       <div class="container">

--- a/courses/math114-statistics.html
+++ b/courses/math114-statistics.html
@@ -345,9 +345,11 @@
           </div>
         </section>
       </div>
-      <div class="course-back-row">
-        <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div>
+      <nav class="course-sequence-nav" aria-label="Course unit navigation">
+        <a href="math114-test2.html" class="button course-sequence-nav__link">&larr; Previous Unit</a>
+        <a href="math114.html" class="button course-sequence-nav__link">Course Home</a>
+        <a href="math114-test3.html" class="button course-sequence-nav__link">Next Unit &rarr;</a>
+      </nav>
     </main>
     <footer>
       <div class="container">

--- a/courses/math114-test1.html
+++ b/courses/math114-test1.html
@@ -273,9 +273,11 @@
           </table>
         </details>
       </section>
-      <div class="course-back-row">
-        <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div>
+      <nav class="course-sequence-nav" aria-label="Course unit navigation">
+        <a href="math114-foundations.html" class="button course-sequence-nav__link">&larr; Previous Unit</a>
+        <a href="math114.html" class="button course-sequence-nav__link">Course Home</a>
+        <a href="math114-financial-math.html" class="button course-sequence-nav__link">Next Unit &rarr;</a>
+      </nav>
     </main>
     <footer>
       <div class="container">

--- a/courses/math114-test2.html
+++ b/courses/math114-test2.html
@@ -268,9 +268,11 @@
           </table>
         </details>
       </section>
-      <div class="course-back-row">
-        <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div>
+      <nav class="course-sequence-nav" aria-label="Course unit navigation">
+        <a href="math114-financial-math.html" class="button course-sequence-nav__link">&larr; Previous Unit</a>
+        <a href="math114.html" class="button course-sequence-nav__link">Course Home</a>
+        <a href="math114-statistics.html" class="button course-sequence-nav__link">Next Unit &rarr;</a>
+      </nav>
     </main>
     <footer>
       <div class="container">

--- a/courses/math114-test3.html
+++ b/courses/math114-test3.html
@@ -255,9 +255,11 @@
           </table>
         </details>
       </section>
-      <div class="course-back-row">
-        <a href="math114.html" class="button">Back to MATH 114 Home</a>
-      </div>
+      <nav class="course-sequence-nav" aria-label="Course unit navigation">
+        <a href="math114-statistics.html" class="button course-sequence-nav__link">&larr; Previous Unit</a>
+        <a href="math114.html" class="button course-sequence-nav__link">Course Home</a>
+        <a href="math114-final-review.html" class="button course-sequence-nav__link">Next Unit &rarr;</a>
+      </nav>
     </main>
     <footer>
       <div class="container">

--- a/styles.css
+++ b/styles.css
@@ -618,22 +618,33 @@ section h2 {
   color: var(--secondary-color);
 }
 
-.course-back-row {
-  display: flex;
-  flex-wrap: wrap;
+.course-sequence-nav {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.75rem;
-  margin-top: 1rem;
+  margin-top: 1.5rem;
+  align-items: stretch;
 }
 
-.course-back-row .button {
+.course-sequence-nav__link {
   margin: 0;
+  width: 100%;
+  text-align: center;
 }
 
-a[aria-disabled="true"] {
+.course-sequence-nav__link[aria-disabled="true"] {
   pointer-events: none;
-  color: #777;
-  text-decoration: none;
-  font-style: italic;
+  opacity: 0.65;
+}
+
+.course-sequence-nav__link[aria-disabled="true"]:hover {
+  transform: none;
+}
+
+@media (max-width: 700px) {
+  .course-sequence-nav {
+    grid-template-columns: 1fr;
+  }
 }
 
 :root[data-theme="dark"] .assignment-resource-table th {


### PR DESCRIPTION
### Motivation
- Provide a consistent Previous / Course Home / Next navigation row at the bottom of each MATH 114 unit page to make it easier for students to move through the course sequence.
- Implement the navigation as a reusable component with shared classes so it can be reused on `courses/math130.html` and other course sequences.
- Make the component responsive and accessible by supporting a stacked mobile layout and disabled endpoint states for first/last units.

### Description
- Added shared CSS rules in `styles.css` for a new `.course-sequence-nav` grid and `.course-sequence-nav__link` with full-width button alignment, endpoint disabled styling, and a mobile stack at `@media (max-width: 700px)`.
- Replaced the single "Back to MATH 114 Home" row with a three-link `<nav class="course-sequence-nav" aria-label="Course unit navigation">` containing Previous / Course Home / Next on each unit page: `courses/math114-foundations.html`, `courses/math114-test1.html`, `courses/math114-financial-math.html`, `courses/math114-test2.html`, `courses/math114-statistics.html`, `courses/math114-test3.html`, and `courses/math114-final-review.html`.
- Wired the requested unit order: `math114-foundations.html` → `math114-test1.html` → `math114-financial-math.html` → `math114-test2.html` → `math114-statistics.html` → `math114-test3.html` → `math114-final-review.html`, with the first/last endpoints rendered using `aria-disabled="true"` when unavailable.

### Testing
- Ran a Python verification script that checks each page contains `course-sequence-nav`, the `Course Home` link, and the expected `href` or disabled endpoint, and the script completed successfully.
- Used `rg` to confirm the presence of the new `course-sequence-nav` markup in the seven unit pages and the new classes in `styles.css`, and the search checks succeeded.
- No automated visual/browser screenshot tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf340830bc8331abba03d629568972)