### PR TITLE
Unify global site navbar into a canonical .top-nav and remove inline nav styles

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -4,7 +4,8 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Math 130 – Test 3 Review (Spring 2026)</title>
+<link rel="stylesheet" href="styles.css">
+    <title>Math 130 – Test 3 Review (Spring 2026)</title>
 
 <!-- Fonts -->
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&amp;family=DM+Sans:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet"/>
@@ -1025,48 +1026,29 @@
 
 </style>
 
-<style>
-  .top-nav { position: sticky; top: 0; z-index: 1000; background: rgba(15, 23, 42, 0.92); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
-  .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
-  .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
-  .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
-  .top-nav-links > a,
-  .dropdown-trigger,
-  .dropdown-menu a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
-  .top-nav-links > a:hover,
-  .top-nav-links > a:focus-visible,
-  .dropdown-trigger:hover,
-  .dropdown-trigger:focus-visible,
-  .dropdown-menu a:hover,
-  .dropdown-menu a:focus-visible { color: #93c5fd; outline: none; }
-  .dropdown { position: relative; }
-  .dropdown-trigger { background: transparent; border: none; padding: 0; font: inherit; cursor: pointer; }
-  .dropdown-menu { display: none; position: absolute; top: calc(100% + 0.35rem); left: 0; min-width: 190px; list-style: none; margin: 0; padding: 0.4rem 0; background: rgba(15, 23, 42, 0.98); border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 0.5rem; box-shadow: 0 12px 30px rgba(2, 6, 23, 0.35); }
-  .dropdown-menu li { margin: 0; }
-  .dropdown-menu a { display: block; padding: 0.4rem 0.8rem; }
-  .dropdown:hover .dropdown-menu,
-  .dropdown:focus-within .dropdown-menu { display: block; }
-</style>
-
 </head>
 <body>
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
-    <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
-    <div class="top-nav-links">
-      <a href="index.html">Home</a>
-      <a href="CV.html">About Me</a>
-      <div class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="learn.html">All Courses</a></li>
-          <li><a href="courses/math130.html">MATH 130 Home</a></li>
-        </ul>
-      </div>
-      <a href="projects.html">Projects</a>
-      <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
-      <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>
-      <a href="mailto:ahvolk@liberty.edu">Contact</a>
+    <div class="top-nav-branding">
+      <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    </div>
+    <div class="top-nav-actions">
+      <ul class="top-nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="CV.html">About Me</a></li>
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+          <ul class="dropdown-menu">
+            <li><a href="learn.html">All Courses</a></li>
+            <li><a href="courses/math130.html">MATH 130 Home</a></li>
+          </ul>
+        </li>
+        <li><a href="projects.html">Projects</a></li>
+        <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+        <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+        <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
+      </ul>
     </div>
   </div>
 </nav>

--- a/404.html
+++ b/404.html
@@ -8,25 +8,29 @@
     <script src="theme.js"></script>
 </head>
 <body>
-<nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="index.html">Home</a></li>
-      <li><a href="CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="learn.html">All Courses</a></li>
-          <li><a href="courses/math130.html">MATH 130 Home</a></li>
-        </ul>
-      </li>
-      <li><a href="projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-    
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <div class="top-nav-branding">
+      <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    </div>
+    <div class="top-nav-actions">
+      <ul class="top-nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="CV.html">About Me</a></li>
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+          <ul class="dropdown-menu">
+            <li><a href="learn.html">All Courses</a></li>
+            <li><a href="courses/math130.html">MATH 130 Home</a></li>
+          </ul>
+        </li>
+        <li><a href="projects.html">Projects</a></li>
+        <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+        <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+        <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
+      </ul>
+      <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+    </div>
   </div>
 </nav>
     <header>

--- a/CV.html
+++ b/CV.html
@@ -12,25 +12,29 @@
     <script src="theme.js"></script>
 </head>
 <body>
- <nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="index.html">Home</a></li>
-      <li><a href="CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="learn.html">All Courses</a></li>
-          <li><a href="courses/math130.html">MATH 130 Home</a></li>
-        </ul>
-      </li>
-      <li><a href="projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-    
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+ <nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <div class="top-nav-branding">
+      <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    </div>
+    <div class="top-nav-actions">
+      <ul class="top-nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="CV.html">About Me</a></li>
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+          <ul class="dropdown-menu">
+            <li><a href="learn.html">All Courses</a></li>
+            <li><a href="courses/math130.html">MATH 130 Home</a></li>
+          </ul>
+        </li>
+        <li><a href="projects.html">Projects</a></li>
+        <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+        <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+        <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
+      </ul>
+      <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+    </div>
   </div>
 </nav>
     <!-- Header with profile image and name -->
@@ -57,8 +61,9 @@
     </header>
 
     <!-- Sticky Navigation Bar with Dropdowns -->
-    <nav class="navbar">
-        <button class="menu-toggle" aria-label="Toggle navigation menu">
+    <nav class="cv-section-nav" aria-label="CV sections">
+        <div class="container cv-section-nav__inner">
+        <button class="menu-toggle" aria-label="Toggle CV section navigation">
             <i class="fas fa-bars"></i>
         </button>
         <ul id="nav-menu">
@@ -97,8 +102,8 @@
                 <a href="#honors">Honors &amp; Awards</a>
             </li>
         </ul>
+        </div>
     </nav>
-    
 
     <div class="container">
         <!-- Two-Column Section (Education and Courses) moved to the top -->

--- a/courses/math130.html
+++ b/courses/math130.html
@@ -8,25 +8,29 @@
   <script src="../theme.js"></script>
 </head>
 <body>
-<nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="../index.html">Home</a></li>
-      <li><a href="../CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="../learn.html">All Courses</a></li>
-          <li><a href="../courses/math130.html">MATH 130 Home</a></li>
-        </ul>
-      </li>
-      <li><a href="../projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-    
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <div class="top-nav-branding">
+      <a class="top-nav-title" href="../index.html">Prof. Volk's Office</a>
+    </div>
+    <div class="top-nav-actions">
+      <ul class="top-nav-links">
+        <li><a href="../index.html">Home</a></li>
+        <li><a href="../CV.html">About Me</a></li>
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+          <ul class="dropdown-menu">
+            <li><a href="../learn.html">All Courses</a></li>
+            <li><a href="../courses/math130.html">MATH 130 Home</a></li>
+          </ul>
+        </li>
+        <li><a href="../projects.html">Projects</a></li>
+        <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+        <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+        <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
+      </ul>
+      <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+    </div>
   </div>
 </nav>
 

--- a/employeepay.html
+++ b/employeepay.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="styles.css">
     <title>Who Earns More? Fixed vs. Doubling Pay</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -36,28 +37,29 @@
         }
     </style>
 
-<style>
-  .top-nav { position: sticky; top: 0; z-index: 1000; background: rgba(15, 23, 42, 0.92); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
-  .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
-  .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
-  .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
-  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
-  .top-nav-links a:hover { color: #93c5fd; }
-</style>
-
 </head>
 <body class="p-4 md:p-8">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
-    <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
-    <div class="top-nav-links">
-      <a href="index.html">Home</a>
-      <a href="CV.html">About Me</a>
-      <a href="learn.html">Course Resources</a>
-      <a href="projects.html">Projects</a>
-      <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a>
-      <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a>
-      <a href="mailto:ahvolk@liberty.edu">Contact</a>
+    <div class="top-nav-branding">
+      <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    </div>
+    <div class="top-nav-actions">
+      <ul class="top-nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="CV.html">About Me</a></li>
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+          <ul class="dropdown-menu">
+            <li><a href="learn.html">All Courses</a></li>
+            <li><a href="courses/math130.html">MATH 130 Home</a></li>
+          </ul>
+        </li>
+        <li><a href="projects.html">Projects</a></li>
+        <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+        <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+        <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
+      </ul>
     </div>
   </div>
 </nav>

--- a/index.html
+++ b/index.html
@@ -8,25 +8,29 @@
   <script src="theme.js"></script>
 </head>
 <body>
-<nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="index.html">Home</a></li>
-      <li><a href="CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="learn.html">All Courses</a></li>
-          <li><a href="courses/math130.html">MATH 130 Home</a></li>
-        </ul>
-      </li>
-      <li><a href="projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-    
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <div class="top-nav-branding">
+      <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    </div>
+    <div class="top-nav-actions">
+      <ul class="top-nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="CV.html">About Me</a></li>
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+          <ul class="dropdown-menu">
+            <li><a href="learn.html">All Courses</a></li>
+            <li><a href="courses/math130.html">MATH 130 Home</a></li>
+          </ul>
+        </li>
+        <li><a href="projects.html">Projects</a></li>
+        <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+        <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+        <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
+      </ul>
+      <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+    </div>
   </div>
 </nav>
   <header>

--- a/infographic.html
+++ b/infographic.html
@@ -8,25 +8,29 @@
     <script src="theme.js"></script>
 </head>
 <body>
-    <nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="index.html">Home</a></li>
-      <li><a href="CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="learn.html">All Courses</a></li>
-          <li><a href="courses/math130.html">MATH 130 Home</a></li>
-        </ul>
-      </li>
-      <li><a href="projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-    
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+    <nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <div class="top-nav-branding">
+      <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    </div>
+    <div class="top-nav-actions">
+      <ul class="top-nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="CV.html">About Me</a></li>
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+          <ul class="dropdown-menu">
+            <li><a href="learn.html">All Courses</a></li>
+            <li><a href="courses/math130.html">MATH 130 Home</a></li>
+          </ul>
+        </li>
+        <li><a href="projects.html">Projects</a></li>
+        <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+        <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+        <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
+      </ul>
+      <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+    </div>
   </div>
 </nav>
     <header>

--- a/learn.html
+++ b/learn.html
@@ -8,26 +8,30 @@
   <script src="theme.js"></script>
 </head>
 <body>
-<nav class="navbar">
-  <div class="container nav-container">
-    <ul class="nav-links">
-      <li><a href="index.html">Home</a></li>
-      <li><a href="CV.html">About Me</a></li>
-      <li class="dropdown">
-        <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
-        <ul class="dropdown-menu">
-          <li><a href="learn.html">All Courses</a></li>
-          <li><a href="courses/math114.html">MATH 114 Home</a></li>
-          <li><a href="courses/math130.html">MATH 130 Home</a></li>
-        </ul>
-      </li>
-      <li><a href="projects.html">Projects</a></li>
-      <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
-      <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-      <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
-    </ul>
-    
-    <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <div class="top-nav-branding">
+      <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    </div>
+    <div class="top-nav-actions">
+      <ul class="top-nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="CV.html">About Me</a></li>
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">Course Resources ▾</button>
+          <ul class="dropdown-menu">
+            <li><a href="learn.html">All Courses</a></li>
+            <li><a href="courses/math114.html">MATH 114 Home</a></li>
+            <li><a href="courses/math130.html">MATH 130 Home</a></li>
+          </ul>
+        </li>
+        <li><a href="projects.html">Projects</a></li>
+        <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+        <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+        <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
+      </ul>
+      <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+    </div>
   </div>
 </nav>
 

--- a/styles.css
+++ b/styles.css
@@ -1014,140 +1014,304 @@ section:nth-child(5) {
     border: 1px solid CanvasText;
   }
 }
-/* Modern Standard Navbar */
-.navbar {
-  background-color: var(--secondary-color);
+/* Canonical Global Site Navbar */
+.top-nav {
   position: sticky;
   top: 0;
   z-index: 1000;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+  background: rgba(15, 23, 42, 0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 10px 30px rgba(2, 6, 23, 0.12);
 }
 
-.nav-container {
+.top-nav-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0.75rem 1rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 1.5rem;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
-.nav-links {
+.top-nav-branding {
   display: flex;
-  list-style: none;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.top-nav-title {
+  color: #f8fafc;
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.top-nav-title:hover,
+.top-nav-title:focus-visible {
+  color: #bfdbfe;
+}
+
+.top-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
   margin: 0;
   padding: 0;
-  gap: 0.5rem;
+  list-style: none;
 }
 
-.nav-links li {
+.top-nav-links li,
+.top-nav-links .dropdown {
   position: relative;
 }
 
-.nav-links a {
+.top-nav-links > li > a,
+.top-nav-links > li > button,
+.top-nav-links > a,
+.top-nav-links .dropdown-menu a {
   display: block;
-  padding: 1rem 0.75rem;
-  color: var(--light-text);
+  color: #e2e8f0;
   text-decoration: none;
+  font-size: 0.95rem;
   font-weight: 500;
-  transition: var(--transition);
-  border-radius: 4px;
-  font-size: 1rem;
+  line-height: 1.2;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  transition: color 0.2s ease, background-color 0.2s ease;
 }
 
-.nav-links a:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: var(--accent-color);
+.top-nav-links > li > a:hover,
+.top-nav-links > li > a:focus-visible,
+.top-nav-links > li > button:hover,
+.top-nav-links > li > button:focus-visible,
+.top-nav-links > a:hover,
+.top-nav-links > a:focus-visible,
+.top-nav-links .dropdown-menu a:hover,
+.top-nav-links .dropdown-menu a:focus-visible {
+  color: #93c5fd;
+  background: rgba(148, 163, 184, 0.14);
+  outline: none;
 }
 
-.dropdown-trigger {
-  display: block;
-  padding: 1rem 0.75rem;
-  color: var(--light-text);
-  text-decoration: none;
-  font-weight: 500;
-  transition: var(--transition);
-  border-radius: 4px;
-  font-size: 1rem;
+.top-nav-links .dropdown-trigger {
   background: transparent;
-  border: 0;
-  font-family: inherit;
+  border: none;
+  font: inherit;
   cursor: pointer;
 }
 
-.dropdown-trigger:hover,
-.dropdown-trigger:focus-visible,
-.nav-links .dropdown-menu a:hover,
-.nav-links .dropdown-menu a:focus-visible {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: var(--accent-color);
+.top-nav-links .dropdown-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  min-width: 190px;
+  margin: 0;
+  padding: 0.4rem;
+  list-style: none;
+  background: rgba(15, 23, 42, 0.98);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.75rem;
+  box-shadow: 0 12px 30px rgba(2, 6, 23, 0.35);
 }
 
-.nav-links .dropdown-menu {
+.top-nav-links .dropdown:hover .dropdown-menu,
+.top-nav-links .dropdown:focus-within .dropdown-menu {
+  display: block;
+}
+
+.top-nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: auto;
+}
+
+.top-nav .theme-toggle {
+  margin: 0;
+}
+
+.cv-section-nav {
+  position: sticky;
+  top: 4.6rem;
+  z-index: 900;
+  background: var(--card-background);
+  border-top: 1px solid rgba(52, 152, 219, 0.15);
+  border-bottom: 1px solid rgba(52, 152, 219, 0.15);
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.06);
+}
+
+.cv-section-nav .cv-section-nav__inner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.35rem 1.5rem;
+}
+
+.cv-section-nav .menu-toggle {
+  background: transparent;
+  color: var(--secondary-color);
+}
+
+.cv-section-nav #nav-menu {
+  display: flex;
+  justify-content: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.cv-section-nav #nav-menu > li {
+  position: relative;
+}
+
+.cv-section-nav #nav-menu > li > a {
+  display: block;
+  padding: 0.8rem 1rem;
+  color: var(--secondary-color);
+  font-weight: 600;
+  border-radius: 999px;
+}
+
+.cv-section-nav #nav-menu > li > a:hover,
+.cv-section-nav #nav-menu > li > a:focus-visible,
+.cv-section-nav #nav-menu .dropdown-menu a:hover,
+.cv-section-nav #nav-menu .dropdown-menu a:focus-visible {
+  background: rgba(52, 152, 219, 0.12);
+  color: var(--primary-color);
+  outline: none;
+}
+
+.cv-section-nav .dropdown-menu {
   position: absolute;
   top: calc(100% + 0.25rem);
   left: 0;
   min-width: 220px;
+  margin: 0;
   padding: 0.35rem;
-  background-color: var(--secondary-color);
-  border-radius: 8px;
+  background: var(--card-background);
+  border: 1px solid rgba(52, 152, 219, 0.18);
+  border-radius: 0.75rem;
   box-shadow: var(--shadow);
   opacity: 0;
   visibility: hidden;
 }
 
-.nav-links .dropdown:hover .dropdown-menu,
-.nav-links .dropdown:focus-within .dropdown-menu {
+.cv-section-nav li:hover .dropdown-menu,
+.cv-section-nav li:focus-within .dropdown-menu {
   opacity: 1;
   visibility: visible;
 }
 
-.nav-links .dropdown-menu a {
-  padding: 0.6rem 0.75rem;
-  white-space: nowrap;
+.cv-section-nav .dropdown-menu a {
+  display: block;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.6rem;
+  color: var(--text-color);
 }
 
-/* Ensure the toggle button aligns perfectly in the new layout */
-.navbar .theme-toggle {
-  margin: 0;
-}
-
-/* Mobile responsiveness: stack the nav links neatly on small screens */
 @media (max-width: 768px) {
-  .nav-container {
-    flex-direction: column;
-    padding: 0.5rem;
+  .top-nav-inner {
+    align-items: flex-start;
   }
 
-  .nav-links {
-    flex-wrap: wrap;
-    justify-content: center;
-    margin-bottom: 0.5rem;
+  .top-nav-branding,
+  .top-nav-actions {
+    width: 100%;
   }
 
-  .nav-links .dropdown-menu {
+  .top-nav-actions {
+    justify-content: space-between;
+    margin-left: 0;
+  }
+
+  .top-nav-links {
+    width: 100%;
+    gap: 0.4rem;
+  }
+
+  .top-nav-links > li,
+  .top-nav-links > a,
+  .top-nav-links .dropdown {
+    width: 100%;
+  }
+
+  .top-nav-links > li > a,
+  .top-nav-links > li > button,
+  .top-nav-links > a {
+    width: 100%;
+  }
+
+  .top-nav-links .dropdown-menu {
     position: static;
+    display: block;
     min-width: 0;
     width: 100%;
+    margin-top: 0.35rem;
+    box-shadow: none;
+    border-radius: 0.75rem;
+  }
+
+  .top-nav-links .dropdown:not(:hover):not(:focus-within) .dropdown-menu {
+    display: none;
+  }
+
+  .cv-section-nav {
+    top: 0;
+  }
+
+  .cv-section-nav .cv-section-nav__inner {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0.5rem 1rem;
+  }
+
+  .cv-section-nav #nav-menu {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .cv-section-nav #nav-menu.open {
+    display: flex;
+  }
+
+  .cv-section-nav .dropdown-menu {
+    position: static;
+    width: 100%;
+    box-shadow: none;
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+    transition:
+      max-height 0.3s ease-out,
+      opacity 0.2s ease-out,
+      visibility 0.2s ease-out;
+  }
+
+  .cv-section-nav .dropdown-open {
+    max-height: 500px;
     opacity: 1;
     visibility: visible;
-    display: none;
-    margin-top: 0;
-    box-shadow: none;
-    padding: 0;
+    transition:
+      max-height 0.5s ease-in,
+      opacity 0.3s ease-in,
+      visibility 0.3s ease-in;
   }
 
-  .nav-links .dropdown:hover .dropdown-menu,
-  .nav-links .dropdown:focus-within .dropdown-menu {
-    display: block;
-  }
-
-  .nav-links a {
-    padding: 0.5rem;
-    font-size: 0.9rem;
-  }
-
-  .dropdown-trigger {
-    padding: 0.5rem;
-    font-size: 0.9rem;
+  .cv-section-nav .dropdown-menu a {
+    padding-left: 2rem;
   }
 }
 .shortcut-bar {


### PR DESCRIPTION
### Motivation
- Create a single, maintainable global navbar pattern based on the compact visual treatment used in `130Test3.html` so all top-level pages share a consistent header and spacing. 
- Remove duplicated inline navbar CSS and per-page nav markup to avoid drift and simplify future updates. 
- Preserve page-local secondary navigation (for example the CV section nav) and keep its visual treatment distinct from the global site nav so users can immediately tell them apart.

### Description
- Added a canonical navbar block to `styles.css` (new `.top-nav`, `.top-nav-inner`, `.top-nav-branding`, `.top-nav-title`, `.top-nav-links`, `.top-nav-actions`, dropdown rules, responsive stacking and a subtle border/shadow) and a distinct `.cv-section-nav` style for the CV’s secondary in-page navigation. 
- Replaced per-page navbar markup and removed inline navbar style blocks so the following pages now use the shared nav markup/classes: `index.html`, `learn.html`, `404.html`, `infographic.html`, `CV.html`, `courses/math130.html`, `130Test3.html`, and `employeepay.html`. 
- Updated standalone pages to include the shared stylesheet where needed (added `link rel="stylesheet" href="styles.css"` in pages that had inline nav CSS). 
- Preserved and restyled the CV page’s internal section navigation as `cv-section-nav` so it remains a distinct, page-local secondary nav.

### Testing
- Searched for leftover nav definitions and usages with `rg -n "<nav class=\"navbar\"|\.top-nav \{|\.top-nav-inner \{|\.top-nav-title \{|\.top-nav-links \{" index.html learn.html 404.html infographic.html CV.html courses/math130.html 130Test3.html employeepay.html styles.css` and verified the canonical rules are in `styles.css` and pages reference `.top-nav` (success). 
- Parsed updated HTML files with Python's `html.parser` using the script that feeds each file to `HTMLParser` to ensure pages remain parseable (`index.html`, `learn.html`, `404.html`, `infographic.html`, `CV.html`, `courses/math130.html`, `130Test3.html`, `employeepay.html`) and all parsed OK (success). 
- Reviewed the workspace diff (`git diff -- ...` output) to confirm inline nav styles/blocks were removed from individual pages and replaced with the shared markup and stylesheet references (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf3821f1788331853581d72c3dd0a1)