### PR TITLE
Implement accessible mobile site navigation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -149,15 +149,23 @@ nav.navbar li {
   position: relative;
 }
 
-nav.navbar a {
+nav.navbar a,
+nav.navbar button.dropdown-trigger {
   display: block;
   padding: 1rem 1.5rem;
   color: var(--light-text);
   text-decoration: none;
   transition: var(--transition);
+  background: transparent;
+  border: none;
+  font: inherit;
+  cursor: pointer;
 }
 
-nav.navbar a:hover {
+nav.navbar a:hover,
+nav.navbar a:focus-visible,
+nav.navbar button.dropdown-trigger:hover,
+nav.navbar button.dropdown-trigger:focus-visible {
   background-color: var(--primary-color);
 }
 
@@ -1101,6 +1109,14 @@ section:nth-child(5) {
   outline: none;
 }
 
+.top-nav a:focus-visible,
+.top-nav button:focus-visible,
+nav.navbar a:focus-visible,
+nav.navbar button:focus-visible {
+  outline: 3px solid #facc15;
+  outline-offset: 3px;
+}
+
 .top-nav-links .dropdown-trigger {
   background: transparent;
   border: none;
@@ -1135,7 +1151,44 @@ section:nth-child(5) {
   margin-left: auto;
 }
 
+.menu-toggle.global-nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 2.75rem;
+  padding: 0.65rem 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.68);
+  color: #f8fafc;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.menu-toggle.global-nav-toggle .menu-toggle__icon::before {
+  content: "☰";
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.top-nav[data-menu-open="true"] .menu-toggle.global-nav-toggle .menu-toggle__icon::before,
+nav.navbar[data-menu-open="true"] .menu-toggle.global-nav-toggle .menu-toggle__icon::before {
+  content: "✕";
+}
+
+.top-nav-links .dropdown[data-mobile-open="true"] .dropdown-menu,
+.top-nav-links .dropdown[data-desktop-open="true"] .dropdown-menu,
+nav.navbar .dropdown[data-mobile-open="true"] .dropdown-menu,
+nav.navbar .dropdown[data-desktop-open="true"] .dropdown-menu {
+  display: block;
+  opacity: 1;
+  visibility: visible;
+}
+
 .top-nav .theme-toggle {
+
   margin: 0;
 }
 
@@ -1221,40 +1274,66 @@ section:nth-child(5) {
 }
 
 @media (max-width: 768px) {
-  .top-nav-inner {
+  .top-nav-inner,
+  nav.navbar .nav-container {
     align-items: flex-start;
   }
 
   .top-nav-branding,
-  .top-nav-actions {
+  .top-nav-actions,
+  nav.navbar .nav-container > .nav-links,
+  nav.navbar .nav-container > .theme-toggle,
+  nav.navbar .nav-container > .menu-toggle.global-nav-toggle {
     width: 100%;
   }
 
-  .top-nav-actions {
+  .top-nav-actions,
+  nav.navbar .nav-container {
     justify-content: space-between;
     margin-left: 0;
+    flex-wrap: wrap;
   }
 
-  .top-nav-links {
+  .menu-toggle.global-nav-toggle {
+    display: flex;
+  }
+
+  .top-nav-links,
+  nav.navbar .nav-links {
+    display: none;
     width: 100%;
     gap: 0.4rem;
+    flex-direction: column;
+    justify-content: flex-start;
+  }
+
+  .top-nav-links[data-open="true"],
+  nav.navbar .nav-links[data-open="true"] {
+    display: flex;
   }
 
   .top-nav-links > li,
   .top-nav-links > a,
-  .top-nav-links .dropdown {
+  .top-nav-links .dropdown,
+  nav.navbar .nav-links > li,
+  nav.navbar .nav-links > a,
+  nav.navbar .nav-links .dropdown {
     width: 100%;
   }
 
   .top-nav-links > li > a,
   .top-nav-links > li > button,
-  .top-nav-links > a {
+  .top-nav-links > a,
+  nav.navbar .nav-links > li > a,
+  nav.navbar .nav-links > li > button,
+  nav.navbar .nav-links > a {
     width: 100%;
   }
 
-  .top-nav-links .dropdown-menu {
+  .top-nav-links .dropdown-menu,
+  nav.navbar .dropdown-menu {
     position: static;
-    display: block;
+    display: none;
     min-width: 0;
     width: 100%;
     margin-top: 0.35rem;
@@ -1262,8 +1341,9 @@ section:nth-child(5) {
     border-radius: 0.75rem;
   }
 
-  .top-nav-links .dropdown:not(:hover):not(:focus-within) .dropdown-menu {
-    display: none;
+  .top-nav-links .dropdown[data-mobile-open="true"] .dropdown-menu,
+  nav.navbar .dropdown[data-mobile-open="true"] .dropdown-menu {
+    display: block;
   }
 
   .cv-section-nav {

--- a/theme.js
+++ b/theme.js
@@ -7,6 +7,7 @@ try {
 }
 
 const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const mobileNavMediaQuery = window.matchMedia('(max-width: 768px)');
 
 // Set the theme before the DOM fully loads
 if (savedTheme === 'dark' || (!savedTheme && systemPrefersDark)) {
@@ -15,37 +16,284 @@ if (savedTheme === 'dark' || (!savedTheme && systemPrefersDark)) {
     document.documentElement.setAttribute('data-theme', 'light');
 }
 
+const menuToggleLabel = (expanded) => expanded ? 'Close navigation menu' : 'Open navigation menu';
+const submenuToggleLabel = (expanded) => expanded ? 'Close Course Resources submenu' : 'Open Course Resources submenu';
+
+function getFocusableElements(container) {
+    if (!container) return [];
+
+    return Array.from(
+        container.querySelectorAll('a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])')
+    ).filter((element) => !element.hasAttribute('hidden') && !element.closest('[hidden]'));
+}
+
+function closeOtherDropdowns(currentDropdown, navRoot) {
+    navRoot.querySelectorAll('.dropdown[data-mobile-open="true"]').forEach((dropdown) => {
+        if (dropdown !== currentDropdown) {
+            dropdown.dataset.mobileOpen = 'false';
+            const trigger = dropdown.querySelector('.dropdown-trigger');
+            if (trigger) {
+                trigger.setAttribute('aria-expanded', 'false');
+                trigger.setAttribute('aria-label', submenuToggleLabel(false));
+            }
+        }
+    });
+}
+
+function setupGlobalNav(navRoot, index) {
+    const links = navRoot.querySelector(':scope .top-nav-links, :scope .nav-links');
+    if (!links) return;
+
+    const navId = links.id || `global-nav-menu-${index + 1}`;
+    links.id = navId;
+    links.dataset.navMenu = 'true';
+
+    const existingToggle = navRoot.querySelector(':scope .menu-toggle, :scope .nav-toggle');
+    const toggleButton = existingToggle || document.createElement('button');
+
+    if (!existingToggle) {
+        toggleButton.type = 'button';
+        toggleButton.className = 'menu-toggle global-nav-toggle';
+        toggleButton.innerHTML = '<span class="menu-toggle__label">Menu</span><span class="menu-toggle__icon" aria-hidden="true"></span>';
+
+        const topNavActions = navRoot.querySelector(':scope .top-nav-actions');
+        const navContainer = navRoot.querySelector(':scope .nav-container, :scope .top-nav-inner');
+        if (topNavActions) {
+            topNavActions.insertBefore(toggleButton, links);
+        } else if (navContainer) {
+            navContainer.insertBefore(toggleButton, links);
+        }
+    }
+
+    toggleButton.setAttribute('aria-controls', navId);
+    toggleButton.setAttribute('aria-expanded', 'false');
+    toggleButton.setAttribute('aria-label', menuToggleLabel(false));
+
+    const setMenuExpanded = (expanded, { focusTarget } = {}) => {
+        links.dataset.open = expanded ? 'true' : 'false';
+        navRoot.dataset.menuOpen = expanded ? 'true' : 'false';
+        toggleButton.setAttribute('aria-expanded', String(expanded));
+        toggleButton.setAttribute('aria-label', menuToggleLabel(expanded));
+
+        if (!expanded) {
+            navRoot.querySelectorAll('.dropdown[data-mobile-open="true"]').forEach((dropdown) => {
+                dropdown.dataset.mobileOpen = 'false';
+                const trigger = dropdown.querySelector('.dropdown-trigger');
+                if (trigger) {
+                    trigger.setAttribute('aria-expanded', 'false');
+                    trigger.setAttribute('aria-label', submenuToggleLabel(false));
+                }
+            });
+        }
+
+        if (focusTarget === 'first') {
+            const [firstFocusable] = getFocusableElements(links);
+            firstFocusable?.focus();
+        } else if (focusTarget === 'toggle') {
+            toggleButton.focus();
+        }
+    };
+
+    toggleButton.addEventListener('click', () => {
+        const expanded = toggleButton.getAttribute('aria-expanded') === 'true';
+        setMenuExpanded(!expanded, { focusTarget: !expanded ? 'first' : 'toggle' });
+    });
+
+    links.addEventListener('keydown', (event) => {
+        if (event.key !== 'Escape') return;
+
+        const openDropdown = event.target.closest('.dropdown[data-mobile-open="true"], .dropdown[data-desktop-open="true"]');
+        if (openDropdown) {
+            event.preventDefault();
+            openDropdown.dataset.mobileOpen = 'false';
+            openDropdown.dataset.desktopOpen = 'false';
+            const trigger = openDropdown.querySelector('.dropdown-trigger');
+            if (trigger) {
+                trigger.setAttribute('aria-expanded', 'false');
+                trigger.setAttribute('aria-label', submenuToggleLabel(false));
+                trigger.focus();
+            }
+            return;
+        }
+
+        if (toggleButton.getAttribute('aria-expanded') === 'true') {
+            event.preventDefault();
+            setMenuExpanded(false, { focusTarget: 'toggle' });
+        }
+    });
+
+    document.addEventListener('click', (event) => {
+        if (!navRoot.contains(event.target)) {
+            setMenuExpanded(false);
+            navRoot.querySelectorAll('.dropdown').forEach((dropdown) => {
+                dropdown.dataset.mobileOpen = 'false';
+                dropdown.dataset.desktopOpen = 'false';
+                const trigger = dropdown.querySelector('.dropdown-trigger');
+                if (trigger) {
+                    trigger.setAttribute('aria-expanded', 'false');
+                    trigger.setAttribute('aria-label', submenuToggleLabel(false));
+                }
+            });
+        }
+    });
+
+    navRoot.querySelectorAll('.dropdown').forEach((dropdown, dropdownIndex) => {
+        const trigger = dropdown.querySelector('.dropdown-trigger');
+        const menu = dropdown.querySelector('.dropdown-menu');
+        if (!trigger || !menu) return;
+
+        const menuId = menu.id || `${navId}-submenu-${dropdownIndex + 1}`;
+        menu.id = menuId;
+        dropdown.dataset.mobileOpen = 'false';
+        dropdown.dataset.desktopOpen = 'false';
+        trigger.setAttribute('aria-controls', menuId);
+        trigger.setAttribute('aria-expanded', 'false');
+        trigger.setAttribute('aria-label', submenuToggleLabel(false));
+
+        const setDropdownExpanded = (expanded, { focusFirstItem = false, returnFocus = false } = {}) => {
+            if (mobileNavMediaQuery.matches) {
+                closeOtherDropdowns(dropdown, navRoot);
+                dropdown.dataset.mobileOpen = expanded ? 'true' : 'false';
+            } else {
+                dropdown.dataset.desktopOpen = expanded ? 'true' : 'false';
+            }
+            trigger.setAttribute('aria-expanded', String(expanded));
+            trigger.setAttribute('aria-label', submenuToggleLabel(expanded));
+
+            if (focusFirstItem && expanded) {
+                const [firstItem] = getFocusableElements(menu);
+                firstItem?.focus();
+            }
+
+            if (returnFocus) {
+                trigger.focus();
+            }
+        };
+
+        trigger.addEventListener('click', (event) => {
+            if (!mobileNavMediaQuery.matches) {
+                const expanded = trigger.getAttribute('aria-expanded') === 'true';
+                setDropdownExpanded(!expanded, { focusFirstItem: !expanded });
+                event.preventDefault();
+                return;
+            }
+
+            event.preventDefault();
+            const expanded = trigger.getAttribute('aria-expanded') === 'true';
+            setDropdownExpanded(!expanded, { focusFirstItem: !expanded });
+        });
+
+        trigger.addEventListener('keydown', (event) => {
+            if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                setDropdownExpanded(true, { focusFirstItem: true });
+            }
+
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                setDropdownExpanded(false, { returnFocus: true });
+            }
+        });
+
+        dropdown.addEventListener('mouseenter', () => {
+            if (!mobileNavMediaQuery.matches) {
+                setDropdownExpanded(true);
+            }
+        });
+
+        dropdown.addEventListener('mouseleave', () => {
+            if (!mobileNavMediaQuery.matches) {
+                setDropdownExpanded(false);
+            }
+        });
+
+        dropdown.addEventListener('focusout', (event) => {
+            if (!dropdown.contains(event.relatedTarget)) {
+                setDropdownExpanded(false);
+            }
+        });
+
+        menu.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                setDropdownExpanded(false, { returnFocus: true });
+            }
+        });
+
+        menu.querySelectorAll('a').forEach((link) => {
+            link.addEventListener('click', () => {
+                if (mobileNavMediaQuery.matches) {
+                    setDropdownExpanded(false);
+                    setMenuExpanded(false);
+                }
+            });
+        });
+    });
+
+    const handleViewportChange = () => {
+        if (!mobileNavMediaQuery.matches) {
+            links.dataset.open = 'true';
+            navRoot.dataset.menuOpen = 'false';
+            toggleButton.setAttribute('aria-expanded', 'false');
+            toggleButton.setAttribute('aria-label', menuToggleLabel(false));
+            navRoot.querySelectorAll('.dropdown').forEach((dropdown) => {
+                dropdown.dataset.mobileOpen = 'false';
+                const trigger = dropdown.querySelector('.dropdown-trigger');
+                if (trigger) {
+                    trigger.setAttribute('aria-expanded', 'false');
+                    trigger.setAttribute('aria-label', submenuToggleLabel(false));
+                }
+            });
+        } else {
+            links.dataset.open = 'false';
+            navRoot.dataset.menuOpen = 'false';
+            toggleButton.setAttribute('aria-expanded', 'false');
+            toggleButton.setAttribute('aria-label', menuToggleLabel(false));
+        }
+    };
+
+    handleViewportChange();
+    if (typeof mobileNavMediaQuery.addEventListener === 'function') {
+        mobileNavMediaQuery.addEventListener('change', handleViewportChange);
+    } else {
+        mobileNavMediaQuery.addListener(handleViewportChange);
+    }
+}
+
 // 2. Wait for the page to load, then attach the button click logic
 document.addEventListener('DOMContentLoaded', () => {
     const toggleBtn = document.getElementById('theme-toggle-btn');
-    if (!toggleBtn) return;
 
-    // Function to update the emoji icon
-    const updateIcon = () => {
-        const currentTheme = document.documentElement.getAttribute('data-theme');
-        toggleBtn.innerHTML = currentTheme === 'dark' ? '☀️' : '🌙';
-        toggleBtn.setAttribute('aria-label', currentTheme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode');
-    };
+    if (toggleBtn) {
+        // Function to update the emoji icon
+        const updateIcon = () => {
+            const currentTheme = document.documentElement.getAttribute('data-theme');
+            toggleBtn.innerHTML = currentTheme === 'dark' ? '☀️' : '🌙';
+            toggleBtn.setAttribute('aria-label', currentTheme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode');
+        };
 
-    // Set initial icon
-    updateIcon();
-
-    // Listen for clicks
-    toggleBtn.addEventListener('click', () => {
-        const currentTheme = document.documentElement.getAttribute('data-theme');
-        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-        
-        // Apply new theme
-        document.documentElement.setAttribute('data-theme', newTheme);
-        
-        // Save to local storage safely
-        try {
-            localStorage.setItem('theme', newTheme);
-        } catch (error) {
-            console.warn("Could not save theme to localStorage.");
-        }
-        
-        // Update the button icon
+        // Set initial icon
         updateIcon();
-    });
+
+        // Listen for clicks
+        toggleBtn.addEventListener('click', () => {
+            const currentTheme = document.documentElement.getAttribute('data-theme');
+            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+            // Apply new theme
+            document.documentElement.setAttribute('data-theme', newTheme);
+
+            // Save to local storage safely
+            try {
+                localStorage.setItem('theme', newTheme);
+            } catch (error) {
+                console.warn("Could not save theme to localStorage.");
+            }
+
+            // Update the button icon
+            updateIcon();
+        });
+    }
+
+    document.querySelectorAll('.top-nav, nav.navbar').forEach(setupGlobalNav);
 });


### PR DESCRIPTION
### Motivation
- Provide a real, accessible mobile navigation for the shared global navbar rather than relying on layout wrapping to make links usable on small screens.
- Ensure the main menu and Course Resources submenu expose proper state via `aria-expanded`/`aria-controls` and behave predictably for keyboard users.
- Preserve desktop hover/focus behavior while converting mobile interactions to explicit tap/click disclosures with clear open/close states.

### Description
- Add a runtime `setupGlobalNav` in `theme.js` that injects a `menu-toggle` when needed, sets `aria-controls`/`aria-expanded`, and synchronizes menu open/close state across viewports and outside clicks.
- Implement mobile-aware submenu handling (mobile vs desktop state) and keyboard support in `theme.js`, including `Escape` to close menus, `ArrowDown` to open submenus, focus management, and a `getFocusableElements` helper.
- Update `styles.css` to add `.menu-toggle.global-nav-toggle` styles, stronger `:focus-visible` outlines for links and buttons, and mobile media-query changes that hide main nav links until the toggle opens them and turn the Course Resources dropdown into a JS-controlled disclosure on small screens.
- Harmonize legacy `nav.navbar` dropdowns and `.top-nav` by styling dropdown triggers as buttons and enabling the same accessible behaviors for both navigation patterns.

### Testing
- Ran `node --check theme.js` to statically validate the modified script; this check passed.
- Executed a small Python validation that printed file sizes and asserted presence of `aria-controls` in the updated files; the script completed successfully and printed "basic checks passed".
- Performed repository checks (`git status --short`) and committed the changes; commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00bb6771c83319a8efefadc91b472)