### PR TITLE
Align course navbar theme toggle

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -137,9 +137,20 @@ nav.navbar {
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
+nav.navbar .nav-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
 nav.navbar ul {
   display: flex;
+  flex: 1 1 auto;
   justify-content: center;
+  align-items: center;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -849,8 +860,9 @@ main.error-main {
   border: none;
   cursor: pointer;
   font-size: 1.5rem;
-  margin-left: auto; /* Pushes the button to the far right of the flex container */
-  margin-right: 1rem;
+  margin: 0;
+  flex: 0 0 auto;
+  align-self: center;
   color: var(--light-text);
   border-radius: 50%;
   background-color: rgba(255, 255, 255, 0.2);


### PR DESCRIPTION
### Motivation
- The theme toggle on course pages (e.g. `courses/math114.html`) appeared vertically misaligned because the legacy `nav.navbar` layout did not place the primary links and utilities in a shared flex row and the toggle relied on auto/right margins.
- The change makes the navbar layout explicit so the toggle and nav links share the same vertical alignment and spacing.

### Description
- Converted the `nav.navbar` inner container to a flex row by adding `.nav-container { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding-top: 0.75rem; padding-bottom: 0.75rem; }` to `styles.css`.
- Made the primary link list take available space with `nav.navbar ul { flex: 1 1 auto; align-items: center; }` so links remain centered while utilities align to the right.
- Replaced the previous margin-based positioning on `.theme-toggle` with `margin: 0; flex: 0 0 auto; align-self: center;` so the toggle aligns naturally inside the navbar.
- All modifications were made in `styles.css` (navbar and theme-toggle sections).

### Testing
- Ran `git diff --check` to validate there were no trailing whitespace or trivial diff issues and it completed successfully.
- Inspected the updated CSS rules with `nl -ba styles.css | sed -n '140,157p;857,874p'` to confirm the new `.nav-container`, `nav.navbar ul` and `.theme-toggle` rules are present and correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0390fa0cc8331bc75bca63131a0ab)