### PR TITLE
Fix course unit navigation button layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -296,13 +296,17 @@ section h2 {
 /* Button styles */
 .button,
 .download-btn {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
   background-color: var(--primary-color);
   color: var(--light-text);
   padding: 0.75rem 1.5rem;
   border-radius: 4px;
   text-decoration: none;
   font-weight: bold;
+  line-height: 1.2;
   transition: var(--transition);
   border: none;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- update the shared button styles to use border-box sizing so full-width course nav buttons stay inside their grid columns
- center button content with inline-flex to keep the course unit navigation labels readable on hover
- add a tighter line-height for the shared buttons to improve text rendering in the course navigation row

## Testing
- Not run (per request/environment constraints; static CSS change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03bc41984833195f44e94f5591a21)