### PR TITLE
Keep course navigation button text white on hover

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -316,6 +316,7 @@ section h2 {
 .button:hover,
 .download-btn:hover {
   background-color: var(--accent-color);
+  color: var(--light-text);
   transform: translateY(-2px);
 }
 


### PR DESCRIPTION
### Motivation
- Course navigation buttons on pages like `courses/math114-test1.html` became hard to read because the link hover rule changed their text to the accent orange at the same time the background also switched, reducing contrast.
- The navigation buttons use the shared `.button` class from `styles.css`, so the fix should be made in the shared stylesheet.

### Description
- Update `styles.css` to explicitly keep button-like controls readable on hover by adding `color: var(--light-text);` to the `.button:hover` and `.download-btn:hover` rules.
- This preserves the intended accent background on hover while ensuring button text remains white across course pages that use the shared `button` styling.

### Testing
- Located affected HTML and CSS with `rg` and inspected `styles.css` using `sed` to confirm the source of the hover styling.
- Verified the CSS change via a diff and line-number inspection with `git diff` and `nl` to ensure the new `color` rule is present and correctly placed.
- No browser screenshot was captured in this environment, but the change was reviewed via the file diffs and line inspections and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04c461734833180b06e47f7cfa510)