### PR TITLE
Restyle 130Test1.html to use Test 3 page-shell and dashboard cards

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -17,7 +17,9 @@
     --amber: #fbbf24; --amber-bg: rgba(251, 191, 36, 0.1);
     --red: #f87171; --red-bg: rgba(248, 113, 113, 0.1);
     --blue: #60a5fa; --blue-bg: rgba(96, 165, 250, 0.1);
-    --radius: 12px;
+    --radius: 16px;
+    --shadow: 0 12px 36px rgba(0,0,0,0.22);
+    --shell: min(1100px, calc(100vw - 2rem));
     --grid-line: rgba(108,99,255,0.03);
     --h1-from: #e2e4ef; --h1-to: #9d98ff;
     --green-border: rgba(52,211,153,0.2); --green-step: rgba(52,211,153,0.25);
@@ -41,33 +43,36 @@
     --accent-hover: rgba(80,70,229,0.25); --accent-chip: rgba(80,70,229,0.1);
     --check-bg: rgba(13,150,104,0.05); --check-border: rgba(13,150,104,0.3);
     --got-border: rgba(13,150,104,0.4); --miss-border: rgba(220,38,38,0.35);
+    --shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+    --shell: min(1100px, calc(100vw - 2rem));
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body { font-family: 'DM Sans', sans-serif; background: var(--bg); color: var(--text); line-height: 1.65; min-height: 100vh; transition: background 0.3s, color 0.3s; }
   body::before { content: ''; position: fixed; inset: 0; background-image: linear-gradient(var(--grid-line) 1px, transparent 1px), linear-gradient(90deg, var(--grid-line) 1px, transparent 1px); background-size: 40px 40px; pointer-events: none; z-index: 0; }
 
   /* Theme toggle */
-  .theme-toggle { position: absolute; top: 1rem; right: 0; background: var(--surface); border: 1px solid var(--border); border-radius: 50px; padding: 0.4rem; cursor: pointer; display: flex; align-items: center; gap: 0.35rem; transition: all 0.3s; z-index: 5; }
+  .theme-toggle { position: static; background: var(--surface); border: 1px solid var(--border); border-radius: 50px; padding: 0.4rem; cursor: pointer; display: flex; align-items: center; gap: 0.35rem; transition: all 0.3s; z-index: 5; box-shadow: var(--shadow); }
   .theme-toggle:hover { border-color: var(--accent); }
   .theme-toggle .toggle-track { width: 40px; height: 22px; border-radius: 11px; background: var(--surface2); position: relative; transition: background 0.3s; }
   .theme-toggle .toggle-thumb { width: 18px; height: 18px; border-radius: 50%; background: var(--accent); position: absolute; top: 2px; left: 2px; transition: transform 0.3s; box-shadow: 0 1px 4px rgba(0,0,0,0.2); }
   body.light .theme-toggle .toggle-thumb { transform: translateX(18px); }
   .theme-toggle .toggle-icon { font-size: 0.85rem; line-height: 1; }
-  .container { max-width: 900px; margin: 0 auto; padding: 2rem 1.25rem 4rem; position: relative; z-index: 1; }
+  .container { width: var(--shell); margin: 0 auto; padding: 2rem 0 4.5rem; position: relative; z-index: 1; }
 
-  header { text-align: center; padding: 3rem 0 2.5rem; position: relative; }
-  header::after { content: ''; position: absolute; bottom: 0; left: 50%; transform: translateX(-50%); width: 60px; height: 3px; background: var(--accent); border-radius: 2px; }
-  .course-label { font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; letter-spacing: 3px; text-transform: uppercase; color: var(--accent); margin-bottom: 0.75rem; }
-  .breadcrumb { display: inline-flex; align-items: center; flex-wrap: wrap; gap: 0.35rem; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.85rem; }
+  header { display: flex; justify-content: space-between; align-items: flex-start; gap: 1.5rem; margin-bottom: 2rem; padding: 1.1rem 0 1.5rem; border-bottom: 1px solid var(--border); }
+  .header-copy { flex: 1; min-width: 0; }
+  .header-actions { display: flex; align-items: flex-start; justify-content: flex-end; }
+  .course-label { font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; letter-spacing: 3px; text-transform: uppercase; color: var(--accent); margin-bottom: 0.55rem; }
+  .breadcrumb { display: inline-flex; align-items: center; flex-wrap: wrap; gap: 0.35rem; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.8rem; }
   .breadcrumb a { color: var(--text); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; }
   .breadcrumb a:hover { color: var(--accent); }
   .breadcrumb-sep { color: var(--text-muted); }
   .breadcrumb-current { color: var(--text-muted); }
-  h1 { font-family: 'DM Serif Display', serif; font-size: clamp(2rem, 5vw, 3rem); font-weight: 400; letter-spacing: -0.5px; margin-bottom: 0.75rem; background: linear-gradient(135deg, var(--h1-from), var(--h1-to)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
-  .subtitle { color: var(--text-muted); font-size: 0.95rem; max-width: 460px; margin: 0 auto; }
+  h1 { font-family: 'DM Serif Display', serif; font-size: clamp(2.2rem, 5vw, 3.2rem); font-weight: 400; letter-spacing: -0.5px; margin-bottom: 0.75rem; background: linear-gradient(135deg, var(--h1-from), var(--h1-to)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+  .subtitle { color: var(--text-muted); font-size: 0.98rem; max-width: 52rem; }
 
-  .info-bar { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin: 2.5rem 0; }
-  .info-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.1rem 1.25rem; display: flex; align-items: center; gap: 0.85rem; }
+  .info-bar { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin: 0 0 1.75rem; }
+  .info-card { background: linear-gradient(180deg, var(--surface), var(--surface2)); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.15rem 1.25rem; display: flex; align-items: center; gap: 0.9rem; min-height: 92px; box-shadow: var(--shadow); }
   .info-icon { width: 40px; height: 40px; border-radius: 10px; display: flex; align-items: center; justify-content: center; font-size: 1.15rem; flex-shrink: 0; }
   .info-card:nth-child(1) .info-icon { background: var(--blue-bg); }
   .info-card:nth-child(2) .info-icon { background: var(--green-bg); }
@@ -75,34 +80,36 @@
   .info-label { font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; }
   .info-value { font-weight: 600; font-size: 0.95rem; }
 
-  /* Tab Nav with mobile scroll fades */
-  .tab-nav-wrapper { position: relative; margin-bottom: 2rem; }
-  .tab-nav { display: flex; gap: 0.25rem; background: var(--surface); border-radius: var(--radius); padding: 0.3rem; border: 1px solid var(--border); overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none; scroll-behavior: smooth; }
-  .tab-nav::-webkit-scrollbar { display: none; }
-  .tab-fade-left, .tab-fade-right { position: absolute; top: 0; bottom: 0; width: 40px; pointer-events: none; z-index: 2; transition: opacity 0.3s; opacity: 0; }
-  .tab-fade-left { left: 0; background: linear-gradient(90deg, var(--surface) 0%, transparent 100%); border-radius: var(--radius) 0 0 var(--radius); }
-  .tab-fade-right { right: 0; background: linear-gradient(-90deg, var(--surface) 0%, transparent 100%); border-radius: 0 var(--radius) var(--radius) 0; }
-  .tab-fade-left.visible, .tab-fade-right.visible { opacity: 1; }
-  .tab-btn { flex: 1; padding: 0.7rem 1rem; border: none; background: transparent; color: var(--text-muted); font-family: 'DM Sans', sans-serif; font-size: 0.85rem; font-weight: 600; border-radius: 9px; cursor: pointer; transition: all 0.25s; white-space: nowrap; min-width: max-content; }
-  .tab-btn:hover { color: var(--text); }
-  .tab-btn.active { background: var(--accent); color: #fff; box-shadow: 0 2px 12px var(--accent-glow); }
+  /* Dashboard-style tab nav */
+  .tab-nav-wrapper { margin-bottom: 2rem; }
+  .tab-nav { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.85rem; }
+  .tab-fade-left, .tab-fade-right { display: none; }
+  .tab-btn { position: relative; width: 100%; padding: 0.95rem 1rem; border: 1px solid var(--border); background: linear-gradient(180deg, var(--surface), var(--surface2)); color: var(--text); font-family: 'DM Sans', sans-serif; font-size: 0.95rem; font-weight: 600; border-radius: 16px; cursor: pointer; transition: all 0.25s; min-height: 92px; text-align: left; display: flex; align-items: center; gap: 0.9rem; box-shadow: var(--shadow); }
+  .tab-btn::before { content: ''; position: absolute; top: 0; left: 18px; right: 18px; height: 3px; border-radius: 999px; background: linear-gradient(90deg, var(--accent), transparent); opacity: 0.7; }
+  .tab-btn:hover { color: var(--text); transform: translateY(-2px); border-color: color-mix(in srgb, var(--accent) 35%, var(--border)); }
+  .tab-btn.active { background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 14%, var(--surface)), var(--surface)); color: var(--text); border-color: var(--accent); box-shadow: 0 10px 24px var(--accent-glow); }
   .tab-btn:focus-visible, .video-link:focus-visible, .review-topic-btn:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
-  .tab-content { display: none; animation: fadeUp 0.35s ease; }
+  .tab-icon { width: 42px; height: 42px; border-radius: 12px; display: inline-flex; align-items: center; justify-content: center; background: color-mix(in srgb, var(--accent) 12%, var(--surface2)); color: var(--accent); flex-shrink: 0; font-size: 1.1rem; }
+  .tab-btn.active .tab-icon { background: color-mix(in srgb, var(--accent) 18%, var(--surface2)); }
+  .tab-copy { display: flex; flex-direction: column; gap: 0.2rem; min-width: 0; }
+  .tab-label { font-weight: 700; line-height: 1.2; }
+  .tab-meta { font-size: 0.8rem; color: var(--text-muted); line-height: 1.3; }
+  .tab-content { display: none; animation: fadeUp 0.35s ease; margin-bottom: 2rem; }
   .tab-content.active { display: block; }
   @keyframes fadeUp { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
 
   /* Topic Cards */
-  .topic-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); margin-bottom: 1rem; overflow: hidden; transition: border-color 0.3s; }
-  .topic-card:hover { border-color: var(--accent-hover); }
-  .topic-header { width: 100%; padding: 1.1rem 1.25rem; cursor: pointer; display: flex; align-items: center; gap: 1rem; user-select: none; border: 0; background: transparent; color: inherit; text-align: left; font: inherit; }
+  .topic-card { background: linear-gradient(180deg, var(--surface), color-mix(in srgb, var(--surface) 72%, var(--surface2))); border: 1px solid var(--border); border-radius: 18px; margin-bottom: 1.15rem; overflow: hidden; transition: border-color 0.3s, transform 0.25s; box-shadow: var(--shadow); }
+  .topic-card:hover { border-color: var(--accent-hover); transform: translateY(-2px); }
+  .topic-header { width: 100%; padding: 1.25rem 1.4rem; cursor: pointer; display: flex; align-items: center; gap: 1rem; user-select: none; border: 0; background: transparent; color: inherit; text-align: left; font: inherit; min-height: 84px; }
   .topic-header:focus-visible { outline: 3px solid var(--accent); outline-offset: -3px; }
-  .topic-number { font-family: 'JetBrains Mono', monospace; font-size: 0.75rem; color: var(--accent); background: var(--accent-chip); padding: 0.3rem 0.55rem; border-radius: 6px; flex-shrink: 0; }
-  .topic-title { font-weight: 600; font-size: 1rem; flex: 1; }
+  .topic-number { font-family: 'JetBrains Mono', monospace; font-size: 0.76rem; color: var(--accent); background: var(--accent-chip); padding: 0.38rem 0.62rem; border-radius: 8px; flex-shrink: 0; border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent); }
+  .topic-title { font-weight: 700; font-size: 1.02rem; flex: 1; }
   .topic-chevron { color: var(--text-muted); transition: transform 0.3s; font-size: 0.8rem; }
   .topic-card.open .topic-chevron { transform: rotate(180deg); }
   .topic-body { max-height: 0; overflow: hidden; transition: max-height 0.4s ease; }
   .topic-card.open .topic-body { max-height: 3000px; }
-  .topic-content { padding: 0 1.25rem 1.25rem; border-top: 1px solid var(--border); padding-top: 1.1rem; }
+  .topic-content { padding: 0 1.4rem 1.4rem; border-top: 1px solid var(--border); padding-top: 1.2rem; }
   .topic-content h4 { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 1.5px; color: var(--accent); margin-bottom: 0.6rem; margin-top: 1.1rem; }
   .topic-content h4:first-child { margin-top: 0; }
   .topic-content p, .topic-content li { color: var(--text-muted); font-size: 0.92rem; margin-bottom: 0.4rem; }
@@ -112,15 +119,15 @@
   .tip-box { background: var(--amber-bg); border-left: 3px solid var(--amber); border-radius: 0 8px 8px 0; padding: 0.75rem 1rem; margin: 0.75rem 0; font-size: 0.88rem; color: var(--amber); }
 
   /* Practice */
-  .practice-dashboard { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; margin-bottom: 1.5rem; }
-  .practice-stat { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem; text-align: center; }
+  .practice-dashboard { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; margin-bottom: 1.75rem; }
+  .practice-stat { background: linear-gradient(180deg, var(--surface), var(--surface2)); border: 1px solid var(--border); border-radius: 18px; padding: 1.2rem; text-align: center; box-shadow: var(--shadow); min-height: 132px; display: flex; flex-direction: column; justify-content: center; }
   .practice-stat .stat-num { font-family: 'DM Serif Display', serif; font-size: 2rem; line-height: 1; margin-bottom: 0.25rem; }
   .practice-stat .stat-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 1px; color: var(--text-muted); }
   .stat-green { color: var(--green); }
   .stat-red { color: var(--red); }
   .stat-blue { color: var(--blue); }
 
-  .problem-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; margin-bottom: 1rem; }
+  .problem-card { background: linear-gradient(180deg, var(--surface), color-mix(in srgb, var(--surface) 72%, var(--surface2))); border: 1px solid var(--border); border-radius: 18px; padding: 1.4rem; margin-bottom: 1rem; box-shadow: var(--shadow); }
   .problem-label { font-family: 'JetBrains Mono', monospace; font-size: 0.7rem; letter-spacing: 1px; text-transform: uppercase; color: var(--text-muted); margin-bottom: 0.5rem; display: flex; justify-content: space-between; align-items: center; }
   .problem-pts { background: var(--surface2); padding: 0.15rem 0.5rem; border-radius: 5px; font-size: 0.72rem; color: var(--accent); }
   .problem-tag-retry { background: var(--red-bg); color: var(--red); padding: 0.15rem 0.55rem; border-radius: 5px; font-size: 0.72rem; font-weight: 600; margin-left: 0.5rem; }
@@ -179,7 +186,7 @@
   .quiz-results p { color: var(--text-muted); margin-bottom: 1.5rem; }
 
   /* Formula Sheet */
-  .formula-section { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; margin-bottom: 1rem; }
+  .formula-section { background: linear-gradient(180deg, var(--surface), var(--surface2)); border: 1px solid var(--border); border-radius: 18px; padding: 1.4rem; margin-bottom: 1rem; box-shadow: var(--shadow); }
   .formula-section h3 { font-size: 0.95rem; font-weight: 600; margin-bottom: 0.85rem; display: flex; align-items: center; gap: 0.5rem; }
   .formula-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 0.6rem; }
   .formula-item { background: var(--surface2); border-radius: 8px; padding: 0.75rem 1rem; }
@@ -188,7 +195,7 @@
   .print-btn:hover { border-color: var(--accent); color: var(--accent); }
 
   /* Checklist */
-  .checklist-item { display: flex; align-items: center; gap: 0.75rem; padding: 0.85rem 1rem; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; margin-bottom: 0.5rem; cursor: pointer; transition: all 0.2s; user-select: none; }
+  .checklist-item { display: flex; align-items: center; gap: 0.75rem; padding: 1rem 1.1rem; background: linear-gradient(180deg, var(--surface), var(--surface2)); border: 1px solid var(--border); border-radius: 14px; margin-bottom: 0.65rem; cursor: pointer; transition: all 0.2s; user-select: none; box-shadow: var(--shadow); }
   .checklist-item:hover { border-color: var(--accent-hover); }
   .checklist-item.checked { border-color: var(--check-border); background: var(--check-bg); }
   .check-box { width: 22px; height: 22px; border: 2px solid var(--border); border-radius: 6px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; transition: all 0.2s; font-size: 0.75rem; }
@@ -230,7 +237,7 @@
 
   .history-section { margin-bottom: 1.5rem; }
   .history-section h3 { font-size: 0.85rem; font-weight: 600; margin-bottom: 0.75rem; display: flex; align-items: center; gap: 0.5rem; }
-  .history-empty { text-align: center; padding: 2rem 1rem; color: var(--text-muted); font-size: 0.9rem; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); }
+  .history-empty { text-align: center; padding: 2rem 1rem; color: var(--text-muted); font-size: 0.9rem; background: linear-gradient(180deg, var(--surface), var(--surface2)); border: 1px solid var(--border); border-radius: 18px; box-shadow: var(--shadow); }
 
   .history-table { width: 100%; border-collapse: separate; border-spacing: 0; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
   .history-table th { font-family: 'JetBrains Mono', monospace; font-size: 0.68rem; letter-spacing: 1px; text-transform: uppercase; color: var(--text-muted); text-align: left; padding: 0.7rem 1rem; background: var(--surface2); border-bottom: 1px solid var(--border); }
@@ -245,7 +252,7 @@
   .badge-best { background: var(--green); color: #fff; font-size: 0.65rem; margin-left: 0.35rem; vertical-align: middle; padding: 0.1rem 0.4rem; }
 
   .stats-overview { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 0.75rem; margin-bottom: 1.5rem; }
-  .stats-overview .overview-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem; text-align: center; }
+  .stats-overview .overview-card { background: linear-gradient(180deg, var(--surface), var(--surface2)); border: 1px solid var(--border); border-radius: 18px; padding: 1rem; text-align: center; box-shadow: var(--shadow); }
   .stats-overview .overview-num { font-family: 'DM Serif Display', serif; font-size: 1.8rem; line-height: 1; margin-bottom: 0.2rem; }
   .stats-overview .overview-lbl { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 1px; color: var(--text-muted); }
 
@@ -255,10 +262,19 @@
   ::-webkit-scrollbar-track { background: var(--bg); }
   ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
 
+  @media (max-width: 900px) {
+    .container { width: min(100vw - 1.5rem, 100%); }
+    header { flex-direction: column; }
+    .header-actions { width: 100%; justify-content: flex-start; }
+    .tab-nav { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  }
+
   @media (max-width: 600px) {
-    .tab-btn { flex: 0 0 auto; font-size: 0.8rem; padding: 0.6rem 0.85rem; }
+    .container { width: min(100vw - 1rem, 100%); padding-top: 1.25rem; }
+    .tab-nav { grid-template-columns: 1fr; }
+    .tab-btn { min-height: 78px; }
     .info-bar { grid-template-columns: 1fr; }
-    .practice-dashboard { gap: 0.5rem; }
+    .practice-dashboard { grid-template-columns: 1fr; gap: 0.75rem; }
     .practice-stat .stat-num { font-size: 1.5rem; }
     .practice-btn-row { flex-direction: column; }
     .practice-btn-row > * { text-align: center; justify-content: center; }
@@ -348,18 +364,14 @@
           </ul>
         </li>
       </ul>
-      <button id="theme-toggle-btn" class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode" aria-label="Toggle dark and light theme">
-        <span class="toggle-icon">🌙</span>
-        <div class="toggle-track"><div class="toggle-thumb"></div></div>
-        <span class="toggle-icon">☀️</span>
-      </button>
     </div>
   </div>
 </nav>
 
 <div class="container">
   <header>
-    <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="header-copy">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="index.html">Home</a>
       <span class="breadcrumb-sep" aria-hidden="true">›</span>
       <a href="learn.html">Courses</a>
@@ -371,6 +383,14 @@
     <div class="course-label">Spring 2026</div>
     <h1>Math 130 — Test 1</h1>
     <p class="subtitle">Interactive study guide covering all tested topics. Review concepts, practice problems, and quiz yourself.</p>
+    </div>
+    <div class="header-actions">
+      <button id="theme-toggle-btn" class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode" aria-label="Toggle dark and light theme">
+        <span class="toggle-icon">🌙</span>
+        <div class="toggle-track"><div class="toggle-thumb"></div></div>
+        <span class="toggle-icon">☀️</span>
+      </button>
+    </div>
   </header>
 
   <div class="info-bar">
@@ -382,12 +402,12 @@
   <div class="tab-nav-wrapper">
     <div class="tab-fade-left" id="fade-left"></div>
     <nav class="tab-nav" id="tabNav">
-      <button class="tab-btn active" data-tab="topics">Topics Review</button>
-      <button class="tab-btn" data-tab="formulas">Formula Sheet</button>
-      <button class="tab-btn" data-tab="practice">Practice</button>
-      <button class="tab-btn" data-tab="quiz">Self-Quiz</button>
-      <button class="tab-btn" data-tab="checklist">Checklist</button>
-      <button class="tab-btn" data-tab="progress">Progress</button>
+      <button class="tab-btn active" data-tab="topics"><span class="tab-icon">📚</span><span class="tab-copy"><span class="tab-label">Topics Review</span><span class="tab-meta">Core ideas and worked examples</span></span></button>
+      <button class="tab-btn" data-tab="formulas"><span class="tab-icon">🧾</span><span class="tab-copy"><span class="tab-label">Formula Sheet</span><span class="tab-meta">Quick reference before practice</span></span></button>
+      <button class="tab-btn" data-tab="practice"><span class="tab-icon">✍️</span><span class="tab-copy"><span class="tab-label">Practice</span><span class="tab-meta">Track wins and retry misses</span></span></button>
+      <button class="tab-btn" data-tab="quiz"><span class="tab-icon">🎯</span><span class="tab-copy"><span class="tab-label">Self-Quiz</span><span class="tab-meta">Check recall under test pacing</span></span></button>
+      <button class="tab-btn" data-tab="checklist"><span class="tab-icon">✅</span><span class="tab-copy"><span class="tab-label">Checklist</span><span class="tab-meta">Mark each objective complete</span></span></button>
+      <button class="tab-btn" data-tab="progress"><span class="tab-icon">📈</span><span class="tab-copy"><span class="tab-label">Progress</span><span class="tab-meta">Review history and best attempts</span></span></button>
     </nav>
     <div class="tab-fade-right" id="fade-right"></div>
   </div>


### PR DESCRIPTION
### Motivation
- Align the Test 1 review page with the stronger outer layout, rhythm, and card treatment already used by Test 3 so the two pages share a consistent dashboard-style UI.
- Improve the tab/navigation interaction, card sizing, and section spacing to provide clearer active states, larger click targets, and better responsive stacking while preserving Test 1’s content.

### Description
- Modified `130Test1.html` to widen the page shell and introduce `--shell`, `--shadow`, and larger `--radius` variables and use the wider `container` approach from Test 3.
- Replaced the horizontal pill `tab-nav` with dashboard-style tab cards and updated markup to include `tab-icon`, `tab-copy`, `tab-label`, and `tab-meta` for stronger icon/text grouping and clearer active styling.
- Restyled topic, practice, formula, checklist, progress, and info cards with gradients, increased radii, explicit minima, box shadows, and adjusted spacing to match Test 3’s visual framework.
- Updated header structure to a two-column layout (`.header-copy` / `.header-actions`) and moved the theme toggle into the header actions; added responsive media-query breakpoints for 900px and 600px to control tab stacking and header flow.

### Testing
- Ran HTML validation via Python’s `HTMLParser` (`HTMLParser().feed(...)`) and it completed successfully.
- Inspected the change delta with a repository diff (`git diff -- 130Test1.html`) and checked the repo status (`git status --short`) to ensure no unrelated files were modified, both commands ran successfully in the environment.
- Attempted `xmllint --html --noout 130Test1.html` but `xmllint` is not installed in this environment so that check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04fba476883319957c5ca89d77800)