### PR TITLE
Normalize Test 2 review spacing cues

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -1278,14 +1278,15 @@
 <div class="card">
 <h2>Essential Formulas for Test 2</h2>
 <p style="color: var(--text-muted); margin-bottom: 1rem; font-weight: 500;">
-                Badges show whether a formula is provided on the exam, must be memorized, or is useful but not required on this specific test.
+                Covers formulas relevant to Sections 4.2, 4.3, and the Test 2 geometry topics.
+                <strong>The formulas marked “Provided on Test 2” match the ones students should expect on the exam.</strong>
             </p>
 <div class="formula-intro">
-<div class="formula-priority-note"><strong>Study order:</strong> memorize cards first, then learn where the provided formulas appear on the exam, and use the useful cards only as background support.</div>
+<div class="formula-priority-note"><strong>Study order:</strong> memorize cards first, then practice identifying when to use each provided formula during mixed review.</div>
 <div aria-label="Formula badge legend" class="formula-legend">
-<div class="legend-chip legend-memorize">Memorize first</div>
-<div class="legend-chip legend-provided">Recognize on test</div>
-<div class="legend-chip legend-useful">Background only</div>
+<div class="legend-chip legend-memorize">Memorize</div>
+<div class="legend-chip legend-provided">Provided on Test 2</div>
+<div class="legend-chip legend-useful">Useful relation</div>
 </div>
 </div>
 <div class="checklist-section">
@@ -1293,13 +1294,13 @@
 <div class="formula-section-note">Focus: recognize the two provided interest formulas and when each model is used.</div>
 <div class="formula-grid">
 <div class="formula-card provided-card">
-<div class="formula-badge status-provided">Provided</div>
+<div class="formula-badge status-provided">Provided on Test 2</div>
 <div class="formula-title">Compound Interest</div>
 <div class="formula-math">$$A = P\left(1+\frac{r}{n}\right)^{nt}$$</div>
 <div class="formula-vars">Printed on the exam.<br/>$n$ = compounds per year (1 annually, 12 monthly, 365 daily)</div>
 </div>
 <div class="formula-card provided-card">
-<div class="formula-badge status-provided">Provided</div>
+<div class="formula-badge status-provided">Provided on Test 2</div>
 <div class="formula-title">Continuous Compounding</div>
 <div class="formula-math">$$A = Pe^{rt}$$</div>
 <div class="formula-vars">Printed on the exam.<br/>$e \approx 2.71828$</div>
@@ -1371,7 +1372,7 @@
 <div class="formula-vars">$b_1$ and $b_2$ are the parallel sides</div>
 </div>
 <div class="formula-card provided-card">
-<div class="formula-badge status-provided">Provided</div>
+<div class="formula-badge status-provided">Provided on Test 2</div>
 <div class="formula-title">Heron's Formula</div>
 <div class="formula-math dual-line">$$A = \sqrt{s(s-a)(s-b)(s-c)}$$ $$s = \frac{a+b+c}{2}$$</div>
 <div class="formula-vars">Printed on the exam for the three-side triangle problem</div>
@@ -1468,9 +1469,10 @@
 <div class="tab-content" id="tab-practice">
 <div class="card">
 <h2 style="text-align: center; margin-bottom: 0.5rem;">Practice Generators</h2>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Select a topic to generate infinite, exam-style questions.</p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Practice generators are live for Test 2 topics and aligned to Sections 4.2, 4.3, and the geometry material covered before the exam.</p>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">By default, enter decimal answers rounded as directed. Repeating decimals are accepted within tolerance (for example, $0.3333$ for $0.\overline{3}$). Some generators may allow additional formats noted in the question (for example, $\pi$ forms).</p>
 <p id="coverage-audit" style="text-align: center; color: var(--text-muted); margin-bottom: 2rem; font-size: 0.9rem;"></p>
+<p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Select a topic to generate infinite, exam-style questions.</p>
 <!-- Mock Exam CTA -->
 <div id="exam-cta" style="background: linear-gradient(135deg, var(--accent-glow), var(--red-bg)); border: 2px solid var(--accent); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem; text-align: center;">
 <h3 style="font-family: 'DM Serif Display', serif; font-size: 1.4rem; margin-bottom: 0.5rem;">🎯 Mock Exam Mode</h3>


### PR DESCRIPTION
### Motivation
- Remove visual drift between the Test 2 and Test 3 review pages so shared components read as part of the same series. 
- Prefer the Test 3 presentation hierarchy and labels where components overlap, while keeping Test 2-specific content and topic coverage.

### Description
- Update the formulas panel intro copy and the study-order note in `130Test2.html` to match the presentation style used in the Test 3 page. 
- Rename the small-formula legend labels and change each formula badge text from `Provided` to `Provided on Test 2` so badge wording matches the exam-specific pattern used on Test 3. 
- Reorder and space the Practice Generators intro paragraphs to mirror Test 3’s hierarchy so the practice section has consistent spacing and flow across the series.
- No changes were made to shared CSS rules for `.container`, `header`, `.tabs`, `.tab-btn`, `.checklist-grid`, `.formula-grid`, or `.slides-grid` because those selectors already matched Test 3.

### Testing
- Ran a Python check that extracts the in-file CSS blocks and asserts the shared selector blocks (`.container`, `header`, `.tabs`, `.tab-btn`, `.checklist-grid`, `.formula-grid`, `.slides-grid`) are identical between `130Test2.html` and `130Test3.html`, and it succeeded. 
- Ran a Python assertion to confirm the updated badge text `Provided on Test 2` appears in `130Test2.html`, and it succeeded. 
- Confirmed the working tree showed the updated `130Test2.html` file (no screenshot was captured during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c052a1bc548331be4fefe8b3f89fd8)