### PR TITLE
Centralize Spring 2026 assignment links to a dedicated page and update course pages

### DIFF
--- a/courses/math114-final-review.html
+++ b/courses/math114-final-review.html
@@ -116,17 +116,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Apr 20, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455404"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455405"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -134,17 +124,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Apr 21, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455408"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455409"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>
@@ -162,17 +142,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Apr 27, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455412"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455413"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -180,17 +150,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Apr 28, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455416"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455417"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>
@@ -230,17 +190,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Apr 30, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455364"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455365"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -248,17 +198,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> May 1, 11:59pm</li>
                 <li><strong>Points:</strong> 140</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455361"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455360"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>
@@ -301,15 +241,7 @@
                   <td>Apr 30, 11:59pm</td>
                   <td>20</td>
                   <td>
-                    <a
-                      href="https://canvas.liberty.edu/courses/735702/assignments/11455364"
-                      >Section 2</a
-                    >
-                    |
-                    <a
-                      href="https://canvas.liberty.edu/courses/735705/assignments/11455365"
-                      >Section 3</a
-                    >
+                    <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
                   </td>
                 </tr>
                 <tr>
@@ -317,15 +249,7 @@
                   <td>May 1, 11:59pm</td>
                   <td>140</td>
                   <td>
-                    <a
-                      href="https://canvas.liberty.edu/courses/735702/assignments/11455361"
-                      >Section 2</a
-                    >
-                    |
-                    <a
-                      href="https://canvas.liberty.edu/courses/735705/assignments/11455360"
-                      >Section 3</a
-                    >
+                    <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
                   </td>
                 </tr>
               </tbody>

--- a/courses/math114-financial-math.html
+++ b/courses/math114-financial-math.html
@@ -114,17 +114,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Feb 18, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455447"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455450"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -132,17 +122,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Feb 19, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455452"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455454"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>
@@ -196,17 +176,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Feb 23, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455456"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455458"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -214,17 +184,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Feb 24, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455460"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455462"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>
@@ -271,17 +231,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Mar 2, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455464"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455466"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -289,17 +239,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Mar 3, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455468"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455470"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>

--- a/courses/math114-foundations.html
+++ b/courses/math114-foundations.html
@@ -137,17 +137,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Jan 17, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455349"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455348"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -155,17 +145,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Jan 19, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455368"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455369"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -173,17 +153,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Jan 20, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455372"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455373"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -191,17 +161,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Jan 24, 11:59pm</li>
                 <li><strong>Points:</strong> 5</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/12119641"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/12119877"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>
@@ -262,17 +222,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Jan 26, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455420"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455421"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -280,17 +230,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Jan 27, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455424"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455425"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>
@@ -338,17 +278,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Feb 2, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455428"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455429"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -356,17 +286,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Feb 3, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455432"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455434"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>

--- a/courses/math114-statistics.html
+++ b/courses/math114-statistics.html
@@ -114,17 +114,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Mar 23, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455483"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455486"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -132,17 +122,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Mar 24, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455488"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455489"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>
@@ -193,17 +173,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Mar 30, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455376"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455377"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -211,17 +181,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Mar 31, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455380"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455381"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>
@@ -282,17 +242,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Apr 6, 11:59pm</li>
                 <li><strong>Points:</strong> 20</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455384"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455385"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
             <article class="unit-task-card">
@@ -300,17 +250,7 @@
               <ul class="unit-task-meta">
                 <li><strong>Due:</strong> Apr 7, 11:59pm</li>
                 <li><strong>Points:</strong> 10</li>
-                <li>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455388"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455389"
-                    >Section 3</a
-                  >
-                </li>
+                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
               </ul>
             </article>
           </div>

--- a/courses/math114-test1.html
+++ b/courses/math114-test1.html
@@ -112,17 +112,7 @@
             <ul class="unit-task-meta">
               <li><strong>Due:</strong> Feb 7, 11:59pm</li>
               <li><strong>Points:</strong> 25</li>
-              <li>
-                <a
-                  href="https://canvas.liberty.edu/courses/735702/assignments/11455446"
-                  >Section 2</a
-                >
-                |
-                <a
-                  href="https://canvas.liberty.edu/courses/735705/assignments/11455448"
-                  >Section 3</a
-                >
-              </li>
+              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
             </ul>
           </article>
           <article class="unit-task-card">
@@ -130,17 +120,7 @@
             <ul class="unit-task-meta">
               <li><strong>Due:</strong> Feb 9, 11:59pm</li>
               <li><strong>Points:</strong> 20</li>
-              <li>
-                <a
-                  href="https://canvas.liberty.edu/courses/735702/assignments/11455440"
-                  >Section 2</a
-                >
-                |
-                <a
-                  href="https://canvas.liberty.edu/courses/735705/assignments/11455442"
-                  >Section 3</a
-                >
-              </li>
+              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
             </ul>
           </article>
           <article class="unit-task-card">
@@ -148,17 +128,7 @@
             <ul class="unit-task-meta">
               <li><strong>Due:</strong> Feb 10, 11:59pm</li>
               <li><strong>Points:</strong> 125</li>
-              <li>
-                <a
-                  href="https://canvas.liberty.edu/courses/735702/assignments/11455436"
-                  >Section 2</a
-                >
-                |
-                <a
-                  href="https://canvas.liberty.edu/courses/735705/assignments/11455438"
-                  >Section 3</a
-                >
-              </li>
+              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
             </ul>
           </article>
         </div>
@@ -227,15 +197,7 @@
                 <td>Feb 9, 11:59pm</td>
                 <td>20</td>
                 <td>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455440"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455442"
-                    >Section 3</a
-                  >
+                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
                 </td>
               </tr>
               <tr>
@@ -243,15 +205,7 @@
                 <td>Feb 10, 11:59pm</td>
                 <td>125</td>
                 <td>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455436"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455438"
-                    >Section 3</a
-                  >
+                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
                 </td>
               </tr>
               <tr>
@@ -259,15 +213,7 @@
                 <td>Feb 7, 11:59pm</td>
                 <td>25</td>
                 <td>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455446"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455448"
-                    >Section 3</a
-                  >
+                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
                 </td>
               </tr>
             </tbody>

--- a/courses/math114-test2.html
+++ b/courses/math114-test2.html
@@ -112,17 +112,7 @@
             <ul class="unit-task-meta">
               <li><strong>Due:</strong> Mar 7, 11:59pm</li>
               <li><strong>Points:</strong> 25</li>
-              <li>
-                <a
-                  href="https://canvas.liberty.edu/courses/735702/assignments/11455481"
-                  >Section 2</a
-                >
-                |
-                <a
-                  href="https://canvas.liberty.edu/courses/735705/assignments/11455485"
-                  >Section 3</a
-                >
-              </li>
+              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
             </ul>
           </article>
           <article class="unit-task-card">
@@ -130,17 +120,7 @@
             <ul class="unit-task-meta">
               <li><strong>Due:</strong> Mar 7, 11:59pm</li>
               <li><strong>Points:</strong> 20</li>
-              <li>
-                <a
-                  href="https://canvas.liberty.edu/courses/735702/assignments/11455476"
-                  >Section 2</a
-                >
-                |
-                <a
-                  href="https://canvas.liberty.edu/courses/735705/assignments/11455479"
-                  >Section 3</a
-                >
-              </li>
+              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
             </ul>
           </article>
           <article class="unit-task-card">
@@ -148,17 +128,7 @@
             <ul class="unit-task-meta">
               <li><strong>Due:</strong> Mar 19, 11:59pm</li>
               <li><strong>Points:</strong> 125</li>
-              <li>
-                <a
-                  href="https://canvas.liberty.edu/courses/735702/assignments/11455472"
-                  >Section 2</a
-                >
-                |
-                <a
-                  href="https://canvas.liberty.edu/courses/735705/assignments/11455474"
-                  >Section 3</a
-                >
-              </li>
+              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
             </ul>
           </article>
         </div>
@@ -222,15 +192,7 @@
                 <td>Mar 19, 11:59pm</td>
                 <td>125</td>
                 <td>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455472"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455474"
-                    >Section 3</a
-                  >
+                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
                 </td>
               </tr>
               <tr>
@@ -238,15 +200,7 @@
                 <td>Mar 7, 11:59pm</td>
                 <td>20</td>
                 <td>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455476"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455479"
-                    >Section 3</a
-                  >
+                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
                 </td>
               </tr>
               <tr>
@@ -254,15 +208,7 @@
                 <td>Mar 7, 11:59pm</td>
                 <td>25</td>
                 <td>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455481"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455485"
-                    >Section 3</a
-                  >
+                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
                 </td>
               </tr>
             </tbody>

--- a/courses/math114-test3.html
+++ b/courses/math114-test3.html
@@ -112,17 +112,7 @@
             <ul class="unit-task-meta">
               <li><strong>Due:</strong> Apr 11, 11:59pm</li>
               <li><strong>Points:</strong> 25</li>
-              <li>
-                <a
-                  href="https://canvas.liberty.edu/courses/735702/assignments/11455401"
-                  >Section 2</a
-                >
-                |
-                <a
-                  href="https://canvas.liberty.edu/courses/735705/assignments/11455403"
-                  >Section 3</a
-                >
-              </li>
+              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
             </ul>
           </article>
           <article class="unit-task-card">
@@ -130,17 +120,7 @@
             <ul class="unit-task-meta">
               <li><strong>Due:</strong> Apr 13, 11:59pm</li>
               <li><strong>Points:</strong> 20</li>
-              <li>
-                <a
-                  href="https://canvas.liberty.edu/courses/735702/assignments/11455396"
-                  >Section 2</a
-                >
-                |
-                <a
-                  href="https://canvas.liberty.edu/courses/735705/assignments/11455397"
-                  >Section 3</a
-                >
-              </li>
+              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
             </ul>
           </article>
           <article class="unit-task-card">
@@ -148,17 +128,7 @@
             <ul class="unit-task-meta">
               <li><strong>Due:</strong> Apr 14, 11:59pm</li>
               <li><strong>Points:</strong> 125</li>
-              <li>
-                <a
-                  href="https://canvas.liberty.edu/courses/735702/assignments/11455392"
-                  >Section 2</a
-                >
-                |
-                <a
-                  href="https://canvas.liberty.edu/courses/735705/assignments/11455393"
-                  >Section 3</a
-                >
-              </li>
+              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
             </ul>
           </article>
         </div>
@@ -209,15 +179,7 @@
                 <td>Apr 14, 11:59pm</td>
                 <td>125</td>
                 <td>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455392"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455393"
-                    >Section 3</a
-                  >
+                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
                 </td>
               </tr>
               <tr>
@@ -225,15 +187,7 @@
                 <td>Apr 13, 11:59pm</td>
                 <td>20</td>
                 <td>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455396"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455397"
-                    >Section 3</a
-                  >
+                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
                 </td>
               </tr>
               <tr>
@@ -241,15 +195,7 @@
                 <td>Apr 11, 11:59pm</td>
                 <td>25</td>
                 <td>
-                  <a
-                    href="https://canvas.liberty.edu/courses/735702/assignments/11455401"
-                    >Section 2</a
-                  >
-                  |
-                  <a
-                    href="https://canvas.liberty.edu/courses/735705/assignments/11455403"
-                    >Section 3</a
-                  >
+                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
                 </td>
               </tr>
             </tbody>

--- a/courses/math114.html
+++ b/courses/math114.html
@@ -210,6 +210,11 @@
           <a href="math114-final-review.html" class="button">Open Final Review &amp; Exam</a>
         </div>
         <div class="quick-link-card">
+          <h3>Spring 2026 Assignment Links</h3>
+          <p>Use the dedicated Spring 2026 links page for assignment access instead of placing Canvas links directly on this course home.</p>
+          <a href="math114Spring26Links.html" class="button">Open Spring 2026 Links</a>
+        </div>
+        <div class="quick-link-card">
           <h3>Common Tools</h3>
           <ul>
             <li><a href="https://www.desmos.com/scientific" target="_blank" rel="noopener noreferrer">Desmos Scientific Calculator</a></li>


### PR DESCRIPTION
### Motivation
- Remove many scattered direct Canvas assignment links and replace them with a single canonical destination for Spring 2026 assignment access to simplify maintenance and avoid exposing section-specific Canvas URLs.
- Encourage students to use a single, versioned links page for assignments instead of embedding per-section Canvas links in multiple unit pages.
- Surface the centralized links page from the course home so it's easy to find.

### Description
- Replaced per-assignment Canvas links with a single link to `math114Spring26Links.html` across unit pages including `math114-final-review.html`, `math114-financial-math.html`, `math114-foundations.html`, `math114-statistics.html`, `math114-test1.html`, `math114-test2.html`, and `math114-test3.html`.
- Added a new quick-link card to the course home `math114.html` that points to `math114Spring26Links.html` and explains its purpose.
- Kept existing tool/resource links and table layouts intact while consolidating assignment link destinations to the new page.

### Testing
- No automated tests were run for these static HTML changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05799d7308331ad67e1586c6ff462)