### PR TITLE
Remove term and section metadata from MATH 114 hero banner

### DIFF
--- a/courses/math114.html
+++ b/courses/math114.html
@@ -72,8 +72,6 @@
     <div class="container">
       <h1>MATH 114: Quantitative Reasoning</h1>
       <p class="subtitle">Enhancing data interpretation, logical reasoning, and real-world problem solving.</p>
-      <p><strong>Term:</strong> Spring R 2025</p>
-      <p><strong>Sections:</strong> 002 and 003</p>
     </div>
   </header>
 


### PR DESCRIPTION
### Motivation
- Remove the term and section metadata from the course hero so the banner only displays the course title and subtitle.

### Description
- Deleted the two paragraph lines `<p><strong>Term:</strong> Spring R 2025</p>` and `<p><strong>Sections:</strong> 002 and 003</p>` from `courses/math114.html` inside the `<header class="course-header course-header--home">` block while keeping the existing `<h1>` and subtitle paragraph unchanged.

### Testing
- Ran `git diff --check` and inspected the header with `sed -n '66,80p' courses/math114.html` to confirm the two lines were removed and the title/subtitle remain, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05b01ae8c8331a4d72f145b7812ed)