### PR TITLE
Hook shared styles.css into pages with shared nav and remove redundant nav CSS

### DIFF
--- a/Taskflow.html
+++ b/Taskflow.html
@@ -63,15 +63,8 @@
     }
   </style>
 
-<style>
-  .top-nav { position: sticky; top: 0; z-index: 1000; background: rgba(15, 23, 42, 0.92); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
-  .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
-  .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
-  .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
-  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
-  .top-nav-links a:hover { color: #93c5fd; }
-</style>
 
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <nav class="top-nav" aria-label="Primary">

--- a/chessboard.html
+++ b/chessboard.html
@@ -102,15 +102,8 @@
        }
     </style>
 
-<style>
-  .top-nav { position: sticky; top: 0; z-index: 1000; background: rgba(15, 23, 42, 0.92); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
-  .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
-  .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
-  .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
-  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
-  .top-nav-links a:hover { color: #93c5fd; }
-</style>
 
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body class="bg-gray-100 p-4 md:p-8 flex flex-col items-center min-h-screen">
 <nav class="top-nav" aria-label="Primary">

--- a/courses/basic-statistical-measures.html
+++ b/courses/basic-statistical-measures.html
@@ -418,6 +418,7 @@
       }
     }
   </style>
+    <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
   <nav class="navbar">

--- a/courses/constant-acceleration-lab-manual.html
+++ b/courses/constant-acceleration-lab-manual.html
@@ -3,6 +3,7 @@
 <head>
 <title>Constant Acceleration Lab Manual</title>
 <script src="../theme.js"></script>
+    <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
 <nav class="navbar">

--- a/courses/density-lab-manual.html
+++ b/courses/density-lab-manual.html
@@ -3,6 +3,7 @@
 <head>
 <title>Density Lab Manual</title>
 <script src="../theme.js"></script>
+    <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
 <nav class="navbar">

--- a/courses/electrical-circuits-lab-manual.html
+++ b/courses/electrical-circuits-lab-manual.html
@@ -27,6 +27,7 @@
   }
 }
 </style>
+    <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
 <nav class="navbar">

--- a/growth.html
+++ b/growth.html
@@ -23,15 +23,8 @@
         }
     </style>
 
-<style>
-  .top-nav { position: sticky; top: 0; z-index: 1000; background: rgba(15, 23, 42, 0.92); backdrop-filter: blur(8px); border-bottom: 1px solid rgba(148, 163, 184, 0.25); }
-  .top-nav-inner { max-width: 1100px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
-  .top-nav-title { color: #f8fafc; font-weight: 700; text-decoration: none; margin-right: 0.5rem; }
-  .top-nav-links { display: flex; align-items: center; gap: 0.85rem; flex-wrap: wrap; }
-  .top-nav-links a { color: #e2e8f0; text-decoration: none; font-size: 0.95rem; }
-  .top-nav-links a:hover { color: #93c5fd; }
-</style>
 
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body class="bg-gray-100 p-4 md:p-8">
 <nav class="top-nav" aria-label="Primary">


### PR DESCRIPTION
### Motivation

- Ensure pages that use the shared navigation markup (`<nav class="top-nav">` or `<nav class="navbar">`) pull navigation styles from the global `styles.css` instead of relying on duplicated inline nav CSS.
- Reduce maintenance burden and avoid style drift by centralizing nav styling while preserving page-specific styling where needed.
- Apply correct relative paths (`href="styles.css"` for root pages, `href="../styles.css"` for `courses/` pages) so links resolve correctly from each file location.

### Description

- Added the shared stylesheet link to the root pages `growth.html`, `Taskflow.html`, and `chessboard.html` using `href="styles.css"` and to course pages `courses/basic-statistical-measures.html`, `courses/constant-acceleration-lab-manual.html`, `courses/density-lab-manual.html`, and `courses/electrical-circuits-lab-manual.html` using `href="../styles.css"`.
- Removed the duplicated inline `.top-nav` CSS blocks from the root pages so the nav now relies on the centralized rules in `styles.css` while leaving other page-level `<style>` blocks intact.
- Preserved page-specific CSS (flowchart layout, chessboard/chart rules, reveal-answer styles, and the printable rules in the electrical lab page) because those rules are unique to each page’s layout or functionality.

### Testing

- Searched and inspected target files to confirm each modified file still contains the shared nav markup and that the correct `href` value appears in the `<head>` of each file using `rg` and inline file inspection, and those checks passed.
- Ran a small verification script that scans the target files to assert `nav` presence and matching stylesheet links (root vs `courses/`), and all assertions succeeded.
- Reviewed the diff to confirm only the shared-nav stylesheet insertions and redundant nav-CSS removals were applied and that page-specific styling remains in place, which matched expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08b9ef0888331b6e3be5d45957be4)