### PR TITLE
Add breadcrumbs to MATH 114 unit pages

### DIFF
--- a/courses/math114-final-review.html
+++ b/courses/math114-final-review.html
@@ -50,6 +50,19 @@
         ></button>
       </div>
     </nav>
+    <div class="page-context-bar">
+      <div class="container">
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+          <a href="../index.html">Home</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="../learn.html">Course Resources</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="math114.html">MATH 114</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <span class="breadcrumb-current" aria-current="page">MATH 114 Final Review</span>
+        </nav>
+      </div>
+    </div>
     <header class="course-header course-header--unit">
       <div class="container">
         <h1>MATH 114: Final Review &amp; Exam</h1>

--- a/courses/math114-financial-math.html
+++ b/courses/math114-financial-math.html
@@ -50,6 +50,19 @@
         ></button>
       </div>
     </nav>
+    <div class="page-context-bar">
+      <div class="container">
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+          <a href="../index.html">Home</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="../learn.html">Course Resources</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="math114.html">MATH 114</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <span class="breadcrumb-current" aria-current="page">MATH 114 Financial Math Unit</span>
+        </nav>
+      </div>
+    </div>
     <header class="course-header course-header--unit">
       <div class="container">
         <h1>MATH 114: Financial Math Unit</h1>

--- a/courses/math114-foundations.html
+++ b/courses/math114-foundations.html
@@ -51,6 +51,19 @@
         ></button>
       </div>
     </nav>
+    <div class="page-context-bar">
+      <div class="container">
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+          <a href="../index.html">Home</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="../learn.html">Course Resources</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="math114.html">MATH 114</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <span class="breadcrumb-current" aria-current="page">MATH 114 Foundations</span>
+        </nav>
+      </div>
+    </div>
     <header class="course-header course-header--unit">
       <div class="container">
         <h1>MATH 114: Orientation &amp; Foundations</h1>

--- a/courses/math114-statistics.html
+++ b/courses/math114-statistics.html
@@ -50,6 +50,19 @@
         ></button>
       </div>
     </nav>
+    <div class="page-context-bar">
+      <div class="container">
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+          <a href="../index.html">Home</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="../learn.html">Course Resources</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="math114.html">MATH 114</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <span class="breadcrumb-current" aria-current="page">MATH 114 Statistics Unit</span>
+        </nav>
+      </div>
+    </div>
     <header class="course-header course-header--unit">
       <div class="container">
         <h1>MATH 114: Statistics Unit</h1>

--- a/courses/math114-test1.html
+++ b/courses/math114-test1.html
@@ -50,6 +50,19 @@
         ></button>
       </div>
     </nav>
+    <div class="page-context-bar">
+      <div class="container">
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+          <a href="../index.html">Home</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="../learn.html">Course Resources</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="math114.html">MATH 114</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <span class="breadcrumb-current" aria-current="page">MATH 114 Test 1 Unit</span>
+        </nav>
+      </div>
+    </div>
     <header class="course-header course-header--unit">
       <div class="container">
         <h1>MATH 114: Test 1 Unit</h1>

--- a/courses/math114-test2.html
+++ b/courses/math114-test2.html
@@ -50,6 +50,19 @@
         ></button>
       </div>
     </nav>
+    <div class="page-context-bar">
+      <div class="container">
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+          <a href="../index.html">Home</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="../learn.html">Course Resources</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="math114.html">MATH 114</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <span class="breadcrumb-current" aria-current="page">MATH 114 Test 2 Unit</span>
+        </nav>
+      </div>
+    </div>
     <header class="course-header course-header--unit">
       <div class="container">
         <h1>MATH 114: Test 2 Unit</h1>

--- a/courses/math114-test3.html
+++ b/courses/math114-test3.html
@@ -50,6 +50,19 @@
         ></button>
       </div>
     </nav>
+    <div class="page-context-bar">
+      <div class="container">
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+          <a href="../index.html">Home</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="../learn.html">Course Resources</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <a href="math114.html">MATH 114</a>
+          <span aria-hidden="true" class="breadcrumb-sep">›</span>
+          <span class="breadcrumb-current" aria-current="page">MATH 114 Test 3 Unit</span>
+        </nav>
+      </div>
+    </div>
     <header class="course-header course-header--unit">
       <div class="container">
         <h1>MATH 114: Test 3 Unit</h1>


### PR DESCRIPTION
### Motivation
- Ensure MATH 114 unit/resource pages use the same shared breadcrumb wrapper used elsewhere on the site for consistent navigation and context.
- Provide clear links back to the site Home, the Courses/Learn index, and the main MATH 114 page, with the current page marked for accessibility.

### Description
- Inserted the shared `page-context-bar` + `breadcrumb` block immediately after the navbar on seven MATH 114 unit/resource pages.
- Each breadcrumb includes links to `../index.html`, `../learn.html`, `math114.html`, and a final current-page label with `aria-current="page"`.
- Applied the same markup pattern used by other course pages (e.g., `courses/math130.html` and MATH 100/105/110 pages) to maintain styling and semantics.
- Files updated: `courses/math114-test1.html`, `courses/math114-test2.html`, `courses/math114-test3.html`, `courses/math114-final-review.html`, `courses/math114-foundations.html`, `courses/math114-statistics.html`, and `courses/math114-financial-math.html`.

### Testing
- Ran a Python validation script that verifies each updated file contains the `page-context-bar` block and the required breadcrumb links, and the script succeeded for all seven files.
- Reviewed the diffs for the seven HTML files to confirm the breadcrumb markup was inserted in the correct location, and the diffs matched the intended changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08d074ce883318ae06d58866bd223)