### PR TITLE
Add shared site shell and fix stylesheet path for MathJournals page

### DIFF
--- a/projects/ResearchMentorship/MathJournals.html
+++ b/projects/ResearchMentorship/MathJournals.html
@@ -4,14 +4,61 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Interactive Undergraduate Math Journals Resource</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="../../styles.css">
+    <script src="../../theme.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
-<body class="bg-gradient-to-br from-slate-50 to-indigo-100 font-sans text-slate-700 min-h-screen p-4 sm:p-8">
+<body class="bg-gradient-to-br from-slate-50 to-indigo-100 font-sans text-slate-700 min-h-screen">
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <div class="top-nav-branding">
+      <a class="top-nav-title" href="../../index.html">Prof. Volk's Office</a>
+    </div>
+    <div class="top-nav-actions">
+      <ul class="top-nav-links">
+        <li><a href="../../index.html">Home</a></li>
+        <li><a href="../../CV.html">About</a></li>
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">Courses ▾</button>
+          <ul class="dropdown-menu">
+            <li><a href="../../learn.html">All Courses</a></li>
+            <li><a href="../../courses/math114.html">MATH 114</a></li>
+            <li><a href="../../courses/math130.html">MATH 130</a></li>
+            <li><a href="../../courses/physics-labs.html">Physics Labs</a></li>
+          </ul>
+        </li>
+        <li><a href="../../projects.html" aria-current="page">Tools</a></li>
+      </ul>
+      <ul class="top-nav-utilities" aria-label="More">
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
+          <ul class="dropdown-menu dropdown-menu--right">
+            <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+            <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+            <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
+          </ul>
+        </li>
+      </ul>
+      <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+    </div>
+  </div>
+</nav>
+<div class="page-context-bar">
+  <div class="container">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a href="../../index.html">Home</a>
+      <span aria-hidden="true" class="breadcrumb-sep">›</span>
+      <a href="../../projects.html">Tools</a>
+      <span aria-hidden="true" class="breadcrumb-sep">›</span>
+      <span class="breadcrumb-current" aria-current="page">Undergraduate Math Journals</span>
+    </nav>
+  </div>
+</div>
 
-    <div class="container mx-auto max-w-7xl bg-white rounded-xl shadow-lg p-6 sm:p-8 md:p-12">
+    <main class="container mx-auto max-w-7xl p-4 sm:p-8">
+    <div class="bg-white rounded-xl shadow-lg p-6 sm:p-8 md:p-12">
 
         <header class="mb-10 border-b border-slate-200 pb-6">
             <h1 class="text-3xl sm:text-4xl font-bold text-indigo-700 mb-3">Interactive Guide to Undergraduate Math Journals</h1>
@@ -232,6 +279,7 @@
         </footer>
 
     </div>
+    </main>
 
     <script>
         // --- Data ---


### PR DESCRIPTION
### Motivation
- Ensure the Math Journals resource uses the site's shared styling and navigation so it looks and behaves consistently with other pages.
- Fix incorrect local stylesheet reference so the page loads the root `styles.css` and theme behavior from `theme.js` when served from `projects/ResearchMentorship/`.
- Provide users a consistent breadcrumb and top navigation so the page is discoverable from `index.html` and `projects.html`.

### Description
- Updated the stylesheet reference to the repo-root path as `../../styles.css` and added the shared `../../theme.js` include in the document head.
- Inserted the site's shared `top-nav` markup (branding, links, dropdowns, utilities, and `theme-toggle-btn`) with links adjusted for the nested path.
- Added a `page-context-bar` with a `breadcrumb` trail linking to `../../index.html` and `../../projects.html` and set the current page label to "Undergraduate Math Journals." 
- Wrapped the original page content inside the site's standard `<main class="container ...">` and inner content card to match the shared-page layout patterns.

### Testing
- Ran `rg -n "../../styles.css|../../theme.js|page-context-bar|breadcrumb|top-nav" projects/ResearchMentorship/MathJournals.html` to verify the new includes and shell markup are present, and the command completed successfully.
- Inspected the file diff with `git diff -- projects/ResearchMentorship/MathJournals.html` to confirm the intended insertions and path updates were applied successfully.
- Performed a file-level inspection of `projects/ResearchMentorship/MathJournals.html` to ensure the `main` wrapper and footer placement are correct; no automated browser rendering test was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08d9fa0dc8331b135f7a70188890a)