### PR TITLE
Update home page tools card wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,12 +84,12 @@
         <a href="learn.html" class="button">Start Learning</a>
       </div>
       <div class="card">
-        <a href="projects.html" aria-label="Projects" title="Projects">
+        <a href="projects.html" aria-label="Tools and Resources" title="Tools and Resources">
           <div class="card-icon">🔧</div>
         </a>
-        <h2>Projects</h2>
-        <p>Explore the various projects I've worked on, including research, educational tools, applications, and other initiatives I've undertaken.</p>
-        <a href="projects.html" class="button">See Projects</a>
+        <h2>Tools and Resources</h2>
+        <p>Explore featured tools, classroom activities, reference pages, and other practical resources collected on the Tools page.</p>
+        <a href="projects.html" class="button">Explore Tools</a>
       </div>
       <div class="card">
         <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer" aria-label="Liberty University Math Club" title="Liberty University Math Club">


### PR DESCRIPTION
### Motivation
- Align the home page card that links to `projects.html` with the site-wide "Tools" naming so the index page references tools and resources consistently with `projects.html`.

### Description
- In `index.html` updated the card linking to `projects.html` by changing the link `aria-label`/`title`, the heading to "Tools and Resources", the descriptive paragraph to emphasize tools/activities/resources, and the CTA button text to `Explore Tools`.

### Testing
- Verified the change with `git diff -- index.html` and inspected the updated snippet with `nl -ba index.html | sed -n '80,100p'`, and confirmed a clean commit via `git status --short` and `git rev-parse HEAD`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08e589f548331b9923fc0693977db)