### PR TITLE
Add shared Math 130 review layer and refactor Test1–4 to use it

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -9,89 +9,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.js"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.css">
 <style>
-  :root {
-    --bg: #0f1117; --surface: #181a24; --surface2: #1f2233; --border: #2a2d42;
-    --text: #e2e4ef; --text-muted: #8b8fa8;
-    --accent: #6c63ff; --accent-glow: rgba(108, 99, 255, 0.25);
-    --green: #34d399; --green-bg: rgba(52, 211, 153, 0.1);
-    --amber: #fbbf24; --amber-bg: rgba(251, 191, 36, 0.1);
-    --red: #f87171; --red-bg: rgba(248, 113, 113, 0.1);
-    --blue: #60a5fa; --blue-bg: rgba(96, 165, 250, 0.1);
-    --radius: 16px;
-    --shadow: 0 12px 36px rgba(0,0,0,0.22);
-    --shell: min(1100px, calc(100vw - 2rem));
-    --grid-line: rgba(108,99,255,0.03);
-    --h1-from: #e2e4ef; --h1-to: #9d98ff;
-    --green-border: rgba(52,211,153,0.2); --green-step: rgba(52,211,153,0.25);
-    --red-border: rgba(248,113,113,0.2);
-    --accent-hover: rgba(108,99,255,0.3); --accent-chip: rgba(108,99,255,0.12);
-    --check-bg: rgba(52,211,153,0.04); --check-border: rgba(52,211,153,0.3);
-    --got-border: rgba(52,211,153,0.4); --miss-border: rgba(248,113,113,0.4);
-  }
-  body.light {
-    --bg: #f4f5f7; --surface: #ffffff; --surface2: #eef0f4; --border: #d5d8e0;
-    --text: #1a1d2b; --text-muted: #5c6070;
-    --accent: #5046e5; --accent-glow: rgba(80, 70, 229, 0.18);
-    --green: #0d9668; --green-bg: rgba(13, 150, 104, 0.08);
-    --amber: #b8860b; --amber-bg: rgba(184, 134, 11, 0.08);
-    --red: #dc2626; --red-bg: rgba(220, 38, 38, 0.07);
-    --blue: #2563eb; --blue-bg: rgba(37, 99, 235, 0.08);
-    --grid-line: rgba(80,70,229,0.04);
-    --h1-from: #1a1d2b; --h1-to: #5046e5;
-    --green-border: rgba(13,150,104,0.2); --green-step: rgba(13,150,104,0.2);
-    --red-border: rgba(220,38,38,0.18);
-    --accent-hover: rgba(80,70,229,0.25); --accent-chip: rgba(80,70,229,0.1);
-    --check-bg: rgba(13,150,104,0.05); --check-border: rgba(13,150,104,0.3);
-    --got-border: rgba(13,150,104,0.4); --miss-border: rgba(220,38,38,0.35);
-    --shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
-    --shell: min(1100px, calc(100vw - 2rem));
-  }
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: 'DM Sans', sans-serif; background: var(--bg); color: var(--text); line-height: 1.65; min-height: 100vh; transition: background 0.3s, color 0.3s; }
-  body::before { content: ''; position: fixed; inset: 0; background-image: linear-gradient(var(--grid-line) 1px, transparent 1px), linear-gradient(90deg, var(--grid-line) 1px, transparent 1px); background-size: 40px 40px; pointer-events: none; z-index: 0; }
-
-  /* Theme toggle */
-  .theme-toggle { position: static; background: var(--surface); border: 1px solid var(--border); border-radius: 50px; padding: 0.4rem; cursor: pointer; display: flex; align-items: center; gap: 0.35rem; transition: all 0.3s; z-index: 5; box-shadow: var(--shadow); }
-  .theme-toggle:hover { border-color: var(--accent); }
-  .theme-toggle .toggle-track { width: 40px; height: 22px; border-radius: 11px; background: var(--surface2); position: relative; transition: background 0.3s; }
-  .theme-toggle .toggle-thumb { width: 18px; height: 18px; border-radius: 50%; background: var(--accent); position: absolute; top: 2px; left: 2px; transition: transform 0.3s; box-shadow: 0 1px 4px rgba(0,0,0,0.2); }
-  body.light .theme-toggle .toggle-thumb { transform: translateX(18px); }
-  .theme-toggle .toggle-icon { font-size: 0.85rem; line-height: 1; }
-  .container { width: var(--shell); margin: 0 auto; padding: 2rem 0 4.5rem; position: relative; z-index: 1; }
-
-  header { display: flex; justify-content: space-between; align-items: flex-start; gap: 1.5rem; margin-bottom: 2rem; padding: 1.1rem 0 1.5rem; border-bottom: 1px solid var(--border); }
-  .header-copy { flex: 1; min-width: 0; }
-  .header-actions { display: flex; align-items: flex-start; justify-content: flex-end; }
-  .course-label { font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; letter-spacing: 3px; text-transform: uppercase; color: var(--accent); margin-bottom: 0.55rem; }
-  h1 { font-family: 'DM Serif Display', serif; font-size: clamp(2.2rem, 5vw, 3.2rem); font-weight: 400; letter-spacing: -0.5px; margin-bottom: 0.75rem; background: linear-gradient(135deg, var(--h1-from), var(--h1-to)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
-  .subtitle { color: var(--text-muted); font-size: 0.98rem; max-width: 52rem; }
-
-  .info-bar { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin: 0 0 1.75rem; }
-  .info-card { background: linear-gradient(180deg, var(--surface), var(--surface2)); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.15rem 1.25rem; display: flex; align-items: center; gap: 0.9rem; min-height: 92px; box-shadow: var(--shadow); }
-  .info-icon { width: 40px; height: 40px; border-radius: 10px; display: flex; align-items: center; justify-content: center; font-size: 1.15rem; flex-shrink: 0; }
-  .info-card:nth-child(1) .info-icon { background: var(--blue-bg); }
-  .info-card:nth-child(2) .info-icon { background: var(--green-bg); }
-  .info-card:nth-child(3) .info-icon { background: var(--amber-bg); }
-  .info-label { font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; }
-  .info-value { font-weight: 600; font-size: 0.95rem; }
-
-  /* Dashboard-style tab nav */
-  .tab-nav-wrapper { margin-bottom: 2rem; }
-  .tab-nav { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.85rem; }
-  .tab-fade-left, .tab-fade-right { display: none; }
-  .tab-btn { position: relative; width: 100%; padding: 0.95rem 1rem; border: 1px solid var(--border); background: linear-gradient(180deg, var(--surface), var(--surface2)); color: var(--text); font-family: 'DM Sans', sans-serif; font-size: 0.95rem; font-weight: 600; border-radius: 16px; cursor: pointer; transition: all 0.25s; min-height: 92px; text-align: left; display: flex; align-items: center; gap: 0.9rem; box-shadow: var(--shadow); }
-  .tab-btn::before { content: ''; position: absolute; top: 0; left: 18px; right: 18px; height: 3px; border-radius: 999px; background: linear-gradient(90deg, var(--accent), transparent); opacity: 0.7; }
-  .tab-btn:hover { color: var(--text); transform: translateY(-2px); border-color: color-mix(in srgb, var(--accent) 35%, var(--border)); }
-  .tab-btn.active { background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 14%, var(--surface)), var(--surface)); color: var(--text); border-color: var(--accent); box-shadow: 0 10px 24px var(--accent-glow); }
-  .tab-btn:focus-visible, .video-link:focus-visible, .review-topic-btn:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
-  .tab-icon { width: 42px; height: 42px; border-radius: 12px; display: inline-flex; align-items: center; justify-content: center; background: color-mix(in srgb, var(--accent) 12%, var(--surface2)); color: var(--accent); flex-shrink: 0; font-size: 1.1rem; }
-  .tab-btn.active .tab-icon { background: color-mix(in srgb, var(--accent) 18%, var(--surface2)); }
-  .tab-copy { display: flex; flex-direction: column; gap: 0.2rem; min-width: 0; }
-  .tab-label { font-weight: 700; line-height: 1.2; }
-  .tab-meta { font-size: 0.8rem; color: var(--text-muted); line-height: 1.3; }
-  .tab-content { display: none; animation: fadeUp 0.35s ease; margin-bottom: 2rem; }
-  .tab-content.active { display: block; }
-  @keyframes fadeUp { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+  /* Page-specific styles only; shared Math 130 review tokens/components live in styles.css. */
 
   /* Topic Cards */
   .topic-card { background: linear-gradient(180deg, var(--surface), color-mix(in srgb, var(--surface) 72%, var(--surface2))); border: 1px solid var(--border); border-radius: 18px; margin-bottom: 1.15rem; overflow: hidden; transition: border-color 0.3s, transform 0.25s; box-shadow: var(--shadow); }
@@ -351,7 +269,7 @@
 
 
 </head>
-<body>
+<body class="review-page">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
@@ -386,9 +304,9 @@
   </div>
 </nav>
 
-<div class="container">
-  <header>
-    <div class="header-copy">
+<div class="container review-shell">
+  <header class="review-header">
+    <div class="header-copy review-title-group">
       <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="index.html">Home</a>
       <span class="breadcrumb-sep" aria-hidden="true">›</span>
@@ -400,7 +318,7 @@
     </nav>
     <div class="course-label">Spring 2026</div>
     <h1>Math 130 — Test 1</h1>
-    <p class="subtitle">Interactive study guide covering all tested topics. Review concepts, practice problems, and quiz yourself.</p>
+    <p class="subtitle review-subtitle">Interactive study guide covering all tested topics. Review concepts, practice problems, and quiz yourself.</p>
     </div>
     <div class="header-actions">
       <button id="theme-toggle-btn" class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark mode" aria-label="Toggle dark and light theme">
@@ -411,83 +329,83 @@
     </div>
   </header>
 
-  <div class="info-bar">
-    <div class="info-card"><div class="info-icon">📝</div><div><div class="info-label">Format</div><div class="info-value">Paper Test</div></div></div>
-    <div class="info-card"><div class="info-icon">💻</div><div><div class="info-label">ALEKS Practice</div><div class="info-value">Up to 10 Attempts</div></div></div>
-    <div class="info-card"><div class="info-icon">📐</div><div><div class="info-label">Topics</div><div class="info-value">10 Core Areas</div></div></div>
+  <div class="info-bar review-meta-chips">
+    <div class="info-card review-chip"><div class="info-icon">📝</div><div><div class="info-label">Format</div><div class="info-value">Paper Test</div></div></div>
+    <div class="info-card review-chip"><div class="info-icon">💻</div><div><div class="info-label">ALEKS Practice</div><div class="info-value">Up to 10 Attempts</div></div></div>
+    <div class="info-card review-chip"><div class="info-icon">📐</div><div><div class="info-label">Topics</div><div class="info-value">10 Core Areas</div></div></div>
   </div>
 
   <div class="tab-nav-wrapper">
     <div class="tab-fade-left" id="fade-left"></div>
-    <nav class="tab-nav" id="tabNav">
-      <button class="tab-btn active" data-tab="topics"><span class="tab-icon">📚</span><span class="tab-copy"><span class="tab-label">Topics Review</span><span class="tab-meta">Core ideas and worked examples</span></span></button>
-      <button class="tab-btn" data-tab="formulas"><span class="tab-icon">🧾</span><span class="tab-copy"><span class="tab-label">Formula Sheet</span><span class="tab-meta">Quick reference before practice</span></span></button>
-      <button class="tab-btn" data-tab="practice"><span class="tab-icon">✍️</span><span class="tab-copy"><span class="tab-label">Practice</span><span class="tab-meta">Track wins and retry misses</span></span></button>
-      <button class="tab-btn" data-tab="quiz"><span class="tab-icon">🎯</span><span class="tab-copy"><span class="tab-label">Self-Quiz</span><span class="tab-meta">Check recall under test pacing</span></span></button>
-      <button class="tab-btn" data-tab="checklist"><span class="tab-icon">✅</span><span class="tab-copy"><span class="tab-label">Checklist</span><span class="tab-meta">Mark each objective complete</span></span></button>
-      <button class="tab-btn" data-tab="progress"><span class="tab-icon">📈</span><span class="tab-copy"><span class="tab-label">Progress</span><span class="tab-meta">Review history and best attempts</span></span></button>
+    <nav class="tab-nav review-tabs review-tabs-3" id="tabNav">
+      <button class="tab-btn review-tab-btn active" data-tab="topics"><span class="tab-icon review-tab-icon">📚</span><span class="tab-copy review-tab-copy"><span class="tab-label review-tab-label">Topics Review</span><span class="tab-meta review-tab-meta">Core ideas and worked examples</span></span></button>
+      <button class="tab-btn review-tab-btn" data-tab="formulas"><span class="tab-icon review-tab-icon">🧾</span><span class="tab-copy review-tab-copy"><span class="tab-label review-tab-label">Formula Sheet</span><span class="tab-meta review-tab-meta">Quick reference before practice</span></span></button>
+      <button class="tab-btn review-tab-btn" data-tab="practice"><span class="tab-icon review-tab-icon">✍️</span><span class="tab-copy review-tab-copy"><span class="tab-label review-tab-label">Practice</span><span class="tab-meta review-tab-meta">Track wins and retry misses</span></span></button>
+      <button class="tab-btn review-tab-btn" data-tab="quiz"><span class="tab-icon review-tab-icon">🎯</span><span class="tab-copy review-tab-copy"><span class="tab-label review-tab-label">Self-Quiz</span><span class="tab-meta review-tab-meta">Check recall under test pacing</span></span></button>
+      <button class="tab-btn review-tab-btn" data-tab="checklist"><span class="tab-icon review-tab-icon">✅</span><span class="tab-copy review-tab-copy"><span class="tab-label review-tab-label">Checklist</span><span class="tab-meta review-tab-meta">Mark each objective complete</span></span></button>
+      <button class="tab-btn review-tab-btn" data-tab="progress"><span class="tab-icon review-tab-icon">📈</span><span class="tab-copy review-tab-copy"><span class="tab-label review-tab-label">Progress</span><span class="tab-meta review-tab-meta">Review history and best attempts</span></span></button>
     </nav>
     <div class="tab-fade-right" id="fade-right"></div>
   </div>
 
   <!-- TOPICS -->
   <div id="tab-topics" class="tab-content active">
-    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">01</span><span class="topic-title">Sets — Intervals, Union, Intersection</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><h4>Key Concepts</h4><ul><li><b>Set-builder notation</b>: e.g. <span class="k">\{x \mid x \geq 3\}</span></li><li><b>Interval notation</b>: brackets [ ] include; parentheses ( ) exclude</li><li><b>Union</b> <span class="k">A \cup B</span>: elements in <em>either</em> set</li><li><b>Intersection</b> <span class="k">A \cap B</span>: elements in <em>both</em> sets</li></ul><h4>Common Intervals</h4><div class="formula-box"><span class="k">[a, b] \quad (a, b) \quad [a, \infty) \quad (-\infty, b]</span></div><div class="tip-box">⚡ ∞ and −∞ always get parentheses, never brackets!</div><div class="video-embed-label">📺 Video Walkthroughs</div><a class="video-link" href="https://www.youtube.com/watch?v=lsvjiAsBZUM" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">How to Find the Intersection and Union of Two Intervals</div><div class="yt-sub">Interval notation with number line visuals</div></div></a><a class="video-link" href="https://www.youtube.com/watch?v=fezDDJij25U" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Intersection and Union of Discrete Sets</div><div class="yt-sub">Working with finite sets — listing elements in ∩ and ∪</div></div></a></div></div></div>
+    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">01</span><span class="topic-title">Sets — Intervals, Union, Intersection</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><h4>Key Concepts</h4><ul><li><b>Set-builder notation</b>: e.g. <span class="k">\{x \mid x \geq 3\}</span></li><li><b>Interval notation</b>: brackets [ ] include; parentheses ( ) exclude</li><li><b>Union</b> <span class="k">A \cup B</span>: elements in <em>either</em> set</li><li><b>Intersection</b> <span class="k">A \cap B</span>: elements in <em>both</em> sets</li></ul><h4>Common Intervals</h4><div class="formula-box review-formula-box"><span class="k">[a, b] \quad (a, b) \quad [a, \infty) \quad (-\infty, b]</span></div><div class="tip-box review-callout review-callout--tip">⚡ ∞ and −∞ always get parentheses, never brackets!</div><div class="video-embed-label">📺 Video Walkthroughs</div><a class="video-link review-video-link" href="https://www.youtube.com/watch?v=lsvjiAsBZUM" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">How to Find the Intersection and Union of Two Intervals</div><div class="yt-sub">Interval notation with number line visuals</div></div></a><a class="video-link review-video-link" href="https://www.youtube.com/watch?v=fezDDJij25U" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Intersection and Union of Discrete Sets</div><div class="yt-sub">Working with finite sets — listing elements in ∩ and ∪</div></div></a></div></div></div>
 
-    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">02</span><span class="topic-title">Absolute Value</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><h4>Key Concepts</h4><ul><li><span class="k">|a|</span> = distance from <span class="k">a</span> to 0 — always ≥ 0</li><li><span class="k">|a| = a</span> if <span class="k">a \geq 0</span>; <span class="k">|a| = -a</span> if <span class="k">a < 0</span></li></ul><div class="formula-box"><span class="k">|x| = c \implies x = c \text{ or } x = -c \quad(c \geq 0)</span></div><div class="tip-box">⚡ Remember: <span class="k">\sqrt{x^2} = |x|</span></div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link" href="https://youtube.com/shorts/alBGenaCn40" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Challenging Absolute Value Equations</div><div class="yt-sub">Quick walkthrough of tricky absolute value problems</div></div></a></div></div></div>
+    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">02</span><span class="topic-title">Absolute Value</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><h4>Key Concepts</h4><ul><li><span class="k">|a|</span> = distance from <span class="k">a</span> to 0 — always ≥ 0</li><li><span class="k">|a| = a</span> if <span class="k">a \geq 0</span>; <span class="k">|a| = -a</span> if <span class="k">a < 0</span></li></ul><div class="formula-box review-formula-box"><span class="k">|x| = c \implies x = c \text{ or } x = -c \quad(c \geq 0)</span></div><div class="tip-box review-callout review-callout--tip">⚡ Remember: <span class="k">\sqrt{x^2} = |x|</span></div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link review-video-link" href="https://youtube.com/shorts/alBGenaCn40" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Challenging Absolute Value Equations</div><div class="yt-sub">Quick walkthrough of tricky absolute value problems</div></div></a></div></div></div>
 
-    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">03</span><span class="topic-title">Exponents</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><h4>Core Laws</h4><ul><li><span class="k">a^m \cdot a^n = a^{m+n}</span></li><li><span class="k">\frac{a^m}{a^n} = a^{m-n}</span></li><li><span class="k">(a^m)^n = a^{mn}</span></li><li><span class="k">(ab)^n = a^n b^n</span></li><li><span class="k">a^{-n} = \frac{1}{a^n}</span></li></ul><div class="tip-box">⚡ Write all final answers with <b>positive exponents only</b>.</div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link" href="https://youtu.be/o2B0IohGKNI" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Rational Exponents with a Few Examples</div><div class="yt-sub">Converting between radicals and fractional exponents</div></div></a></div></div></div>
+    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">03</span><span class="topic-title">Exponents</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><h4>Core Laws</h4><ul><li><span class="k">a^m \cdot a^n = a^{m+n}</span></li><li><span class="k">\frac{a^m}{a^n} = a^{m-n}</span></li><li><span class="k">(a^m)^n = a^{mn}</span></li><li><span class="k">(ab)^n = a^n b^n</span></li><li><span class="k">a^{-n} = \frac{1}{a^n}</span></li></ul><div class="tip-box review-callout review-callout--tip">⚡ Write all final answers with <b>positive exponents only</b>.</div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link review-video-link" href="https://youtu.be/o2B0IohGKNI" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Rational Exponents with a Few Examples</div><div class="yt-sub">Converting between radicals and fractional exponents</div></div></a></div></div></div>
 
-    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">04</span><span class="topic-title">Factoring</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><h4>Methods (always start with GCF!)</h4><ul><li><b>GCF</b> — always factor out first</li><li><b>Grouping</b> — split into pairs</li><li><b>Difference of squares</b>: <span class="k">a^2 - b^2 = (a-b)(a+b)</span></li><li><b>Difference of cubes</b>: <span class="k">a^3 - b^3 = (a-b)(a^2+ab+b^2)</span></li><li><b>Sum of cubes</b>: <span class="k">a^3 + b^3 = (a+b)(a^2-ab+b^2)</span></li><li><b>Trinomials</b>: find two numbers that multiply to <span class="k">ac</span> and add to <span class="k">b</span></li></ul><div class="tip-box">⚡ Mnemonic for cubes: "SOAP" — Same, Opposite, Always Positive.</div><div class="video-embed-label">📺 Video Walkthroughs</div><a class="video-link" href="https://youtu.be/-CyiqgtA2_U" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Factor a Quadratic with Lead Coefficient = 1</div><div class="yt-sub">Finding two numbers that multiply and add correctly</div></div></a><a class="video-link" href="https://youtu.be/5aPaldvXCmw" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">How to Factor Quadratics with a Lead Coefficient</div><div class="yt-sub">AC method for trinomials when a ≠ 1</div></div></a><a class="video-link" href="https://youtu.be/7GQvKh6Tmgk" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">How to Solve Quadratics by Factoring</div><div class="yt-sub">GCF, trinomials without &amp; with lead coefficients</div></div></a></div></div></div>
+    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">04</span><span class="topic-title">Factoring</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><h4>Methods (always start with GCF!)</h4><ul><li><b>GCF</b> — always factor out first</li><li><b>Grouping</b> — split into pairs</li><li><b>Difference of squares</b>: <span class="k">a^2 - b^2 = (a-b)(a+b)</span></li><li><b>Difference of cubes</b>: <span class="k">a^3 - b^3 = (a-b)(a^2+ab+b^2)</span></li><li><b>Sum of cubes</b>: <span class="k">a^3 + b^3 = (a+b)(a^2-ab+b^2)</span></li><li><b>Trinomials</b>: find two numbers that multiply to <span class="k">ac</span> and add to <span class="k">b</span></li></ul><div class="tip-box review-callout review-callout--tip">⚡ Mnemonic for cubes: "SOAP" — Same, Opposite, Always Positive.</div><div class="video-embed-label">📺 Video Walkthroughs</div><a class="video-link review-video-link" href="https://youtu.be/-CyiqgtA2_U" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Factor a Quadratic with Lead Coefficient = 1</div><div class="yt-sub">Finding two numbers that multiply and add correctly</div></div></a><a class="video-link review-video-link" href="https://youtu.be/5aPaldvXCmw" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">How to Factor Quadratics with a Lead Coefficient</div><div class="yt-sub">AC method for trinomials when a ≠ 1</div></div></a><a class="video-link review-video-link" href="https://youtu.be/7GQvKh6Tmgk" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">How to Solve Quadratics by Factoring</div><div class="yt-sub">GCF, trinomials without &amp; with lead coefficients</div></div></a></div></div></div>
 
-    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">05</span><span class="topic-title">Operations with Fractions & Rational Expressions</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><ul><li><b>Always factor first</b></li><li><b>Add/subtract</b>: find LCD, rewrite, combine numerators</li><li><b>Multiply</b>: factor → cancel → multiply</li><li><b>Divide</b>: flip second fraction → multiply</li></ul><div class="tip-box">⚡ Factor first! This is the #1 mistake on rational expression problems.</div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link" href="https://youtu.be/LH40X-gPLOw" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Solving Rational Equations</div><div class="yt-sub">Finding LCD, clearing fractions, checking for extraneous solutions</div></div></a></div></div></div>
+    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">05</span><span class="topic-title">Operations with Fractions & Rational Expressions</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><ul><li><b>Always factor first</b></li><li><b>Add/subtract</b>: find LCD, rewrite, combine numerators</li><li><b>Multiply</b>: factor → cancel → multiply</li><li><b>Divide</b>: flip second fraction → multiply</li></ul><div class="tip-box review-callout review-callout--tip">⚡ Factor first! This is the #1 mistake on rational expression problems.</div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link review-video-link" href="https://youtu.be/LH40X-gPLOw" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Solving Rational Equations</div><div class="yt-sub">Finding LCD, clearing fractions, checking for extraneous solutions</div></div></a></div></div></div>
 
-    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">06</span><span class="topic-title">Equations — Linear & Quadratic</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><h4>Linear</h4><ul><li>Distribute, combine like terms, isolate variable</li><li>With fractions: multiply by LCD</li><li>Watch for no solution or all reals</li></ul><h4>Quadratic</h4><ul><li>Factor or use quadratic formula</li><li>Rational equations: check for extraneous solutions!</li></ul><div class="formula-box"><span class="k">x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}</span></div><div class="video-embed-label">📺 Video Walkthroughs</div><a class="video-link" href="https://youtu.be/7GQvKh6Tmgk" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">How to Solve Quadratics by Factoring</div><div class="yt-sub">GCF, trinomials without &amp; with lead coefficients</div></div></a><a class="video-link" href="https://youtu.be/LH40X-gPLOw" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Solving Rational Equations</div><div class="yt-sub">Finding LCD, clearing fractions, checking for extraneous solutions</div></div></a></div></div></div>
+    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">06</span><span class="topic-title">Equations — Linear & Quadratic</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><h4>Linear</h4><ul><li>Distribute, combine like terms, isolate variable</li><li>With fractions: multiply by LCD</li><li>Watch for no solution or all reals</li></ul><h4>Quadratic</h4><ul><li>Factor or use quadratic formula</li><li>Rational equations: check for extraneous solutions!</li></ul><div class="formula-box review-formula-box"><span class="k">x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}</span></div><div class="video-embed-label">📺 Video Walkthroughs</div><a class="video-link review-video-link" href="https://youtu.be/7GQvKh6Tmgk" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">How to Solve Quadratics by Factoring</div><div class="yt-sub">GCF, trinomials without &amp; with lead coefficients</div></div></a><a class="video-link review-video-link" href="https://youtu.be/LH40X-gPLOw" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Solving Rational Equations</div><div class="yt-sub">Finding LCD, clearing fractions, checking for extraneous solutions</div></div></a></div></div></div>
 
-    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">07</span><span class="topic-title">Midpoint & Distance Formula</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><div class="formula-box"><span class="k">\text{Midpoint} = \left(\frac{x_1+x_2}{2},\frac{y_1+y_2}{2}\right)</span></div><div class="formula-box"><span class="k">d = \sqrt{(x_2-x_1)^2+(y_2-y_1)^2}</span></div><div class="tip-box">⚡ Round to one decimal place when instructed!</div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link" href="https://www.youtube.com/watch?v=dxskClJTbPQ" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Midpoint &amp; Distance Formula</div><div class="yt-sub">Step-by-step examples with coordinate pairs</div></div></a></div></div></div>
+    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">07</span><span class="topic-title">Midpoint & Distance Formula</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><div class="formula-box review-formula-box"><span class="k">\text{Midpoint} = \left(\frac{x_1+x_2}{2},\frac{y_1+y_2}{2}\right)</span></div><div class="formula-box review-formula-box"><span class="k">d = \sqrt{(x_2-x_1)^2+(y_2-y_1)^2}</span></div><div class="tip-box review-callout review-callout--tip">⚡ Round to one decimal place when instructed!</div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link review-video-link" href="https://www.youtube.com/watch?v=dxskClJTbPQ" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Midpoint &amp; Distance Formula</div><div class="yt-sub">Step-by-step examples with coordinate pairs</div></div></a></div></div></div>
 
-    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">08</span><span class="topic-title">Equation of a Circle</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><div class="formula-box"><span class="k">(x-h)^2 + (y-k)^2 = r^2</span></div><p>Center = <span class="k">(h,k)</span>, Radius = <span class="k">r</span></p><div class="tip-box">⚡ Right side is r², not r. Radius 5 → write 25.</div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link" href="https://youtu.be/golqytjtN-c?si=PLdB6fAKGrhVcuZo" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Standard Equation of a Circle Formula Explained!</div><div class="yt-sub">Center, radius, and writing the equation step by step</div></div></a></div></div></div>
+    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">08</span><span class="topic-title">Equation of a Circle</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><div class="formula-box review-formula-box"><span class="k">(x-h)^2 + (y-k)^2 = r^2</span></div><p>Center = <span class="k">(h,k)</span>, Radius = <span class="k">r</span></p><div class="tip-box review-callout review-callout--tip">⚡ Right side is r², not r. Radius 5 → write 25.</div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link review-video-link" href="https://youtu.be/golqytjtN-c?si=PLdB6fAKGrhVcuZo" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Standard Equation of a Circle Formula Explained!</div><div class="yt-sub">Center, radius, and writing the equation step by step</div></div></a></div></div></div>
 
-    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">09</span><span class="topic-title">Lines — Slope, Forms, Parallel & Perpendicular</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><ul><li><b>Slope-intercept</b>: <span class="k">y = mx + b</span></li><li><b>Point-slope</b>: <span class="k">y - y_1 = m(x - x_1)</span></li><li><b>General</b>: <span class="k">Ax + By + C = 0</span></li></ul><div class="formula-box"><span class="k">\text{Parallel: } m_1 = m_2 \qquad \text{Perp: } m_1 \cdot m_2 = -1</span></div><div class="tip-box">⚡ Perpendicular: flip and negate. Slope 3 → perp slope −1/3.</div><div class="video-embed-label">📺 Video Walkthroughs</div><a class="video-link" href="https://www.youtube.com/watch?v=4umbDjZ2R1I" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Slope Intercept vs Point Slope Form</div><div class="yt-sub">When to use each form and converting between them</div></div></a><a class="video-link" href="https://www.youtube.com/watch?v=acsR7w0I__w" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Finding Slopes of Parallel and Perpendicular Lines</div><div class="yt-sub">Identifying slopes and graphing parallel &amp; perpendicular lines</div></div></a></div></div></div>
+    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">09</span><span class="topic-title">Lines — Slope, Forms, Parallel & Perpendicular</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><ul><li><b>Slope-intercept</b>: <span class="k">y = mx + b</span></li><li><b>Point-slope</b>: <span class="k">y - y_1 = m(x - x_1)</span></li><li><b>General</b>: <span class="k">Ax + By + C = 0</span></li></ul><div class="formula-box review-formula-box"><span class="k">\text{Parallel: } m_1 = m_2 \qquad \text{Perp: } m_1 \cdot m_2 = -1</span></div><div class="tip-box review-callout review-callout--tip">⚡ Perpendicular: flip and negate. Slope 3 → perp slope −1/3.</div><div class="video-embed-label">📺 Video Walkthroughs</div><a class="video-link review-video-link" href="https://www.youtube.com/watch?v=4umbDjZ2R1I" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Slope Intercept vs Point Slope Form</div><div class="yt-sub">When to use each form and converting between them</div></div></a><a class="video-link review-video-link" href="https://www.youtube.com/watch?v=acsR7w0I__w" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">Finding Slopes of Parallel and Perpendicular Lines</div><div class="yt-sub">Identifying slopes and graphing parallel &amp; perpendicular lines</div></div></a></div></div></div>
 
-    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">10</span><span class="topic-title">Maximum/Minimum of a Quadratic — Vertex</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><div class="formula-box"><span class="k">x = -\frac{b}{2a}</span></div><p>Plug back into <span class="k">f(x)</span> for the max/min <b>value</b>.</p><ul><li><span class="k">a > 0</span> → minimum</li><li><span class="k">a < 0</span> → maximum</li></ul><div class="tip-box">⚡ The question usually wants the y-value (height, etc.), not the x-value.</div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link" href="https://www.youtube.com/watch?v=ygH-Y5YG5kE" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">How to Find the Vertex of a Parabola</div><div class="yt-sub">NancyPi — clear walkthrough of the vertex formula</div></div></a></div></div></div>
+    <div class="topic-card"><button class="topic-header topic-toggle" type="button"><span class="topic-number">10</span><span class="topic-title">Maximum/Minimum of a Quadratic — Vertex</span><span class="topic-chevron">▼</span></button><div class="topic-body"><div class="topic-content"><div class="formula-box review-formula-box"><span class="k">x = -\frac{b}{2a}</span></div><p>Plug back into <span class="k">f(x)</span> for the max/min <b>value</b>.</p><ul><li><span class="k">a > 0</span> → minimum</li><li><span class="k">a < 0</span> → maximum</li></ul><div class="tip-box review-callout review-callout--tip">⚡ The question usually wants the y-value (height, etc.), not the x-value.</div><div class="video-embed-label">📺 Video Walkthrough</div><a class="video-link review-video-link" href="https://www.youtube.com/watch?v=ygH-Y5YG5kE" target="_blank" rel="noopener" onclick="event.stopPropagation()"><div class="yt-icon"></div><div class="yt-info"><div class="yt-title">How to Find the Vertex of a Parabola</div><div class="yt-sub">NancyPi — clear walkthrough of the vertex formula</div></div></a></div></div></div>
   </div>
 
   <!-- FORMULAS -->
   <div id="tab-formulas" class="tab-content">
     <button class="print-btn" onclick="window.print()">🖨️ Print Formula Sheet</button>
 
-    <div class="formula-section"><h3>📐 Core Algebra</h3><div class="formula-grid">
-      <div class="formula-item"><div class="label">Difference of Squares</div><div class="formula-box"><span class="k">a^2-b^2=(a-b)(a+b)</span></div></div>
-      <div class="formula-item"><div class="label">Difference of Cubes</div><div class="formula-box"><span class="k">a^3-b^3=(a-b)(a^2+ab+b^2)</span></div></div>
-      <div class="formula-item"><div class="label">Sum of Cubes</div><div class="formula-box"><span class="k">a^3+b^3=(a+b)(a^2-ab+b^2)</span></div></div>
-      <div class="formula-item"><div class="label">Quadratic Formula</div><div class="formula-box"><span class="k">x=\frac{-b \pm \sqrt{b^2-4ac}}{2a}</span></div></div>
+    <div class="formula-section review-formula-section"><h3>📐 Core Algebra</h3><div class="formula-grid">
+      <div class="formula-item"><div class="label">Difference of Squares</div><div class="formula-box review-formula-box"><span class="k">a^2-b^2=(a-b)(a+b)</span></div></div>
+      <div class="formula-item"><div class="label">Difference of Cubes</div><div class="formula-box review-formula-box"><span class="k">a^3-b^3=(a-b)(a^2+ab+b^2)</span></div></div>
+      <div class="formula-item"><div class="label">Sum of Cubes</div><div class="formula-box review-formula-box"><span class="k">a^3+b^3=(a+b)(a^2-ab+b^2)</span></div></div>
+      <div class="formula-item"><div class="label">Quadratic Formula</div><div class="formula-box review-formula-box"><span class="k">x=\frac{-b \pm \sqrt{b^2-4ac}}{2a}</span></div></div>
     </div></div>
 
-    <div class="formula-section"><h3>📏 Coordinate Geometry</h3><div class="formula-grid">
-      <div class="formula-item"><div class="label">Midpoint</div><div class="formula-box"><span class="k">M=\left(\frac{x_1+x_2}{2},\frac{y_1+y_2}{2}\right)</span></div></div>
-      <div class="formula-item"><div class="label">Distance</div><div class="formula-box"><span class="k">d=\sqrt{(x_2-x_1)^2+(y_2-y_1)^2}</span></div></div>
-      <div class="formula-item"><div class="label">Slope</div><div class="formula-box"><span class="k">m=\frac{y_2-y_1}{x_2-x_1}</span></div></div>
-      <div class="formula-item"><div class="label">Circle</div><div class="formula-box"><span class="k">(x-h)^2+(y-k)^2=r^2</span></div></div>
+    <div class="formula-section review-formula-section"><h3>📏 Coordinate Geometry</h3><div class="formula-grid">
+      <div class="formula-item"><div class="label">Midpoint</div><div class="formula-box review-formula-box"><span class="k">M=\left(\frac{x_1+x_2}{2},\frac{y_1+y_2}{2}\right)</span></div></div>
+      <div class="formula-item"><div class="label">Distance</div><div class="formula-box review-formula-box"><span class="k">d=\sqrt{(x_2-x_1)^2+(y_2-y_1)^2}</span></div></div>
+      <div class="formula-item"><div class="label">Slope</div><div class="formula-box review-formula-box"><span class="k">m=\frac{y_2-y_1}{x_2-x_1}</span></div></div>
+      <div class="formula-item"><div class="label">Circle</div><div class="formula-box review-formula-box"><span class="k">(x-h)^2+(y-k)^2=r^2</span></div></div>
     </div></div>
 
-    <div class="formula-section"><h3>📈 Lines</h3><div class="formula-grid">
-      <div class="formula-item"><div class="label">Point-Slope</div><div class="formula-box"><span class="k">y-y_1=m(x-x_1)</span></div></div>
-      <div class="formula-item"><div class="label">Slope-Intercept</div><div class="formula-box"><span class="k">y=mx+b</span></div></div>
-      <div class="formula-item"><div class="label">Parallel</div><div class="formula-box"><span class="k">m_1=m_2</span></div></div>
-      <div class="formula-item"><div class="label">Perpendicular</div><div class="formula-box"><span class="k">m_1 \cdot m_2=-1</span></div></div>
+    <div class="formula-section review-formula-section"><h3>📈 Lines</h3><div class="formula-grid">
+      <div class="formula-item"><div class="label">Point-Slope</div><div class="formula-box review-formula-box"><span class="k">y-y_1=m(x-x_1)</span></div></div>
+      <div class="formula-item"><div class="label">Slope-Intercept</div><div class="formula-box review-formula-box"><span class="k">y=mx+b</span></div></div>
+      <div class="formula-item"><div class="label">Parallel</div><div class="formula-box review-formula-box"><span class="k">m_1=m_2</span></div></div>
+      <div class="formula-item"><div class="label">Perpendicular</div><div class="formula-box review-formula-box"><span class="k">m_1 \cdot m_2=-1</span></div></div>
     </div></div>
 
-    <div class="formula-section"><h3>⛰️ Quadratic Vertex</h3><div class="formula-grid">
-      <div class="formula-item"><div class="label">Vertex x-coordinate</div><div class="formula-box"><span class="k">x=-\frac{b}{2a}</span></div></div>
-      <div class="formula-item"><div class="label">Rule</div><div class="formula-box" style="font-family:'DM Sans';font-size:0.85rem;color:var(--text-muted)">a &gt; 0 → min | a &lt; 0 → max</div></div>
+    <div class="formula-section review-formula-section"><h3>⛰️ Quadratic Vertex</h3><div class="formula-grid">
+      <div class="formula-item"><div class="label">Vertex x-coordinate</div><div class="formula-box review-formula-box"><span class="k">x=-\frac{b}{2a}</span></div></div>
+      <div class="formula-item"><div class="label">Rule</div><div class="formula-box review-formula-box" style="font-family:'DM Sans';font-size:0.85rem;color:var(--text-muted)">a &gt; 0 → min | a &lt; 0 → max</div></div>
     </div></div>
 
-    <div class="formula-section"><h3>🔢 Exponent Rules</h3><div class="formula-grid">
-      <div class="formula-item"><div class="label">Product</div><div class="formula-box"><span class="k">a^m \cdot a^n=a^{m+n}</span></div></div>
-      <div class="formula-item"><div class="label">Quotient</div><div class="formula-box"><span class="k">\frac{a^m}{a^n}=a^{m-n}</span></div></div>
-      <div class="formula-item"><div class="label">Power</div><div class="formula-box"><span class="k">(a^m)^n=a^{mn}</span></div></div>
-      <div class="formula-item"><div class="label">Negative</div><div class="formula-box"><span class="k">a^{-n}=\frac{1}{a^n}</span></div></div>
+    <div class="formula-section review-formula-section"><h3>🔢 Exponent Rules</h3><div class="formula-grid">
+      <div class="formula-item"><div class="label">Product</div><div class="formula-box review-formula-box"><span class="k">a^m \cdot a^n=a^{m+n}</span></div></div>
+      <div class="formula-item"><div class="label">Quotient</div><div class="formula-box review-formula-box"><span class="k">\frac{a^m}{a^n}=a^{m-n}</span></div></div>
+      <div class="formula-item"><div class="label">Power</div><div class="formula-box review-formula-box"><span class="k">(a^m)^n=a^{mn}</span></div></div>
+      <div class="formula-item"><div class="label">Negative</div><div class="formula-box review-formula-box"><span class="k">a^{-n}=\frac{1}{a^n}</span></div></div>
     </div></div>
   </div>
 
@@ -603,7 +521,7 @@ function revealPS(){
   if(practiceSolShown)return;practiceSolShown=true;
   const pi=practiceQueue[practiceIdx],p=allProblems[pi];
   document.getElementById('psol').classList.add('show');
-  const warnHtml=p.warning?'<div class="warning-box"><b>Watch out:</b> '+p.warning+'</div>':'';
+  const warnHtml=p.warning?'<div class="warning-box review-callout review-callout--warning"><b>Watch out:</b> '+p.warning+'</div>':'';
   document.getElementById('pbtns').innerHTML='<button class="practice-action-btn got-it" onclick="pGot()">✓ Got It</button><button class="practice-action-btn missed" onclick="pMiss()">✗ Missed It</button>'+warnHtml;
   setTimeout(renderMath,50);
 }

--- a/130Test2.html
+++ b/130Test2.html
@@ -16,233 +16,7 @@
 <!-- Icons -->
 <script defer="" src="https://cdn.jsdelivr.net/npm/lucide@0.344.0/dist/umd/lucide.min.js"></script>
 <style>
-        :root {
-            /* Dark Theme (Default) */
-            --bg: #0f1117; 
-            --surface: #181a24; 
-            --surface2: #1f2233; 
-            --border: #2a2d42;
-            --text: #e2e4ef; 
-            --text-muted: #8b8fa8;
-            --accent: #6c63ff; 
-            --accent-glow: rgba(108, 99, 255, 0.25);
-            --accent-hover: #5a52d5;
-            --green: #34d399; 
-            --green-bg: rgba(52, 211, 153, 0.1);
-            --amber: #fbbf24; 
-            --amber-bg: rgba(251, 191, 36, 0.1);
-            --red: #f87171; 
-            --red-bg: rgba(248, 113, 113, 0.1);
-            --shadow: 0 8px 32px rgba(0,0,0,0.3);
-            --radius: 16px;
-        }
-
-        body.light {
-            /* Light Theme */
-            --bg: #f8fafc; 
-            --surface: #ffffff; 
-            --surface2: #f1f5f9; 
-            --border: #e2e8f0;
-            --text: #0f172a; 
-            --text-muted: #64748b;
-            --accent: #5b52e0;
-            --accent-glow: rgba(91, 82, 224, 0.12);
-            --accent-hover: #4a42c0;
-            --green: #059669;
-            --green-bg: rgba(5, 150, 105, 0.08);
-            --amber: #d97706;
-            --amber-bg: rgba(217, 119, 6, 0.08);
-            --red: #dc2626;
-            --red-bg: rgba(220, 38, 38, 0.08);
-            --shadow: 0 8px 32px rgba(0,0,0,0.06);
-        }
-
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        
-        body {
-            font-family: 'DM Sans', sans-serif;
-            background-color: var(--bg);
-            color: var(--text);
-            line-height: 1.6;
-            transition: background-color 0.3s, color 0.3s;
-            min-height: 100vh;
-        }
-
-        .container {
-            max-width: 1000px;
-            margin: 0 auto;
-            padding: 2rem;
-        }
-        /* Header */
-        header {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-start;
-            gap: 1rem;
-            margin-bottom: 1.6rem;
-            padding-bottom: 1rem;
-            border-bottom: 1px solid var(--border);
-        }
-
-        h1, h2, h3 { font-family: 'DM Serif Display', serif; font-weight: 400; }
-        h1 { font-size: 2.35rem; color: var(--accent); line-height: 1.05; }
-        h2 { font-size: 1.8rem; margin-bottom: 1.5rem; }
-
-        .header-copy {
-            max-width: 42rem;
-        }
-
-        .header-meta {
-            color: var(--text-muted);
-            margin-top: 0.35rem;
-            font-weight: 600;
-            letter-spacing: 0.01em;
-        }
-
-        .header-subtitle {
-            color: var(--text-muted);
-            margin-top: 0.12rem;
-            font-size: 0.95rem;
-        }
-
-        .header-chips {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.6rem;
-            margin-top: 0.75rem;
-        }
-
-        .header-chip {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.45rem;
-            padding: 0.42rem 0.75rem;
-            border-radius: 999px;
-            border: 1px solid var(--border);
-            background: var(--surface);
-            color: var(--text-muted);
-            font-size: 0.82rem;
-            font-weight: 600;
-            line-height: 1;
-        }
-
-        .header-chip i {
-            width: 0.9rem;
-            height: 0.9rem;
-            color: var(--accent);
-            flex-shrink: 0;
-        }
-
-        .header-chip.accent {
-            background: var(--accent-glow);
-            border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
-            color: var(--text);
-        }
-        
-        .theme-toggle {
-            background: var(--surface2);
-            border: 1px solid var(--border);
-            color: var(--text);
-            padding: 0.75rem;
-            border-radius: 50%;
-            cursor: pointer;
-            transition: all 0.2s;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            flex-shrink: 0;
-        }
-        
-        .theme-toggle:hover {
-            background: var(--border);
-            transform: scale(1.05);
-        }
-
-        /* Dashboard Navigation */
-        .tabs {
-            display: grid;
-            grid-template-columns: repeat(3, minmax(0, 1fr));
-            gap: 0.75rem;
-            margin-bottom: 1.1rem;
-        }
-
-        .tab-btn {
-            background: linear-gradient(180deg, var(--surface), var(--surface2));
-            border: 1px solid var(--border);
-            color: var(--text);
-            padding: 0.85rem 0.95rem;
-            border-radius: 16px;
-            font-family: 'DM Sans', sans-serif;
-            font-size: 1rem;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.2s ease;
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-            text-align: left;
-            min-height: 78px;
-            box-shadow: 0 6px 18px rgba(0,0,0,0.06);
-        }
-
-        .tab-btn:hover {
-            transform: translateY(-2px);
-            border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
-            box-shadow: 0 10px 24px rgba(0,0,0,0.10);
-        }
-
-        .tab-btn.active {
-            background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 14%, var(--surface)), var(--surface));
-            border-color: var(--accent);
-            box-shadow: 0 10px 24px var(--accent-glow);
-        }
-
-        .tab-btn.priority {
-            position: relative;
-        }
-
-        .tab-btn.priority::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 18px;
-            right: 18px;
-            height: 3px;
-            border-radius: 999px;
-            background: linear-gradient(90deg, var(--accent), transparent);
-            opacity: 0.85;
-        }
-
-        .tab-icon-wrap {
-            width: 38px;
-            height: 38px;
-            border-radius: 11px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            background: color-mix(in srgb, var(--accent) 12%, var(--surface2));
-            color: var(--accent);
-            flex-shrink: 0;
-        }
-
-        .tab-btn.active .tab-icon-wrap {
-            background: color-mix(in srgb, var(--accent) 18%, var(--surface2));
-            color: var(--accent);
-        }
-
-        .tab-copy {
-            display: flex;
-            flex-direction: column;
-            gap: 0;
-            min-width: 0;
-        }
-
-        .tab-label {
-            font-weight: 700;
-            color: var(--text);
-            line-height: 1.2;
-            font-size: 0.98rem;
-        }
+        /* Page-specific styles only; shared Math 130 review tokens/components live in styles.css. */
 
         /* Cards */
         .card {
@@ -988,7 +762,7 @@
 
 
 </head>
-<body>
+<body class="review-page">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
@@ -1019,16 +793,16 @@
           </ul>
         </li>
       </ul>
-      <button aria-label="Toggle dark and light theme" class="theme-toggle" id="theme-toggle-btn" title="Toggle Theme">
+      <button aria-label="Toggle dark and light theme" class="theme-toggle review-theme-toggle" id="theme-toggle-btn" title="Toggle Theme">
         <i data-lucide="moon"></i>
       </button>
     </div>
   </div>
 </nav>
 
-<div class="container">
-<header>
-<div class="header-copy">
+<div class="container review-shell">
+<header class="review-header">
+<div class="header-copy review-title-group">
 <nav class="breadcrumb" aria-label="Breadcrumb">
 <a href="index.html">Home</a>
 <span aria-hidden="true" class="breadcrumb-sep">›</span>
@@ -1040,54 +814,54 @@
 </nav>
 <h1>Math 130 – Test 2 Review</h1>
 <p class="header-meta">Spring 2026 | Prof. Young &amp; Prof. Volk</p>
-<p class="header-subtitle">Topics: Geometry, Exponentials &amp; Logarithms</p>
-<div class="header-chips">
-<span class="header-chip accent"><i data-lucide="route"></i> Recommended order: Slides → Formulas → Practice</span>
-<span class="header-chip"><i data-lucide="calendar-clock"></i> Test 2: Mon, Mar 30</span>
+<p class="header-subtitle review-subtitle">Topics: Geometry, Exponentials &amp; Logarithms</p>
+<div class="header-chips review-meta-chips">
+<span class="header-chip review-chip accent is-accent"><i data-lucide="route"></i> Recommended order: Slides → Formulas → Practice</span>
+<span class="header-chip review-chip"><i data-lucide="calendar-clock"></i> Test 2: Mon, Mar 30</span>
 </div>
 </div>
 </header>
-<div aria-label="Review tool sections" class="tabs" role="tablist">
-<button class="tab-btn active priority" data-tab="slides">
-<span class="tab-icon-wrap"><i data-lucide="monitor"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Slides</span>
+<div aria-label="Review tool sections" class="tabs review-tabs review-tabs-3" role="tablist">
+<button class="tab-btn review-tab-btn active priority" data-tab="slides">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="monitor"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Slides</span>
 </span>
         </button>
-<button class="tab-btn priority" data-tab="formulas">
-<span class="tab-icon-wrap"><i data-lucide="sigma"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Formulas</span>
+<button class="tab-btn review-tab-btn priority" data-tab="formulas">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="sigma"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Formulas</span>
 </span>
         </button>
-<button class="tab-btn priority" data-tab="practice">
-<span class="tab-icon-wrap"><i data-lucide="pen-tool"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Practice</span>
+<button class="tab-btn review-tab-btn priority" data-tab="practice">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="pen-tool"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Practice</span>
 </span>
         </button>
-<button class="tab-btn" data-tab="videos">
-<span class="tab-icon-wrap"><i data-lucide="play-circle"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Videos</span>
+<button class="tab-btn review-tab-btn" data-tab="videos">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="play-circle"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Videos</span>
 </span>
         </button>
-<button class="tab-btn" data-tab="schedule">
-<span class="tab-icon-wrap"><i data-lucide="calendar"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Schedule</span>
+<button class="tab-btn review-tab-btn" data-tab="schedule">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="calendar"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Schedule</span>
 </span>
         </button>
-<button class="tab-btn" data-tab="progress">
-<span class="tab-icon-wrap"><i data-lucide="bar-chart-2"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Progress</span>
+<button class="tab-btn review-tab-btn" data-tab="progress">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="bar-chart-2"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Progress</span>
 </span>
         </button>
 </div>
 <!-- SCHEDULE TAB -->
 <div class="tab-content" id="tab-schedule">
-<div class="card">
+<div class="card review-card">
 <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; margin-bottom: 1.5rem;">
 <h2 style="margin-bottom: 0;">Course Schedule</h2>
 <div id="exam-countdown" style="background: var(--red-bg); border: 1px solid var(--red); color: var(--red); padding: 0.5rem 1rem; border-radius: 12px; font-weight: 600; font-family: 'JetBrains Mono', monospace; font-size: 0.95rem;"></div>
@@ -1198,7 +972,7 @@
 </table>
 </div>
 </div>
-<div class="card">
+<div class="card review-card">
 <h2>ALEKS Modules</h2>
 <div style="overflow-x: auto;">
 <table class="history-table">
@@ -1236,7 +1010,7 @@
 </div>
 <!-- FORMULAS TAB -->
 <div class="tab-content" id="tab-formulas">
-<div class="card">
+<div class="card review-card">
 <h2>Essential Formulas for Test 2</h2>
 <p style="color: var(--text-muted); margin-bottom: 1rem; font-weight: 500;">
                 Covers formulas relevant to Sections 4.2, 4.3, and the Test 2 geometry topics.
@@ -1250,7 +1024,7 @@
 <div class="legend-chip legend-useful">Useful relation</div>
 </div>
 </div>
-<div class="checklist-section">
+<div class="checklist-section review-checklist-section">
 <h3>Section 4.2: Exponentials &amp; Interest</h3>
 <div class="formula-section-note">Focus: recognize the two provided interest formulas and when each model is used.</div>
 <div class="formula-grid">
@@ -1274,7 +1048,7 @@
 </div>
 </div>
 </div>
-<div class="checklist-section" style="margin-top: 2rem;">
+<div class="checklist-section review-checklist-section review-stack-gap">
 <h3>Section 4.3: Logarithms</h3>
 <div class="formula-section-note">Focus: memorize log-to-exponential conversion, inverse log equations, and change of base. The log property rules are support only.</div>
 <div class="formula-grid">
@@ -1316,7 +1090,7 @@
 </div>
 </div>
 </div>
-<div class="checklist-section" style="margin-top: 2rem;">
+<div class="checklist-section review-checklist-section review-stack-gap">
 <h3>Geometry: Polygons &amp; Area</h3>
 <div class="formula-section-note">Focus: triangle area, trapezoid area, proportional segments, and Heron's formula as a provided reference.</div>
 <div class="formula-grid">
@@ -1352,7 +1126,7 @@
 </div>
 </div>
 </div>
-<div class="checklist-section" style="margin-top: 2rem;">
+<div class="checklist-section review-checklist-section review-stack-gap">
 <h3>Geometry: Angle, Arc, and Circle Relationships</h3>
 <div class="formula-section-note">Focus: DMS conversions, radian-degree conversion, arc and sector formulas, circle angle theorems, and linear speed.</div>
 <div class="formula-grid">
@@ -1428,14 +1202,14 @@
 </div>
 <!-- PRACTICE TAB -->
 <div class="tab-content" id="tab-practice">
-<div class="card">
+<div class="card review-card">
 <h2 style="text-align: center; margin-bottom: 0.5rem;">Practice Generators</h2>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Practice generators are live for Test 2 topics and aligned to Sections 4.2, 4.3, and the geometry material covered before the exam.</p>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">By default, enter decimal answers rounded as directed. Repeating decimals are accepted within tolerance (for example, $0.3333$ for $0.\overline{3}$). Some generators may allow additional formats noted in the question (for example, $\pi$ forms).</p>
 <p id="coverage-audit" style="text-align: center; color: var(--text-muted); margin-bottom: 2rem; font-size: 0.9rem;"></p>
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Select a topic to generate infinite, exam-style questions.</p>
 <!-- Mock Exam CTA -->
-<div id="exam-cta" style="background: linear-gradient(135deg, var(--accent-glow), var(--red-bg)); border: 2px solid var(--accent); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem; text-align: center;">
+<div id="exam-cta" class="review-callout review-callout--exam">
 <h3 style="font-family: 'DM Serif Display', serif; font-size: 1.4rem; margin-bottom: 0.5rem;">🎯 Mock Exam Mode</h3>
 <p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.95rem;">20 exam-matched questions weighted like the real test: ~15% Section 4.2, ~15% Section 4.3, ~70% Geometry. Includes a compound interest table and a multi-part circle theorem problem.</p>
 <button class="btn-primary" id="btn-start-exam" onclick="startMockExam()">Start Mock Exam</button>
@@ -1469,12 +1243,12 @@
 <span id="exam-mode-label" style="font-weight: 600; color: var(--accent);">Mock Exam</span>
 <span id="exam-progress-label" style="font-family: 'JetBrains Mono', monospace; color: var(--text-muted); font-size: 0.9rem;">1 / 15</span>
 </div>
-<div class="progress-bar-track" style="height: 10px;">
-<div class="progress-bar-fill" id="exam-progress-fill" style="width: 0%; transition: width 0.4s ease;"></div>
+<div class="progress-bar-track review-progress-track" style="height: 10px;">
+<div class="progress-bar-fill review-progress-fill" id="exam-progress-fill" style="width: 0%; transition: width 0.4s ease;"></div>
 </div>
 </div>
 <!-- Exam Results (hidden until complete) -->
-<div class="card" id="exam-results" style="display: none;">
+<div class="card review-card" id="exam-results" style="display: none;">
 <h2 style="text-align: center;">📊 Exam Results</h2>
 <div id="exam-score-display" style="text-align: center; font-size: 3rem; font-family: 'JetBrains Mono', monospace; color: var(--accent); margin: 1rem 0;"></div>
 <div id="exam-breakdown" style="margin-top: 1rem;"></div>
@@ -1501,12 +1275,12 @@
 </div>
 <!-- CHECKLIST & PROGRESS TAB -->
 <div class="tab-content" id="tab-progress">
-<div class="card">
+<div class="card review-card">
 <h2>Topics Checklist</h2>
 <div class="progress-summary" id="progress-summary"></div>
 <div id="checklist-container"></div>
 </div>
-<div class="card">
+<div class="card review-card">
 <h2>Your Statistics</h2>
 <div class="stats-grid">
 <div class="stat-card">
@@ -1548,69 +1322,69 @@
 </div>
 <!-- VIDEOS TAB -->
 <div class="tab-content" id="tab-videos">
-<div class="card">
+<div class="card review-card">
 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; flex-wrap: wrap; gap: 0.5rem;">
 <h2>Study Videos</h2>
 <div id="video-progress" style="color: var(--text-muted); font-size: 0.95rem; font-weight: 500;"></div>
 </div>
-<div class="checklist-section">
+<div class="checklist-section review-checklist-section">
 <h3>Section 4.2: Exponentials</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="exp_table_graph" data-video-id="v42_1" href="https://www.youtube.com/watch?v=kikGvjKFN8Q" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="exp_table_graph" data-video-id="v42_1" href="https://www.youtube.com/watch?v=kikGvjKFN8Q" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Graphing &amp; Tables</span>
 </a>
-<a class="check-item video-link" data-practice-id="exp_table_graph" data-video-id="v42_2" href="https://www.youtube.com/watch?v=aix8TLHdKgc" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="exp_table_graph" data-video-id="v42_2" href="https://www.youtube.com/watch?v=aix8TLHdKgc" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Calculator: Decimal Exponents</span>
 </a>
-<a class="check-item video-link" data-practice-id="interest" data-video-id="v42_3" href="https://www.youtube.com/watch?v=NCYNXkbTTUo" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="interest" data-video-id="v42_3" href="https://www.youtube.com/watch?v=NCYNXkbTTUo" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Simple vs Compound Interest</span>
 </a>
-<a class="check-item video-link" data-practice-id="interest" data-video-id="v42_4" href="https://www.youtube.com/watch?v=2S4vK30dII0" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="interest" data-video-id="v42_4" href="https://www.youtube.com/watch?v=2S4vK30dII0" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Continuous Compounding</span>
 </a>
 </div>
 </div>
-<div class="checklist-section" style="margin-top: 2rem;">
+<div class="checklist-section review-checklist-section review-stack-gap">
 <h3>Section 4.3: Logarithms</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="logexp_conv" data-video-id="v43_1" href="https://www.youtube.com/watch?v=-ZQvz4bc2Eg" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="logexp_conv" data-video-id="v43_1" href="https://www.youtube.com/watch?v=-ZQvz4bc2Eg" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Log ↔ Exp Conversions</span>
 </a>
-<a class="check-item video-link" data-practice-id="logexp" data-video-id="v43_2" href="https://www.youtube.com/watch?v=eL2FhO11mf0" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="logexp" data-video-id="v43_2" href="https://www.youtube.com/watch?v=eL2FhO11mf0" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Evaluating Log Expressions</span>
 </a>
-<a class="check-item video-link" data-practice-id="logexp" data-video-id="v43_3" href="https://www.youtube.com/watch?v=3Rf8KEhY0ts" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="logexp" data-video-id="v43_3" href="https://www.youtube.com/watch?v=3Rf8KEhY0ts" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Logarithm Change of Base</span>
 </a>
-<a class="check-item video-link" data-practice-id="logexp" data-video-id="v43_4" href="https://www.youtube.com/watch?v=fnhFneOz6n8" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="logexp" data-video-id="v43_4" href="https://www.youtube.com/watch?v=fnhFneOz6n8" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Solving Exponential Eqns using Logs</span>
 </a>
 </div>
 </div>
-<div class="checklist-section" style="margin-top: 2rem;">
+<div class="checklist-section review-checklist-section review-stack-gap">
 <h3>Geometry &amp; Circles</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="piecewise_rect" data-video-id="vgeo_1" href="https://www.youtube.com/watch?v=8ysZhPknfYY" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="piecewise_rect" data-video-id="vgeo_1" href="https://www.youtube.com/watch?v=8ysZhPknfYY" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Piecewise Rectangular Areas</span>
 </a>
-<a class="check-item video-link" data-practice-id="dms_to_dec" data-video-id="vgeo_2" href="https://www.youtube.com/watch?v=FcDyaiHO4GQ" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="dms_to_dec" data-video-id="vgeo_2" href="https://www.youtube.com/watch?v=FcDyaiHO4GQ" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>DMS to Decimal Conversion</span>
 </a>
-<a class="check-item video-link" data-practice-id="std_pos_angle" data-video-id="vgeo_3" href="https://www.youtube.com/watch?v=JmLN3QxshlE" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="std_pos_angle" data-video-id="vgeo_3" href="https://www.youtube.com/watch?v=JmLN3QxshlE" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Radians &amp; Degrees Intro</span>
 </a>
-<a class="check-item video-link" data-practice-id="circles" data-video-id="vgeo_4" href="https://www.youtube.com/watch?v=XUus6-9E9sQ" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="circles" data-video-id="vgeo_4" href="https://www.youtube.com/watch?v=XUus6-9E9sQ" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Circle Sectors &amp; Arc Length</span>
 </a>
@@ -1621,7 +1395,7 @@
 
 <!-- LECTURE SLIDES TAB -->
 <div class="tab-content active" id="tab-slides">
-<div class="card">
+<div class="card review-card">
 <h2>Lecture Slides</h2>
 <div class="slides-shell">
 <div class="slides-intro">
@@ -3376,7 +3150,7 @@
                     <span class="progress-item-label">${cat}</span>
                     <span class="progress-item-count">${doneCount} / ${items.length}</span>
                 </div>
-                <div class="progress-bar-track">
+                <div class="progress-bar-track review-progress-track">
                     <div class="progress-bar-fill ${pct === 100 ? 'complete' : ''}" style="width: ${pct}%"></div>
                 </div>
             `;
@@ -4041,7 +3815,7 @@
                     <span class="progress-item-label">${section}</span>
                     <span class="progress-item-count" style="color: ${secColor}">${data.correct}/${data.total} (${secPct}%)</span>
                 </div>
-                <div class="progress-bar-track">
+                <div class="progress-bar-track review-progress-track">
                     <div class="progress-bar-fill ${secPct === 100 ? 'complete' : ''}" style="width: ${secPct}%; background: ${secColor};"></div>
                 </div>
             `;

--- a/130Test3.html
+++ b/130Test3.html
@@ -16,233 +16,7 @@
 <!-- Icons -->
 <script defer="" src="https://cdn.jsdelivr.net/npm/lucide@0.344.0/dist/umd/lucide.min.js"></script>
 <style>
-        :root {
-            /* Dark Theme (Default) */
-            --bg: #0f1117; 
-            --surface: #181a24; 
-            --surface2: #1f2233; 
-            --border: #2a2d42;
-            --text: #e2e4ef; 
-            --text-muted: #8b8fa8;
-            --accent: #6c63ff; 
-            --accent-glow: rgba(108, 99, 255, 0.25);
-            --accent-hover: #5a52d5;
-            --green: #34d399; 
-            --green-bg: rgba(52, 211, 153, 0.1);
-            --amber: #fbbf24; 
-            --amber-bg: rgba(251, 191, 36, 0.1);
-            --red: #f87171; 
-            --red-bg: rgba(248, 113, 113, 0.1);
-            --shadow: 0 8px 32px rgba(0,0,0,0.3);
-            --radius: 16px;
-        }
-
-        body.light {
-            /* Light Theme */
-            --bg: #f8fafc; 
-            --surface: #ffffff; 
-            --surface2: #f1f5f9; 
-            --border: #e2e8f0;
-            --text: #0f172a; 
-            --text-muted: #64748b;
-            --accent: #5b52e0;
-            --accent-glow: rgba(91, 82, 224, 0.12);
-            --accent-hover: #4a42c0;
-            --green: #059669;
-            --green-bg: rgba(5, 150, 105, 0.08);
-            --amber: #d97706;
-            --amber-bg: rgba(217, 119, 6, 0.08);
-            --red: #dc2626;
-            --red-bg: rgba(220, 38, 38, 0.08);
-            --shadow: 0 8px 32px rgba(0,0,0,0.06);
-        }
-
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        
-        body {
-            font-family: 'DM Sans', sans-serif;
-            background-color: var(--bg);
-            color: var(--text);
-            line-height: 1.6;
-            transition: background-color 0.3s, color 0.3s;
-            min-height: 100vh;
-        }
-
-        .container {
-            max-width: 1000px;
-            margin: 0 auto;
-            padding: 2rem;
-        }
-        /* Header */
-        header {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-start;
-            gap: 1rem;
-            margin-bottom: 1.6rem;
-            padding-bottom: 1rem;
-            border-bottom: 1px solid var(--border);
-        }
-
-        h1, h2, h3 { font-family: 'DM Serif Display', serif; font-weight: 400; }
-        h1 { font-size: 2.35rem; color: var(--accent); line-height: 1.05; }
-        h2 { font-size: 1.8rem; margin-bottom: 1.5rem; }
-
-        .header-copy {
-            max-width: 42rem;
-        }
-
-        .header-meta {
-            color: var(--text-muted);
-            margin-top: 0.35rem;
-            font-weight: 600;
-            letter-spacing: 0.01em;
-        }
-
-        .header-subtitle {
-            color: var(--text-muted);
-            margin-top: 0.12rem;
-            font-size: 0.95rem;
-        }
-
-        .header-chips {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.6rem;
-            margin-top: 0.75rem;
-        }
-
-        .header-chip {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.45rem;
-            padding: 0.42rem 0.75rem;
-            border-radius: 999px;
-            border: 1px solid var(--border);
-            background: var(--surface);
-            color: var(--text-muted);
-            font-size: 0.82rem;
-            font-weight: 600;
-            line-height: 1;
-        }
-
-        .header-chip i {
-            width: 0.9rem;
-            height: 0.9rem;
-            color: var(--accent);
-            flex-shrink: 0;
-        }
-
-        .header-chip.accent {
-            background: var(--accent-glow);
-            border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
-            color: var(--text);
-        }
-        
-        .theme-toggle {
-            background: var(--surface2);
-            border: 1px solid var(--border);
-            color: var(--text);
-            padding: 0.75rem;
-            border-radius: 50%;
-            cursor: pointer;
-            transition: all 0.2s;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            flex-shrink: 0;
-        }
-        
-        .theme-toggle:hover {
-            background: var(--border);
-            transform: scale(1.05);
-        }
-
-        /* Dashboard Navigation */
-        .tabs {
-            display: grid;
-            grid-template-columns: repeat(3, minmax(0, 1fr));
-            gap: 0.75rem;
-            margin-bottom: 1.1rem;
-        }
-
-        .tab-btn {
-            background: linear-gradient(180deg, var(--surface), var(--surface2));
-            border: 1px solid var(--border);
-            color: var(--text);
-            padding: 0.85rem 0.95rem;
-            border-radius: 16px;
-            font-family: 'DM Sans', sans-serif;
-            font-size: 1rem;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.2s ease;
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-            text-align: left;
-            min-height: 78px;
-            box-shadow: 0 6px 18px rgba(0,0,0,0.06);
-        }
-
-        .tab-btn:hover {
-            transform: translateY(-2px);
-            border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
-            box-shadow: 0 10px 24px rgba(0,0,0,0.10);
-        }
-
-        .tab-btn.active {
-            background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 14%, var(--surface)), var(--surface));
-            border-color: var(--accent);
-            box-shadow: 0 10px 24px var(--accent-glow);
-        }
-
-        .tab-btn.priority {
-            position: relative;
-        }
-
-        .tab-btn.priority::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 18px;
-            right: 18px;
-            height: 3px;
-            border-radius: 999px;
-            background: linear-gradient(90deg, var(--accent), transparent);
-            opacity: 0.85;
-        }
-
-        .tab-icon-wrap {
-            width: 38px;
-            height: 38px;
-            border-radius: 11px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            background: color-mix(in srgb, var(--accent) 12%, var(--surface2));
-            color: var(--accent);
-            flex-shrink: 0;
-        }
-
-        .tab-btn.active .tab-icon-wrap {
-            background: color-mix(in srgb, var(--accent) 18%, var(--surface2));
-            color: var(--accent);
-        }
-
-        .tab-copy {
-            display: flex;
-            flex-direction: column;
-            gap: 0;
-            min-width: 0;
-        }
-
-        .tab-label {
-            font-weight: 700;
-            color: var(--text);
-            line-height: 1.2;
-            font-size: 0.98rem;
-        }
+        /* Page-specific styles only; shared Math 130 review tokens/components live in styles.css. */
 
         /* Cards */
         .card {
@@ -1086,7 +860,7 @@
 
 
 </head>
-<body>
+<body class="review-page">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
@@ -1117,16 +891,16 @@
           </ul>
         </li>
       </ul>
-      <button aria-label="Toggle dark and light theme" class="theme-toggle" id="theme-toggle-btn" title="Toggle Theme">
+      <button aria-label="Toggle dark and light theme" class="theme-toggle review-theme-toggle" id="theme-toggle-btn" title="Toggle Theme">
         <i data-lucide="moon"></i>
       </button>
     </div>
   </div>
 </nav>
 
-<div class="container">
-<header>
-<div class="header-copy">
+<div class="container review-shell">
+<header class="review-header">
+<div class="header-copy review-title-group">
 <nav class="breadcrumb" aria-label="Breadcrumb">
 <a href="index.html">Home</a>
 <span aria-hidden="true" class="breadcrumb-sep">›</span>
@@ -1138,54 +912,54 @@
 </nav>
 <h1>Math 130 – Test 3 Review</h1>
 <p class="header-meta">Spring 2026 | Prof. Young &amp; Prof. Volk</p>
-<p class="header-subtitle">Topics: Sections 5.1–5.3, 7.1, and 8.4</p>
-<div class="header-chips">
-<span class="header-chip accent"><i data-lucide="route"></i> Recommended order: Slides → Formulas → Practice</span>
-<span class="header-chip"><i data-lucide="calendar-clock"></i> Test 3: Fri, May 1</span>
+<p class="header-subtitle review-subtitle">Topics: Sections 5.1–5.3, 7.1, and 8.4</p>
+<div class="header-chips review-meta-chips">
+<span class="header-chip review-chip accent is-accent"><i data-lucide="route"></i> Recommended order: Slides → Formulas → Practice</span>
+<span class="header-chip review-chip"><i data-lucide="calendar-clock"></i> Test 3: Fri, May 1</span>
 </div>
 </div>
 </header>
-<div aria-label="Review tool sections" class="tabs" role="tablist">
-<button class="tab-btn active priority" data-tab="slides">
-<span class="tab-icon-wrap"><i data-lucide="monitor"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Slides</span>
+<div aria-label="Review tool sections" class="tabs review-tabs review-tabs-3" role="tablist">
+<button class="tab-btn review-tab-btn active priority" data-tab="slides">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="monitor"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Slides</span>
 </span>
         </button>
-<button class="tab-btn priority" data-tab="formulas">
-<span class="tab-icon-wrap"><i data-lucide="sigma"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Formulas</span>
+<button class="tab-btn review-tab-btn priority" data-tab="formulas">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="sigma"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Formulas</span>
 </span>
         </button>
-<button class="tab-btn priority" data-tab="practice">
-<span class="tab-icon-wrap"><i data-lucide="pen-tool"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Practice</span>
+<button class="tab-btn review-tab-btn priority" data-tab="practice">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="pen-tool"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Practice</span>
 </span>
         </button>
-<button class="tab-btn" data-tab="videos">
-<span class="tab-icon-wrap"><i data-lucide="play-circle"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Videos</span>
+<button class="tab-btn review-tab-btn" data-tab="videos">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="play-circle"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Videos</span>
 </span>
         </button>
-<button class="tab-btn" data-tab="schedule">
-<span class="tab-icon-wrap"><i data-lucide="calendar"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Schedule</span>
+<button class="tab-btn review-tab-btn" data-tab="schedule">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="calendar"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Schedule</span>
 </span>
         </button>
-<button class="tab-btn" data-tab="progress">
-<span class="tab-icon-wrap"><i data-lucide="bar-chart-2"></i></span>
-<span class="tab-copy">
-<span class="tab-label">Progress</span>
+<button class="tab-btn review-tab-btn" data-tab="progress">
+<span class="tab-icon-wrap review-tab-icon"><i data-lucide="bar-chart-2"></i></span>
+<span class="tab-copy review-tab-copy">
+<span class="tab-label review-tab-label">Progress</span>
 </span>
         </button>
 </div>
 <!-- SCHEDULE TAB -->
 <div class="tab-content" id="tab-schedule">
-<div class="card">
+<div class="card review-card">
 <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; margin-bottom: 1.5rem;">
 <h2 style="margin-bottom: 0;">Course Schedule</h2>
 <div id="exam-countdown" style="background: var(--red-bg); border: 1px solid var(--red); color: var(--red); padding: 0.5rem 1rem; border-radius: 12px; font-weight: 600; font-family: 'JetBrains Mono', monospace; font-size: 0.95rem;"></div>
@@ -1304,7 +1078,7 @@
 </table>
 </div>
 </div>
-<div class="card">
+<div class="card review-card">
 <h2>ALEKS Modules</h2>
 <div style="overflow-x: auto;">
 <table class="history-table">
@@ -1358,11 +1132,11 @@
             </p>
 </div>
 <div class="section-summary-grid">
-<div class="section-summary-card">
+<div class="section-summary-card review-summary-card">
 <span class="section-summary-label">Memorize first</span>
 <span class="section-summary-value">Arc length, right-triangle trig, inverse trig, and vector formulas.</span>
 </div>
-<div class="section-summary-card">
+<div class="section-summary-card review-summary-card">
 <span class="section-summary-label">Use as references</span>
 <span class="section-summary-value">Formula-box identities and the supporting “Useful” relations.</span>
 </div>
@@ -1376,7 +1150,7 @@
 </div>
 </div>
 
-<div class="checklist-section">
+<div class="checklist-section review-checklist-section">
 <h3>Provided Formulas (Exact Test 3 Formula Box)</h3>
 <div class="formula-grid">
 <div class="formula-card provided-card">
@@ -1400,7 +1174,7 @@
 </div>
 </div>
 
-<div class="checklist-section" style="margin-top: 2rem;">
+<div class="checklist-section review-checklist-section review-stack-gap">
 <h3>Section 5.1–5.2 Foundations</h3>
 <div class="formula-grid">
 <div class="formula-card memorize-card">
@@ -1424,7 +1198,7 @@
 </div>
 </div>
 
-<div class="checklist-section" style="margin-top: 2rem;">
+<div class="checklist-section review-checklist-section review-stack-gap">
 <h3>Section 5.3 &amp; 7.1 Applications</h3>
 <div class="formula-grid">
 <div class="formula-card memorize-card">
@@ -1448,7 +1222,7 @@
 </div>
 </div>
 
-<div class="checklist-section" style="margin-top: 2rem;">
+<div class="checklist-section review-checklist-section review-stack-gap">
 <h3>Section 8.4 Vectors</h3>
 <div class="formula-grid">
 <div class="formula-card memorize-card">
@@ -1491,17 +1265,17 @@
 <p style="text-align: center; color: var(--text-muted); margin-bottom: 0;">Select a topic to generate infinite, exam-style questions.</p>
 </div>
 <div class="section-summary-grid">
-<div class="section-summary-card">
+<div class="section-summary-card review-summary-card">
 <span class="section-summary-label">Primary mode</span>
 <span class="section-summary-value">Mock Exam for full mixed review across Sections 5.1–8.4.</span>
 </div>
-<div class="section-summary-card">
+<div class="section-summary-card review-summary-card">
 <span class="section-summary-label">Secondary mode</span>
 <span class="section-summary-value">Mock Quizzes for focused skill checks tied to specific sections.</span>
 </div>
 </div>
 <!-- Mock Exam CTA -->
-<div id="exam-cta" style="background: linear-gradient(135deg, var(--accent-glow), var(--red-bg)); border: 2px solid var(--accent); border-radius: 18px; padding: 1.75rem; margin-bottom: 2rem; text-align: center; box-shadow: 0 18px 36px rgba(108, 99, 255, 0.16);">
+<div id="exam-cta" class="review-callout review-callout--exam">
 <h3 style="font-family: 'DM Serif Display', serif; font-size: 1.4rem; margin-bottom: 0.5rem;">🎯 Mock Exam Mode</h3>
 <p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.95rem;">20 mixed Unit 3 review questions with coverage from Sections 5.1, 5.2, 5.3, 7.1, and 8.4 (at least one per section).</p>
 <button class="btn-primary" id="btn-start-exam" onclick="startMockExam()">Start Mock Exam</button>
@@ -1535,12 +1309,12 @@
 <span id="exam-mode-label" style="font-weight: 600; color: var(--accent);">Mock Exam</span>
 <span id="exam-progress-label" style="font-family: 'JetBrains Mono', monospace; color: var(--text-muted); font-size: 0.9rem;">1 / 15</span>
 </div>
-<div class="progress-bar-track" style="height: 10px;">
-<div class="progress-bar-fill" id="exam-progress-fill" style="width: 0%; transition: width 0.4s ease;"></div>
+<div class="progress-bar-track review-progress-track" style="height: 10px;">
+<div class="progress-bar-fill review-progress-fill" id="exam-progress-fill" style="width: 0%; transition: width 0.4s ease;"></div>
 </div>
 </div>
 <!-- Exam Results (hidden until complete) -->
-<div class="card" id="exam-results" style="display: none;">
+<div class="card review-card" id="exam-results" style="display: none;">
 <h2 style="text-align: center;">📊 Exam Results</h2>
 <div id="exam-score-display" style="text-align: center; font-size: 3rem; font-family: 'JetBrains Mono', monospace; color: var(--accent); margin: 1rem 0;"></div>
 <div id="exam-breakdown" style="margin-top: 1rem;"></div>
@@ -1618,69 +1392,69 @@
 </div>
 <!-- VIDEOS TAB -->
 <div class="tab-content" id="tab-videos">
-<div class="card">
+<div class="card review-card">
 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; flex-wrap: wrap; gap: 0.5rem;">
 <h2>Study Videos</h2>
 <div id="video-progress" style="color: var(--text-muted); font-size: 0.95rem; font-weight: 500;"></div>
 </div>
-<div class="checklist-section">
+<div class="checklist-section review-checklist-section">
 <h3>Section 5.2: Right-Triangle Trigonometry</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="trig_ratio" data-video-id="v42_1" href="https://www.youtube.com/watch?v=kikGvjKFN8Q" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="trig_ratio" data-video-id="v42_1" href="https://www.youtube.com/watch?v=kikGvjKFN8Q" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Trig Ratios from Right Triangles</span>
 </a>
-<a class="check-item video-link" data-practice-id="trig_ratio" data-video-id="v42_2" href="https://www.youtube.com/watch?v=aix8TLHdKgc" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="trig_ratio" data-video-id="v42_2" href="https://www.youtube.com/watch?v=aix8TLHdKgc" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Calculator Trig Values (Degree/Radian Mode)</span>
 </a>
-<a class="check-item video-link" data-practice-id="angle_unit_conversion" data-video-id="v42_3" href="https://www.youtube.com/watch?v=NCYNXkbTTUo" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="angle_unit_conversion" data-video-id="v42_3" href="https://www.youtube.com/watch?v=NCYNXkbTTUo" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Degree/Radian Unit Conversion</span>
 </a>
-<a class="check-item video-link" data-practice-id="angle_unit_conversion" data-video-id="v42_4" href="https://www.youtube.com/watch?v=2S4vK30dII0" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="angle_unit_conversion" data-video-id="v42_4" href="https://www.youtube.com/watch?v=2S4vK30dII0" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Side Lengths from Trig Ratios</span>
 </a>
 </div>
 </div>
-<div class="checklist-section" style="margin-top: 2rem;">
+<div class="checklist-section review-checklist-section review-stack-gap">
 <h3>Section 5.3: Reference angles, signs, and solving trig equations on 0°–360°</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="reference_angle_deg" data-video-id="v43_1" href="https://www.youtube.com/watch?v=-ZQvz4bc2Eg" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="reference_angle_deg" data-video-id="v43_1" href="https://www.youtube.com/watch?v=-ZQvz4bc2Eg" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Reference Angles (Degrees and Radians)</span>
 </a>
-<a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_2" href="https://www.youtube.com/watch?v=eL2FhO11mf0" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="quadrant_signs" data-video-id="v43_2" href="https://www.youtube.com/watch?v=eL2FhO11mf0" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Quadrant Signs (ASTC)</span>
 </a>
-<a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_3" href="https://www.youtube.com/watch?v=3Rf8KEhY0ts" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="quadrant_signs" data-video-id="v43_3" href="https://www.youtube.com/watch?v=3Rf8KEhY0ts" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Reference Angles: Extra Practice</span>
 </a>
-<a class="check-item video-link" data-practice-id="quadrant_signs" data-video-id="v43_4" href="https://www.youtube.com/watch?v=fnhFneOz6n8" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="quadrant_signs" data-video-id="v43_4" href="https://www.youtube.com/watch?v=fnhFneOz6n8" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Trig Values from Quadrant + Reference Angle</span>
 </a>
 </div>
 </div>
-<div class="checklist-section" style="margin-top: 2rem;">
+<div class="checklist-section review-checklist-section review-stack-gap">
 <h3>Geometry &amp; Section 8.4</h3>
 <div class="checklist-grid">
-<a class="check-item video-link" data-practice-id="solve_right_triangle" data-video-id="vgeo_1" href="https://www.youtube.com/watch?v=8ysZhPknfYY" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="solve_right_triangle" data-video-id="vgeo_1" href="https://www.youtube.com/watch?v=8ysZhPknfYY" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Solve a Right Triangle</span>
 </a>
-<a class="check-item video-link" data-practice-id="angle_of_elevation" data-video-id="vgeo_2" href="https://www.youtube.com/watch?v=FcDyaiHO4GQ" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="angle_of_elevation" data-video-id="vgeo_2" href="https://www.youtube.com/watch?v=FcDyaiHO4GQ" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Angle of Elevation/Depression</span>
 </a>
-<a class="check-item video-link" data-practice-id="distance_rate_time" data-video-id="vgeo_3" href="https://www.youtube.com/watch?v=JmLN3QxshlE" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="distance_rate_time" data-video-id="vgeo_3" href="https://www.youtube.com/watch?v=JmLN3QxshlE" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Distance-Rate-Time with Trig</span>
 </a>
-<a class="check-item video-link" data-practice-id="vector_magnitude" data-video-id="vgeo_4" href="https://www.youtube.com/watch?v=XUus6-9E9sQ" style="text-decoration: none;" target="_blank" rel="noopener noreferrer">
+<a class="check-item video-link review-video-link review-link-reset" data-practice-id="vector_magnitude" data-video-id="vgeo_4" href="https://www.youtube.com/watch?v=XUus6-9E9sQ" target="_blank" rel="noopener noreferrer">
 <i data-lucide="play" style="color: var(--accent);"></i>
 <span>Vector Magnitude and Direction</span>
 </a>
@@ -1698,11 +1472,11 @@
 <p>Open the lead deck first, then work forward through the supporting modules so the highest-priority review materials stand out immediately.</p>
 </div>
 <div class="section-summary-grid">
-<div class="section-summary-card">
+<div class="section-summary-card review-summary-card">
 <span class="section-summary-label">Lead review deck</span>
 <span class="section-summary-value">Math 130 Unit 3: Test 3 Review (Module 3E)</span>
 </div>
-<div class="section-summary-card">
+<div class="section-summary-card review-summary-card">
 <span class="section-summary-label">Support sequence</span>
 <span class="section-summary-value">Modules 10–13 for foundations, then Unit 3E for final consolidation.</span>
 </div>
@@ -2960,7 +2734,7 @@
                     <span class="progress-item-label">${group.label}</span>
                     <span class="progress-item-count">${doneCount} / ${items.length}</span>
                 </div>
-                <div class="progress-bar-track">
+                <div class="progress-bar-track review-progress-track">
                     <div class="progress-bar-fill ${pct === 100 ? 'complete' : ''}" style="width: ${pct}%"></div>
                 </div>
             `;
@@ -3611,7 +3385,7 @@
                     <span class="progress-item-label">${section}</span>
                     <span class="progress-item-count" style="color: ${secColor}">${data.correct}/${data.total} (${secPct}%)</span>
                 </div>
-                <div class="progress-bar-track">
+                <div class="progress-bar-track review-progress-track">
                     <div class="progress-bar-fill ${secPct === 100 ? 'complete' : ''}" style="width: ${secPct}%; background: ${secColor};"></div>
                 </div>
             `;

--- a/130Test4.html
+++ b/130Test4.html
@@ -577,9 +577,9 @@
     }
 </style>
 </head>
-<body>
-<div class="container">
-    <header>
+<body class="review-page">
+<div class="container review-shell">
+    <header class="review-header">
         <div class="breadcrumb">
             <a href="#">Math 130</a>
             <span>›</span>
@@ -589,53 +589,53 @@
         </div>
 
         <h1>Final Week Review</h1>
-        <p class="header-subtitle">A simplified final-week page modeled after the earlier review pages. This one only covers the last week: Quiz 13 on vectors, reading day, and the comprehensive final.</p>
+        <p class="header-subtitle review-subtitle">A simplified final-week page modeled after the earlier review pages. This one only covers the last week: Quiz 13 on vectors, reading day, and the comprehensive final.</p>
 
-        <div class="header-chips">
+        <div class="header-chips review-meta-chips">
             <span class="chip accent"><i data-lucide="route"></i> Suggested order: Schedule → Quiz 13 → Final Exam → Formulas</span>
             <span class="chip"><i data-lucide="calendar-clock"></i> Quiz 13: Mon, 5/4</span>
             <span class="chip"><i data-lucide="graduation-cap"></i> Final Exam: Thu, 5/7</span>
             <span class="chip"><i data-lucide="layers-3"></i> Final week only</span>
         </div>
 
-        <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+        <button class="theme-toggle review-theme-toggle" id="themeToggle" aria-label="Toggle theme">
             <i data-lucide="sun-moon"></i>
         </button>
     </header>
 
-    <nav class="tabs" aria-label="Final week navigation">
-        <button class="tab-btn active" data-tab="schedule">
+    <nav class="tabs review-tabs review-tabs-4" aria-label="Final week navigation">
+        <button class="tab-btn review-tab-btn active" data-tab="schedule">
             <span class="tab-icon"><i data-lucide="calendar-range"></i></span>
-            <span class="tab-copy">
-                <span class="tab-label">Schedule</span>
+            <span class="tab-copy review-tab-copy">
+                <span class="tab-label review-tab-label">Schedule</span>
                 <span class="tab-sub">Only the final week</span>
             </span>
         </button>
-        <button class="tab-btn" data-tab="quiz13">
+        <button class="tab-btn review-tab-btn" data-tab="quiz13">
             <span class="tab-icon"><i data-lucide="move-3d"></i></span>
-            <span class="tab-copy">
-                <span class="tab-label">Quiz 13</span>
+            <span class="tab-copy review-tab-copy">
+                <span class="tab-label review-tab-label">Quiz 13</span>
                 <span class="tab-sub">Section 8.4 vectors</span>
             </span>
         </button>
-        <button class="tab-btn" data-tab="finalexam">
+        <button class="tab-btn review-tab-btn" data-tab="finalexam">
             <span class="tab-icon"><i data-lucide="book-open-check"></i></span>
-            <span class="tab-copy">
-                <span class="tab-label">Final Exam</span>
+            <span class="tab-copy review-tab-copy">
+                <span class="tab-label review-tab-label">Final Exam</span>
                 <span class="tab-sub">Fall 2025 alignment</span>
             </span>
         </button>
-        <button class="tab-btn" data-tab="formulas">
+        <button class="tab-btn review-tab-btn" data-tab="formulas">
             <span class="tab-icon"><i data-lucide="sigma"></i></span>
-            <span class="tab-copy">
-                <span class="tab-label">Formulas</span>
+            <span class="tab-copy review-tab-copy">
+                <span class="tab-label review-tab-label">Formulas</span>
                 <span class="tab-sub">Provided + must know</span>
             </span>
         </button>
     </nav>
 
     <section class="tab-content active" id="tab-schedule">
-        <div class="card">
+        <div class="card review-card">
             <div class="eyebrow"><i data-lucide="calendar-days"></i> Final week schedule</div>
             <h2>What happens this week</h2>
             <p class="muted">This page intentionally leaves out lecture-slide sections, checklist trackers, and ALEKS items. The goal is to keep final-week navigation clean and focused.</p>
@@ -717,7 +717,7 @@
             </div>
         </div>
 
-        <div class="card" style="margin-top:1rem;">
+        <div class="card review-card" style="margin-top:1rem;">
             <div class="eyebrow"><i data-lucide="compass"></i> Core vector moves</div>
             <h2>Quiz 13 essentials</h2>
             <div class="formula-grid">
@@ -792,7 +792,7 @@
             </div>
         </div>
 
-        <div class="card" style="margin-top:1rem;">
+        <div class="card review-card" style="margin-top:1rem;">
             <div class="eyebrow"><i data-lucide="clipboard-list"></i> Official review categories</div>
             <h2>Review sheet structure</h2>
 
@@ -910,7 +910,7 @@
     </section>
 
     <section class="tab-content" id="tab-formulas">
-        <div class="card">
+        <div class="card review-card">
             <div class="eyebrow"><i data-lucide="sigma"></i> Formula focus</div>
             <h2>Provided on the Fall 2025 final</h2>
             <p class="muted" style="margin-bottom:1rem;">These formulas were printed on the final. They still require recognition and correct setup.</p>
@@ -949,7 +949,7 @@
             </div>
         </div>
 
-        <div class="card">
+        <div class="card review-card">
             <h3>Know these cold</h3>
             <div class="formula-grid">
                 <div class="formula-card core">

--- a/styles.css
+++ b/styles.css
@@ -1580,3 +1580,341 @@ nav.navbar .dropdown[data-desktop-open="true"] .dropdown-menu {
   color: var(--accent-color);
   background-color: rgba(255, 255, 255, 0.3);
 }
+
+
+/* Math 130 review layer */
+:root {
+  --review-bg: #0f1117;
+  --review-surface: #181a24;
+  --review-surface-2: #1f2233;
+  --review-border: #2a2d42;
+  --review-accent: #6c63ff;
+  --review-accent-soft: rgba(108, 99, 255, 0.12);
+  --review-accent-glow: rgba(108, 99, 255, 0.25);
+  --review-muted: #8b8fa8;
+  --review-text: #e2e4ef;
+  --review-shadow: 0 12px 36px rgba(0, 0, 0, 0.22);
+  --review-grid: rgba(108, 99, 255, 0.03);
+  --review-accent-hover: rgba(108, 99, 255, 0.3);
+  --review-green-border: rgba(52, 211, 153, 0.2);
+  --review-red-border: rgba(248, 113, 113, 0.2);
+  --review-check-bg: rgba(52, 211, 153, 0.04);
+  --review-check-border: rgba(52, 211, 153, 0.3);
+  --review-got-border: rgba(52, 211, 153, 0.4);
+  --review-miss-border: rgba(248, 113, 113, 0.4);
+  --review-green-step: rgba(52, 211, 153, 0.25);
+  --review-h1-from: #e2e4ef;
+  --review-h1-to: #9d98ff;
+  --review-success: #34d399;
+  --review-success-bg: rgba(52, 211, 153, 0.1);
+  --review-warning: #f59e0b;
+  --review-warning-bg: rgba(245, 158, 11, 0.1);
+  --review-error: #f87171;
+  --review-error-bg: rgba(248, 113, 113, 0.1);
+  --review-info: #60a5fa;
+  --review-info-bg: rgba(96, 165, 250, 0.1);
+  --review-radius: 16px;
+  --review-shell-width: min(1100px, calc(100vw - 2rem));
+}
+
+body.review-page {
+  --bg: var(--review-bg);
+  --surface: var(--review-surface);
+  --surface2: var(--review-surface-2);
+  --border: var(--review-border);
+  --accent: var(--review-accent);
+  --accent-soft: var(--review-accent-soft);
+  --accent-glow: var(--review-accent-glow);
+  --text: var(--review-text);
+  --text-muted: var(--review-muted);
+  --green: var(--review-success);
+  --green-bg: var(--review-success-bg);
+  --amber: var(--review-warning);
+  --amber-bg: var(--review-warning-bg);
+  --red: var(--review-error);
+  --red-bg: var(--review-error-bg);
+  --blue: var(--review-info);
+  --blue-bg: var(--review-info-bg);
+  --shadow: var(--review-shadow);
+  --radius: var(--review-radius);
+  --grid-line: var(--review-grid);
+  --accent-hover: var(--review-accent-hover);
+  --green-border: var(--review-green-border);
+  --red-border: var(--review-red-border);
+  --check-bg: var(--review-check-bg);
+  --check-border: var(--review-check-border);
+  --got-border: var(--review-got-border);
+  --miss-border: var(--review-miss-border);
+  --green-step: var(--review-green-step);
+  --h1-from: var(--review-h1-from);
+  --h1-to: var(--review-h1-to);
+  font-family: 'DM Sans', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+body.review-page.light {
+  --review-bg: #f8fafc;
+  --review-surface: #ffffff;
+  --review-surface-2: #f1f5f9;
+  --review-border: #e2e8f0;
+  --review-accent: #5b52e0;
+  --review-accent-soft: rgba(91, 82, 224, 0.08);
+  --review-accent-glow: rgba(91, 82, 224, 0.12);
+  --review-muted: #64748b;
+  --review-text: #0f172a;
+  --review-shadow: 0 8px 32px rgba(15, 23, 42, 0.06);
+  --review-grid: rgba(91, 82, 224, 0.04);
+  --review-accent-hover: rgba(91, 82, 224, 0.25);
+  --review-green-border: rgba(5, 150, 105, 0.2);
+  --review-red-border: rgba(220, 38, 38, 0.18);
+  --review-check-bg: rgba(5, 150, 105, 0.05);
+  --review-check-border: rgba(5, 150, 105, 0.3);
+  --review-got-border: rgba(5, 150, 105, 0.4);
+  --review-miss-border: rgba(220, 38, 38, 0.35);
+  --review-green-step: rgba(5, 150, 105, 0.2);
+  --review-h1-from: #1a1d2b;
+  --review-h1-to: #5046e5;
+  --review-success: #059669;
+  --review-success-bg: rgba(5, 150, 105, 0.08);
+  --review-warning: #d97706;
+  --review-warning-bg: rgba(217, 119, 6, 0.08);
+  --review-error: #dc2626;
+  --review-error-bg: rgba(220, 38, 38, 0.08);
+  --review-info: #2563eb;
+  --review-info-bg: rgba(37, 99, 235, 0.08);
+}
+
+body.review-page::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: linear-gradient(var(--grid-line) 1px, transparent 1px), linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+  background-size: 40px 40px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.review-shell {
+  width: var(--review-shell-width);
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 4rem;
+  position: relative;
+  z-index: 1;
+}
+
+.review-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.6rem;
+  padding-bottom: 1.15rem;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+
+.review-title-group { max-width: 52rem; }
+.review-header h1,
+.review-page h1.review-title {
+  font-family: 'DM Serif Display', serif;
+  font-weight: 400;
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1.05;
+  color: var(--accent);
+  margin: 0 0 0.35rem;
+}
+.review-page h2,
+.review-page h3,
+.review-page h4 { font-family: 'DM Serif Display', serif; font-weight: 400; }
+.review-page h2 { font-size: 1.8rem; margin-bottom: 1.5rem; }
+.review-kicker, .course-label { font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; letter-spacing: 3px; text-transform: uppercase; color: var(--accent); margin-bottom: 0.55rem; }
+.review-subtitle, .header-subtitle, .subtitle { color: var(--text-muted); font-size: 0.98rem; max-width: 52rem; }
+.review-meta-chips, .header-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 0.75rem;
+}
+.review-chip, .header-chip, .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.42rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1;
+}
+.review-chip i, .header-chip i, .chip i { width: 0.9rem; height: 0.9rem; color: var(--accent); flex-shrink: 0; }
+.review-chip.is-accent, .header-chip.accent, .chip.accent { background: var(--accent-soft, var(--accent-glow)); border-color: color-mix(in srgb, var(--accent) 28%, var(--border)); color: var(--text); }
+.review-header-actions { display:flex; align-items:flex-start; justify-content:flex-end; }
+.review-theme-toggle, .theme-toggle {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.review-theme-toggle:hover, .theme-toggle:hover { border-color: var(--accent); transform: translateY(-1px); }
+
+.tabs.review-tabs, .tab-nav.review-tabs {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1.1rem 0 1.25rem;
+}
+.tabs.review-tabs.review-tabs-3, .tab-nav.review-tabs.review-tabs-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.tabs.review-tabs.review-tabs-4, .tab-nav.review-tabs.review-tabs-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.tab-btn.review-tab-btn, .review-tabs .tab-btn {
+  background: linear-gradient(180deg, var(--surface), var(--surface2));
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.98rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-align: left;
+  min-height: 78px;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.06);
+}
+.review-tabs .tab-btn.priority, .review-tabs .tab-btn.is-priority { position: relative; }
+.review-tabs .tab-btn.priority::before, .review-tabs .tab-btn.is-priority::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 18px;
+  right: 18px;
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), transparent);
+  opacity: 0.85;
+}
+.tab-btn.review-tab-btn:hover, .review-tabs .tab-btn:hover { transform: translateY(-2px); border-color: color-mix(in srgb, var(--accent) 35%, var(--border)); box-shadow: 0 10px 24px rgba(0,0,0,0.10); }
+.tab-btn.review-tab-btn.active, .review-tabs .tab-btn.active { border-color: var(--accent); background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 14%, var(--surface)), var(--surface)); box-shadow: 0 10px 24px var(--accent-glow); }
+.review-tab-icon, .tab-icon, .tab-icon-wrap {
+  width: 38px;
+  height: 38px;
+  border-radius: 11px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface2));
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.review-tabs .tab-btn.active .review-tab-icon,
+.review-tabs .tab-btn.active .tab-icon,
+.review-tabs .tab-btn.active .tab-icon-wrap { background: color-mix(in srgb, var(--accent) 18%, var(--surface2)); }
+.review-tab-copy, .tab-copy { display:flex; flex-direction:column; gap:0.1rem; min-width:0; }
+.review-tab-label, .tab-label { color: var(--text); font-weight: 700; line-height: 1.2; }
+.review-tab-meta, .tab-meta, .tab-sub { color: var(--text-muted); font-size: 0.82rem; line-height: 1.25; }
+.review-page .tab-content { display:none; }
+.review-page .tab-content.active { display:block; animation: fadeUp 0.28s ease; }
+
+.review-panel, .review-card, .card, .formula-section, .info-card, .practice-stat, .problem-card, .topic-card, .section-summary-card {
+  background: linear-gradient(180deg, var(--surface), color-mix(in srgb, var(--surface) 78%, var(--surface2)));
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+.review-card, .card, .formula-section { padding: 1.5rem; margin-bottom: 1.5rem; }
+
+.review-checklist-section, .checklist-section { margin-bottom: 2rem; }
+.review-checklist-section > h3, .checklist-section > h3 { font-family: 'DM Sans', sans-serif; font-size: 1.2rem; color: var(--accent); margin-bottom: 1rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+.review-checklist-row, .check-item, .checklist-item {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  width: 100%;
+  padding: 1rem;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  transition: all 0.2s;
+}
+
+.review-formula-box, .formula-box {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+  margin: 0.6rem 0;
+}
+.review-formula-section, .formula-section { padding: 1.4rem; }
+.review-formula-grid, .formula-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.75rem; }
+
+.review-progress-track, .progress-bar-track, .quiz-progress-bar {
+  background: var(--border);
+  border-radius: 999px;
+  height: 8px;
+  overflow: hidden;
+}
+.review-progress-fill, .progress-bar-fill, .quiz-progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+  transition: width 0.4s ease;
+}
+.review-progress-fill.is-complete, .progress-bar-fill.complete { background: var(--green); }
+
+.review-video-link, .video-link {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 0.75rem 0;
+  padding: 0.85rem 1rem;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text);
+  text-decoration: none;
+  transition: all 0.2s;
+}
+.review-video-link:hover, .video-link:hover { border-color: var(--green, var(--accent)); }
+.review-video-link::after, .video-link::after { content: '↗'; font-size: 0.8rem; color: var(--text); opacity: 0.35; margin-left: auto; padding-left: 0.5rem; flex-shrink: 0; }
+
+.review-callout {
+  padding: 1rem 1.1rem;
+  margin: 1rem 0;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--surface2) 84%, transparent), var(--surface));
+  box-shadow: var(--shadow);
+}
+.review-callout--exam { text-align:center; border-width: 2px; border-color: var(--accent); background: linear-gradient(135deg, var(--accent-glow), var(--red-bg)); }
+.review-callout--tip, .tip-box { background: var(--amber-bg); border-color: color-mix(in srgb, var(--amber) 35%, var(--border)); color: var(--amber); }
+.review-callout--warning, .warning-box { background: var(--red-bg); border-color: color-mix(in srgb, var(--red) 35%, var(--border)); color: var(--red); }
+.review-callout--info { background: var(--blue-bg); border-color: color-mix(in srgb, var(--blue) 35%, var(--border)); color: var(--text); }
+.review-callout--success { background: var(--green-bg); border-color: color-mix(in srgb, var(--green) 35%, var(--border)); color: var(--green); }
+.review-summary-card, .section-summary-card { padding: 1rem 1.1rem; }
+.review-stack-gap { margin-top: 2rem; }
+.review-link-reset { text-decoration: none; }
+
+@media (max-width: 1024px) {
+  .tabs.review-tabs.review-tabs-3, .tab-nav.review-tabs.review-tabs-3, .tabs.review-tabs.review-tabs-4, .tab-nav.review-tabs.review-tabs-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 720px) {
+  .review-shell { width: min(100vw - 1rem, 100%); padding: 1rem 1rem 3rem; }
+  .review-header { flex-direction: column; align-items: flex-start; }
+  .review-meta-chips, .header-chips { margin-top: 0.65rem; }
+  .review-chip, .header-chip, .chip { width: 100%; justify-content: flex-start; }
+  .tabs.review-tabs.review-tabs-3, .tab-nav.review-tabs.review-tabs-3, .tabs.review-tabs.review-tabs-4, .tab-nav.review-tabs.review-tabs-4 { grid-template-columns: 1fr; }
+  .review-tabs .tab-btn { min-height: auto; }
+}


### PR DESCRIPTION
### Motivation
- Consolidate duplicated review-page styles that were repeated across the four Math 130 review pages into a single shared layer to improve maintainability and theme consistency. 
- Provide a stable set of design tokens and component classes for recurring UI patterns (shell, header, tabs, cards, checklist, formulas, progress, video cards, and callouts) so future review pages can reuse a single stylesheet.

### Description
- Added a Math 130 review layer to `styles.css` that defines shared tokens (background/surface/border/accent/muted text/shadows/grid overlay) and semantic colors for `success`/`warning`/`error`/`info`, plus responsive utilities and a `body.review-page` theme hook. 
- Introduced shared component classes such as `.review-shell`, `.review-header`, `.review-meta-chips`/`.review-chip`, `.review-tabs`/`.review-tab-btn`/`.review-tab-icon`, `.review-card`/`.review-panel`, `.review-checklist-section`/`.check-item`, `.review-formula-box`/`.review-formula-grid`, `.review-progress-track`/`.review-progress-fill`, `.review-video-link`, and `.review-callout` variants (`--exam`, `--tip`, `--warning`, `--info`, `--success`). 
- Refactored `130Test1.html`, `130Test2.html`, `130Test3.html`, and `130Test4.html` to use the shared classes (added `body class=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0914e75748331bd97eb17cb6562d3)