### PR TITLE
Redesign Math 130 course dashboard

### DIFF
--- a/courses/math130.html
+++ b/courses/math130.html
@@ -4,10 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MATH 130: Advanced Technical Mathematics</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../styles.css">
   <script src="../theme.js"></script>
 </head>
-<body>
+<body class="math130-course-page">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
@@ -54,64 +57,119 @@
   </div>
 </div>
 
-  <header>
-    <div class="container">
-      <h1>MATH 130: Advanced Technical Mathematics</h1>
-      <p class="subtitle">Advanced mathematical concepts, problem-solving techniques, and practical applications in technical fields.</p>
-    </div>
-  </header>
-
-  <main class="container">
-    <section>
-      <h2>Course Overview</h2>
-      <p>This course explores advanced mathematical topics designed for technical and engineering applications. The curriculum is divided into four main units, each concluding with a comprehensive exam designed to test your mastery of the material.</p>
+<main class="math130-dashboard">
+  <div class="container math130-dashboard__stack">
+    <section class="math130-hero review-card" aria-labelledby="math130-course-title">
+      <div class="math130-hero__content">
+        <div class="course-label">MATH 130 Course Dashboard</div>
+        <h1 id="math130-course-title">Advanced Technical Mathematics</h1>
+        <p class="review-subtitle">Use this page as the visual home base for all four Math 130 review units. Each unit card below points to the same review pages you already use, but now highlights where to begin, what each test emphasizes, and which study tools are waiting on the next page.</p>
+        <div class="header-chips" aria-label="Course highlights">
+          <span class="chip accent">4 review units</span>
+          <span class="chip">Slides, videos, and review tools</span>
+          <span class="chip">Exam-by-exam study flow</span>
+        </div>
+      </div>
+      <aside class="math130-hero__summary review-callout review-callout--info" aria-labelledby="math130-usage-title">
+        <h2 id="math130-usage-title">How to use this course site</h2>
+        <ul class="math130-summary-list">
+          <li>Open the unit that matches your current test window or review goal.</li>
+          <li>Start with the recommended entry point before branching into videos, practice, or formula review.</li>
+          <li>Return here any time you need the full course roadmap across all four exams.</li>
+        </ul>
+      </aside>
     </section>
 
-    <section class="welcome-section">
-      <h2>Course Units & Study Materials</h2>
-      <p>Select a unit below to access lecture slides, videos, assignments, formula sheets, and review materials.</p>
+    <section class="math130-order-strip review-callout review-callout--exam" aria-labelledby="math130-order-title">
+      <div class="math130-order-strip__eyebrow">Start with this order</div>
+      <div class="math130-order-strip__content">
+        <h2 id="math130-order-title">Follow the same study rhythm for every unit.</h2>
+        <div class="review-meta-chips" aria-label="Recommended study order">
+          <span class="chip accent">1. Preview the unit focus</span>
+          <span class="chip">2. Open the linked review page</span>
+          <span class="chip">3. Work the core practice resources</span>
+          <span class="chip">4. Finish with the test-specific review tools</span>
+        </div>
+      </div>
     </section>
 
-    <div class="card-container">
-      
-      <div class="card">
-        <div class="card-icon">📐</div>
-        <h2>Unit 1 (Test 1)</h2>
-        <p>Foundational concepts, algebraic operations, and introductory problem-solving techniques.</p>
-        <a href="../130Test1.html" class="button">View Unit 1 Resources</a>
+    <section class="math130-progress" aria-labelledby="math130-progress-title">
+      <div class="math130-section-heading">
+        <div>
+          <div class="course-label">Course Units &amp; Study Materials</div>
+          <h2 id="math130-progress-title">Choose a unit and jump straight into the matching review hub.</h2>
+        </div>
+        <p class="review-subtitle">The cards below reuse the Math 130 review card system so the landing page feels like the parent dashboard for Test 1 through Final Exam resources.</p>
       </div>
 
-      <div class="card">
-        <div class="card-icon">📈</div>
-        <h2>Unit 2 (Test 2)</h2>
-        <p>Advanced functions, equations, graphing, and specialized technical applications.</p>
-        <a href="../130Test2.html" class="button">View Unit 2 Resources</a>
-      </div>
+      <div class="tabs review-tabs review-tabs-4 math130-unit-grid card-container">
+        <article class="tab-btn review-tab-btn is-priority math130-unit-card">
+          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true">📐</div>
+          <div class="review-tab-copy math130-unit-card__copy">
+            <span class="review-tab-label">Unit 1 · Test 1</span>
+            <span class="review-tab-meta">Foundations, algebra fluency, and setup skills for later units.</span>
+            <div class="math130-meta-stack">
+              <div><strong>Topic focus:</strong> Foundational concepts, algebraic operations, and introductory problem-solving.</div>
+              <div><strong>Recommended start:</strong> Begin with the main overview and foundational examples.</div>
+              <div><strong>Main resources:</strong> Lecture slides, videos, assignments, and review materials.</div>
+            </div>
+            <a href="../130Test1.html" class="button math130-unit-card__button">View Unit 1 Resources</a>
+          </div>
+        </article>
 
-      <div class="card">
-        <div class="card-icon">⚙️</div>
-        <h2>Unit 3 (Test 3)</h2>
-        <p>Trigonometry and vectors: Sections 5.1, 5.2, 5.3, 7.1, and 8.4 with targeted Test 3 review tools.</p>
-        <a href="../130Test3.html" class="button">View Unit 3 Resources</a>
-      </div>
+        <article class="tab-btn review-tab-btn math130-unit-card">
+          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true">📈</div>
+          <div class="review-tab-copy math130-unit-card__copy">
+            <span class="review-tab-label">Unit 2 · Test 2</span>
+            <span class="review-tab-meta">Functions, equations, graphing, and technical modeling tools.</span>
+            <div class="math130-meta-stack">
+              <div><strong>Topic focus:</strong> Advanced functions, equations, graphing, and specialized applications.</div>
+              <div><strong>Recommended start:</strong> Open the Test 2 review tabs and follow the guided checklist flow.</div>
+              <div><strong>Main resources:</strong> Review tabs, formula work, practice sets, and quiz-style checks.</div>
+            </div>
+            <a href="../130Test2.html" class="button math130-unit-card__button">View Unit 2 Resources</a>
+          </div>
+        </article>
 
-      <div class="card">
-        <div class="card-icon">📝</div>
-        <h2>Unit 4 (Final Exam)</h2>
-        <p>Culminating concepts and comprehensive review materials for the final exam.</p>
-        <a href="../130Test4.html" class="button">View Unit 4 Resources</a>
-      </div>
+        <article class="tab-btn review-tab-btn math130-unit-card">
+          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true">⚙️</div>
+          <div class="review-tab-copy math130-unit-card__copy">
+            <span class="review-tab-label">Unit 3 · Test 3</span>
+            <span class="review-tab-meta">Trigonometry, vectors, and targeted mid-course review support.</span>
+            <div class="math130-meta-stack">
+              <div><strong>Topic focus:</strong> Sections 5.1, 5.2, 5.3, 7.1, and 8.4 with Test 3 review tools.</div>
+              <div><strong>Recommended start:</strong> Use the section overview first, then move into formulas and practice.</div>
+              <div><strong>Main resources:</strong> Guided summaries, checklist items, formulas, and mock quiz tools.</div>
+            </div>
+            <a href="../130Test3.html" class="button math130-unit-card__button">View Unit 3 Resources</a>
+          </div>
+        </article>
 
+        <article class="tab-btn review-tab-btn math130-unit-card">
+          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true">📝</div>
+          <div class="review-tab-copy math130-unit-card__copy">
+            <span class="review-tab-label">Unit 4 · Final Exam</span>
+            <span class="review-tab-meta">Cumulative review and final-week preparation across the course.</span>
+            <div class="math130-meta-stack">
+              <div><strong>Topic focus:</strong> Culminating concepts and comprehensive final exam review.</div>
+              <div><strong>Recommended start:</strong> Begin with the final-week plan and identify the highest-priority refreshers.</div>
+              <div><strong>Main resources:</strong> Final review guides, summary cards, formula refreshers, and practice prompts.</div>
+            </div>
+            <a href="../130Test4.html" class="button math130-unit-card__button">View Unit 4 Resources</a>
+          </div>
+        </article>
+      </div>
+    </section>
+  </div>
+</main>
+
+<footer>
+  <div class="container">
+    <p>&copy; 2025 - All Rights Reserved</p>
+    <div class="social-links">
+      <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">📺</a>
     </div>
-  </main>
-
-  <footer>
-    <div class="container">
-      <p>&copy; 2025 - All Rights Reserved</p>
-      <div class="social-links">
-        <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">📺</a>
-      </div>
-    </div>
-  </footer>
+  </div>
+</footer>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1918,3 +1918,208 @@ body.review-page::before {
   .tabs.review-tabs.review-tabs-3, .tab-nav.review-tabs.review-tabs-3, .tabs.review-tabs.review-tabs-4, .tab-nav.review-tabs.review-tabs-4 { grid-template-columns: 1fr; }
   .review-tabs .tab-btn { min-height: auto; }
 }
+
+/* Math 130 course dashboard */
+body.math130-course-page {
+  background:
+    radial-gradient(circle at top, color-mix(in srgb, var(--accent) 10%, transparent), transparent 36%),
+    var(--background-color);
+}
+
+.math130-dashboard {
+  padding: 2.25rem 0 3.5rem;
+}
+
+.math130-dashboard__stack {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.math130-hero,
+.math130-progress,
+.math130-order-strip {
+  position: relative;
+  overflow: hidden;
+}
+
+.math130-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.9fr);
+  gap: 1.25rem;
+  padding: 2rem;
+  border-radius: var(--radius, 16px);
+  box-shadow: var(--shadow);
+}
+
+.math130-hero::before,
+.math130-progress::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 100%;
+  height: 4px;
+  background: linear-gradient(90deg, var(--accent), transparent 68%);
+  opacity: 0.9;
+}
+
+.math130-hero h1,
+.math130-progress h2,
+.math130-order-strip h2 {
+  font-family: 'DM Serif Display', serif;
+  font-weight: 400;
+}
+
+.math130-hero h1 {
+  font-size: clamp(2.2rem, 4vw, 3.4rem);
+  margin-bottom: 0.65rem;
+  color: var(--accent);
+}
+
+.math130-hero__content,
+.math130-hero__summary,
+.math130-progress {
+  position: relative;
+  z-index: 1;
+}
+
+.math130-hero__summary {
+  margin: 0;
+  align-self: stretch;
+}
+
+.math130-hero__summary h2 {
+  font-size: 1.35rem;
+  margin-bottom: 0.85rem;
+}
+
+.math130-summary-list {
+  display: grid;
+  gap: 0.8rem;
+  padding-left: 0;
+}
+
+.math130-summary-list li {
+  position: relative;
+  padding-left: 1.1rem;
+  color: var(--text);
+}
+
+.math130-summary-list li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.math130-order-strip {
+  display: grid;
+  gap: 0.65rem;
+  align-items: start;
+}
+
+.math130-order-strip__eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  opacity: 0.9;
+}
+
+.math130-order-strip__content {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.math130-order-strip .review-meta-chips {
+  margin-top: 0;
+}
+
+.math130-progress {
+  padding: 1.8rem;
+  border-radius: var(--radius, 16px);
+}
+
+.math130-section-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1.25rem;
+}
+
+.math130-section-heading h2 {
+  margin: 0.25rem 0 0;
+}
+
+.math130-section-heading .review-subtitle {
+  max-width: 28rem;
+  margin: 0;
+}
+
+.math130-unit-grid {
+  margin: 0;
+}
+
+.math130-unit-card {
+  align-items: flex-start;
+  min-height: 100%;
+  height: 100%;
+}
+
+.math130-unit-card__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  font-size: 1.25rem;
+}
+
+.math130-unit-card__copy {
+  gap: 0.65rem;
+  width: 100%;
+}
+
+.math130-meta-stack {
+  display: grid;
+  gap: 0.55rem;
+  width: 100%;
+  color: var(--text-muted);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.math130-meta-stack strong {
+  color: var(--text);
+}
+
+.math130-unit-card__button {
+  margin-top: 0.2rem;
+  width: 100%;
+  border-radius: 12px;
+}
+
+@media (max-width: 980px) {
+  .math130-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .math130-section-heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .math130-section-heading .review-subtitle {
+    max-width: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .math130-dashboard {
+    padding-top: 1.5rem;
+  }
+
+  .math130-hero,
+  .math130-progress {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Turn `courses/math130.html` from a generic two-section listing into the visual parent/dashboard for the four existing review pages so students land on a clear course hub.
- Surface quick metadata and a recommended study order per unit so each review page reads as a child of a consistent Math 130 review design system.
- Align spacing, radii, shadows, chips, and callouts on the landing page with the review components already used on the Test 2–4 pages.

### Description
- Replaced the previous landing markup with a dashboard layout that includes a hero/header with course title and orientation copy, a compact “How to use this course site” summary, and a chip-based "Start with this order" strip in `courses/math130.html`.
- Rebuilt the unit area as four larger review-style unit cards that reuse the review classes (`review-card`, `review-tabs`, `tab-btn`, `review-meta-chips`, etc.), each showing topic focus, a recommended starting point, and main resource types while preserving links to `../130Test1.html`–`../130Test4.html`.
- Added a `math130-course-page` body class and appended dashboard-specific rules to `styles.css` to match the extracted review design tokens for spacing, radii, shadows, gradients, chips, and responsive behavior.
- Included the Google Fonts preload/link needed by the review design system and kept the existing top navigation and page-context bar intact.

### Testing
- Ran `git diff --check` to validate no obvious whitespace/format issues, and it completed successfully.
- Parsed the updated HTML with a Python `HTMLParser` script to ensure well-formed markup, which succeeded.
- Ran a Python assertion script confirming the four unit links (`../130Test1.html`, `../130Test2.html`, `../130Test3.html`, `../130Test4.html`) remain present, which passed.
- Verified repository status with `git status --short` as part of automated checks; no outstanding errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c09ff8862083318dea954cb98126f1)