### PR TITLE
Improve review page semantic color contrast

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -29,7 +29,7 @@
   .topic-content ul { list-style: none; padding-left: 0; }
   .topic-content li::before { content: '\2192'; color: var(--accent); margin-right: 0.5rem; font-weight: 600; }
   .formula-box { background: var(--surface2); border: 1px solid var(--border); border-radius: 8px; padding: 0.85rem 1rem; margin: 0.6rem 0; font-family: 'JetBrains Mono', monospace; font-size: 0.88rem; text-align: center; overflow: visible; }
-  .tip-box { background: var(--amber-bg); border-left: 3px solid var(--amber); border-radius: 0 8px 8px 0; padding: 0.75rem 1rem; margin: 0.75rem 0; font-size: 0.88rem; color: var(--amber); }
+  .tip-box { background: color-mix(in srgb, var(--amber) 10%, var(--surface)); border-left: 3px solid var(--amber); border-radius: 0 8px 8px 0; padding: 0.75rem 1rem; margin: 0.75rem 0; font-size: 0.88rem; color: var(--text); }
 
   /* Practice */
   .practice-dashboard { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; margin-bottom: 1.75rem; }
@@ -120,7 +120,7 @@
 
 
   /* Warning callout */
-  .warning-box { background: var(--amber-bg); border-left: 3px solid var(--amber); border-radius: 0 8px 8px 0; padding: 0.65rem 1rem; margin-top: 0.75rem; font-size: 0.85rem; color: var(--amber); animation: fadeUp 0.3s ease; }
+  .warning-box { background: color-mix(in srgb, var(--amber) 10%, var(--surface)); border-left: 3px solid var(--amber); border-radius: 0 8px 8px 0; padding: 0.65rem 1rem; margin-top: 0.75rem; font-size: 0.85rem; color: var(--text); animation: fadeUp 0.3s ease; }
   .warning-box b { color: var(--amber); }
 
   /* Review topic button */

--- a/130Test2.html
+++ b/130Test2.html
@@ -77,7 +77,7 @@
         }
         .formula-priority-note {
             border-left: 4px solid var(--accent);
-            color: var(--text-muted);
+            color: var(--text-body-muted, var(--text-muted));
             font-size: 0.95rem;
             line-height: 1.6;
         }
@@ -114,7 +114,7 @@
         .legend-chip.legend-provided::before { background: var(--green); }
         .legend-chip.legend-useful::before { background: var(--text-muted); }
         .formula-section-note {
-            color: var(--text-muted);
+            color: var(--text-body-muted, var(--text-muted));
             font-size: 0.9rem;
             margin: -0.35rem 0 1rem;
             padding-left: 0.15rem;
@@ -285,13 +285,13 @@
         .best-row { background: var(--green-bg); }
         
         .badge { padding: 0.3rem 0.8rem; border-radius: 20px; font-size: 0.8rem; font-weight: bold; }
-        .badge-perfect { background: var(--green); color: #000; }
-        .badge-retry { background: var(--amber-bg); color: var(--amber); border: 1px solid var(--amber); }
-        .badge-class { background: var(--surface2); color: var(--text-muted); border: 1px solid var(--border); }
-        .badge-quiz { background: var(--accent-glow); color: var(--accent); border: 1px solid var(--accent); margin-left: 4px; }
-        .badge-due { background: var(--red-bg); color: var(--red); border: 1px solid var(--red); margin-left: 4px; }
-        .badge-exam { background: var(--red-bg); color: var(--red); border: 1px solid var(--red); }
-        .badge-noclass { background: var(--amber-bg); color: var(--amber); border: 1px solid var(--amber); }
+        .badge-perfect { background: color-mix(in srgb, var(--green) 18%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--green) 48%, var(--border)); }
+        .badge-retry { background: color-mix(in srgb, var(--amber) 14%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--amber) 45%, var(--border)); }
+        .badge-class { background: var(--surface2); color: var(--text-body-muted, var(--text-muted)); border: 1px solid var(--border); }
+        .badge-quiz { background: color-mix(in srgb, var(--accent) 16%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border)); margin-left: 4px; }
+        .badge-due { background: color-mix(in srgb, var(--red) 12%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--red) 45%, var(--border)); margin-left: 4px; }
+        .badge-exam { background: color-mix(in srgb, var(--red) 14%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--red) 48%, var(--border)); }
+        .badge-noclass { background: color-mix(in srgb, var(--amber) 12%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--amber) 42%, var(--border)); }
 
         .tab-content { display: none; }
         .tab-content.active { display: block; animation: fadeIn 0.4s ease; }
@@ -337,9 +337,9 @@
     margin-bottom: 0.7rem;
     text-transform: uppercase;
 }
-.status-provided { background: var(--green-bg); color: var(--green); border: 1px solid var(--green); }
-.status-memorize { background: var(--red-bg); color: var(--red); border: 1px solid var(--red); }
-.status-supplemental { background: var(--surface); color: var(--text-muted); border: 1px solid var(--border); }
+.status-provided { background: color-mix(in srgb, var(--green) 14%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--green) 45%, var(--border)); }
+.status-memorize { background: color-mix(in srgb, var(--red) 12%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--red) 45%, var(--border)); }
+.status-supplemental { background: var(--surface); color: var(--text-body-muted, var(--text-muted)); border: 1px solid var(--border); }
 
 /* Print Configuration */
 @media print {
@@ -594,9 +594,9 @@
             gap: 0.45rem;
             padding: 0.38rem 0.72rem;
             border-radius: 999px;
-            background: var(--accent-glow);
-            color: var(--accent);
-            border: 1px solid rgba(108, 99, 255, 0.28);
+            background: color-mix(in srgb, var(--accent) 16%, var(--surface));
+            color: var(--text);
+            border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border));
             font-size: 0.8rem;
             font-weight: 700;
             letter-spacing: 0.04em;
@@ -1211,29 +1211,29 @@
 <!-- Mock Exam CTA -->
 <div id="exam-cta" class="review-callout review-callout--exam">
 <h3 style="font-family: 'DM Serif Display', serif; font-size: 1.4rem; margin-bottom: 0.5rem;">🎯 Mock Exam Mode</h3>
-<p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.95rem;">20 exam-matched questions weighted like the real test: ~15% Section 4.2, ~15% Section 4.3, ~70% Geometry. Includes a compound interest table and a multi-part circle theorem problem.</p>
+<p style="color: var(--text-body-muted, var(--text-muted)); margin-bottom: 1rem; font-size: 0.95rem;">20 exam-matched questions weighted like the real test: ~15% Section 4.2, ~15% Section 4.3, ~70% Geometry. Includes a compound interest table and a multi-part circle theorem problem.</p>
 <button class="btn-primary" id="btn-start-exam" onclick="startMockExam()">Start Mock Exam</button>
 </div>
 <!-- Mock Quiz CTA -->
-<div id="quiz-cta" style="background: var(--surface2); border: 1px solid var(--border); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem;">
+<div id="quiz-cta" style="background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 8%, var(--surface)), var(--surface)); border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border)); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem;">
 <h3 style="font-family: 'DM Serif Display', serif; font-size: 1.25rem; margin-bottom: 0.75rem; text-align: center;">📝 Mock Quiz Mode</h3>
-<p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.9rem; text-align: center;">Quizzes 5, 6, and 8 use 5 focused questions. Quiz 7 uses a fixed 8-question blueprint. One attempt per question.</p>
+<p style="color: var(--text-body-muted, var(--text-muted)); margin-bottom: 1rem; font-size: 0.9rem; text-align: center;">Quizzes 5, 6, and 8 use 5 focused questions. Quiz 7 uses a fixed 8-question blueprint. One attempt per question.</p>
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75rem;">
 <button class="btn-secondary" onclick="startMockQuiz(5)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
 <div style="font-weight: 600; margin-bottom: 2px;">Quiz 5 — Section 4.2</div>
-<div style="font-size: 0.8rem; color: var(--text-muted);">Exponentials &amp; Interest</div>
+<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Exponentials &amp; Interest</div>
 </button>
 <button class="btn-secondary" onclick="startMockQuiz(6)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
 <div style="font-weight: 600; margin-bottom: 2px;">Quiz 6 — Section 4.3</div>
-<div style="font-size: 0.8rem; color: var(--text-muted);">Logarithms</div>
+<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Logarithms</div>
 </button>
 <button class="btn-secondary" onclick="startMockQuiz(7)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
 <div style="font-weight: 600; margin-bottom: 2px;">Quiz 7 — Triangles, Lines &amp; Areas (8 Questions)</div>
-<div style="font-size: 0.8rem; color: var(--text-muted);">Similar Triangles, Parallel Lines, Triangle/Polygon Areas, DMS Conversions</div>
+<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Similar Triangles, Parallel Lines, Triangle/Polygon Areas, DMS Conversions</div>
 </button>
 <button class="btn-secondary" onclick="startMockQuiz(8)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
 <div style="font-weight: 600; margin-bottom: 2px;">Quiz 8 — Circles</div>
-<div style="font-size: 0.8rem; color: var(--text-muted);">DMS, Radians, Arcs, Sectors, Speed, Circle Theorems</div>
+<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">DMS, Radians, Arcs, Sectors, Speed, Circle Theorems</div>
 </button>
 </div>
 </div>

--- a/130Test3.html
+++ b/130Test3.html
@@ -153,7 +153,7 @@
         }
         .formula-priority-note {
             border-left: 4px solid var(--accent);
-            color: var(--text-muted);
+            color: var(--text-body-muted, var(--text-muted));
             font-size: 0.95rem;
             line-height: 1.6;
         }
@@ -190,7 +190,7 @@
         .legend-chip.legend-provided::before { background: var(--green); }
         .legend-chip.legend-useful::before { background: var(--text-muted); }
         .formula-section-note {
-            color: var(--text-muted);
+            color: var(--text-body-muted, var(--text-muted));
             font-size: 0.9rem;
             margin: -0.35rem 0 1rem;
             padding-left: 0.15rem;
@@ -362,13 +362,13 @@
         .best-row { background: var(--green-bg); }
         
         .badge { padding: 0.3rem 0.8rem; border-radius: 20px; font-size: 0.8rem; font-weight: bold; }
-        .badge-perfect { background: var(--green); color: #000; }
-        .badge-retry { background: var(--amber-bg); color: var(--amber); border: 1px solid var(--amber); }
-        .badge-class { background: var(--surface2); color: var(--text-muted); border: 1px solid var(--border); }
-        .badge-quiz { background: var(--accent-glow); color: var(--accent); border: 1px solid var(--accent); margin-left: 4px; }
-        .badge-due { background: var(--red-bg); color: var(--red); border: 1px solid var(--red); margin-left: 4px; }
-        .badge-exam { background: var(--red-bg); color: var(--red); border: 1px solid var(--red); }
-        .badge-noclass { background: var(--amber-bg); color: var(--amber); border: 1px solid var(--amber); }
+        .badge-perfect { background: color-mix(in srgb, var(--green) 18%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--green) 48%, var(--border)); }
+        .badge-retry { background: color-mix(in srgb, var(--amber) 14%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--amber) 45%, var(--border)); }
+        .badge-class { background: var(--surface2); color: var(--text-body-muted, var(--text-muted)); border: 1px solid var(--border); }
+        .badge-quiz { background: color-mix(in srgb, var(--accent) 16%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border)); margin-left: 4px; }
+        .badge-due { background: color-mix(in srgb, var(--red) 12%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--red) 45%, var(--border)); margin-left: 4px; }
+        .badge-exam { background: color-mix(in srgb, var(--red) 14%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--red) 48%, var(--border)); }
+        .badge-noclass { background: color-mix(in srgb, var(--amber) 12%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--amber) 42%, var(--border)); }
 
         .tab-content { display: none; }
         .tab-content.active { display: block; animation: fadeIn 0.4s ease; }
@@ -414,9 +414,9 @@
     margin-bottom: 0.7rem;
     text-transform: uppercase;
 }
-.status-provided { background: var(--green-bg); color: var(--green); border: 1px solid var(--green); }
-.status-memorize { background: var(--red-bg); color: var(--red); border: 1px solid var(--red); }
-.status-supplemental { background: var(--surface); color: var(--text-muted); border: 1px solid var(--border); }
+.status-provided { background: color-mix(in srgb, var(--green) 14%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--green) 45%, var(--border)); }
+.status-memorize { background: color-mix(in srgb, var(--red) 12%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--red) 45%, var(--border)); }
+.status-supplemental { background: var(--surface); color: var(--text-body-muted, var(--text-muted)); border: 1px solid var(--border); }
 
 /* Print Configuration */
 @media print {
@@ -689,9 +689,9 @@
             gap: 0.45rem;
             padding: 0.38rem 0.72rem;
             border-radius: 999px;
-            background: var(--accent-glow);
-            color: var(--accent);
-            border: 1px solid rgba(108, 99, 255, 0.28);
+            background: color-mix(in srgb, var(--accent) 16%, var(--surface));
+            color: var(--text);
+            border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border));
             font-size: 0.8rem;
             font-weight: 700;
             letter-spacing: 0.04em;
@@ -1277,29 +1277,29 @@
 <!-- Mock Exam CTA -->
 <div id="exam-cta" class="review-callout review-callout--exam">
 <h3 style="font-family: 'DM Serif Display', serif; font-size: 1.4rem; margin-bottom: 0.5rem;">🎯 Mock Exam Mode</h3>
-<p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.95rem;">20 mixed Unit 3 review questions with coverage from Sections 5.1, 5.2, 5.3, 7.1, and 8.4 (at least one per section).</p>
+<p style="color: var(--text-body-muted, var(--text-muted)); margin-bottom: 1rem; font-size: 0.95rem;">20 mixed Unit 3 review questions with coverage from Sections 5.1, 5.2, 5.3, 7.1, and 8.4 (at least one per section).</p>
 <button class="btn-primary" id="btn-start-exam" onclick="startMockExam()">Start Mock Exam</button>
 </div>
 <!-- Mock Quiz CTA -->
-<div id="quiz-cta" style="background: linear-gradient(180deg, var(--surface2), var(--surface)); border: 1px solid var(--border); border-radius: 16px; padding: 1.35rem 1.5rem; margin-bottom: 2rem;">
+<div id="quiz-cta" style="background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 10%, var(--surface)), var(--surface)); border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border)); border-radius: 16px; padding: 1.35rem 1.5rem; margin-bottom: 2rem;">
 <h3 style="font-family: 'DM Serif Display', serif; font-size: 1.25rem; margin-bottom: 0.75rem; text-align: center;">📝 Mock Quiz Mode</h3>
-<p style="color: var(--text-muted); margin-bottom: 1rem; font-size: 0.9rem; text-align: center;">Each mock quiz has 5 one-attempt questions sampled from an alignment-focused pool (Quiz 10 mixes Sections 5.1 & 5.2; Quizzes 11–13 prioritize exact trig, bearings, and vector workflows).</p>
+<p style="color: var(--text-body-muted, var(--text-muted)); margin-bottom: 1rem; font-size: 0.9rem; text-align: center;">Each mock quiz has 5 one-attempt questions sampled from an alignment-focused pool (Quiz 10 mixes Sections 5.1 & 5.2; Quizzes 11–13 prioritize exact trig, bearings, and vector workflows).</p>
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75rem;">
 <button class="btn-secondary" onclick="startMockQuiz(5)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
 <div style="font-weight: 600; margin-bottom: 2px;">Quiz 10 — Sections 5.1–5.2 (Core Skills)</div>
-<div style="font-size: 0.8rem; color: var(--text-muted);">Coterminal angles + exact trig triangle skills</div>
+<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Coterminal angles + exact trig triangle skills</div>
 </button>
 <button class="btn-secondary" onclick="startMockQuiz(6)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
 <div style="font-weight: 600; margin-bottom: 2px;">Quiz 11 — Section 5.3 (Core Skills)</div>
-<div style="font-size: 0.8rem; color: var(--text-muted);">Reference angles, signs, and solving trig equations on 0°–360°</div>
+<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Reference angles, signs, and solving trig equations on 0°–360°</div>
 </button>
 <button class="btn-secondary" onclick="startMockQuiz(7)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
 <div style="font-weight: 600; margin-bottom: 2px;">Quiz 12 — Section 7.1 (Core Skills)</div>
-<div style="font-size: 0.8rem; color: var(--text-muted);">Airplane applications, angle of elevation, and bearings</div>
+<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Airplane applications, angle of elevation, and bearings</div>
 </button>
 <button class="btn-secondary" onclick="startMockQuiz(8)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
 <div style="font-weight: 600; margin-bottom: 2px;">Quiz 13 — Section 8.4 (Core Skills)</div>
-<div style="font-size: 0.8rem; color: var(--text-muted);">Graph/resultant vectors and magnitude-direction conversions</div>
+<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Graph/resultant vectors and magnitude-direction conversions</div>
 </button>
 </div>
 </div>

--- a/130Test4.html
+++ b/130Test4.html
@@ -48,7 +48,7 @@
         --surface2: #f1f5f9;
         --border: #e2e8f0;
         --text: #0f172a;
-        --text-muted: #64748b;
+        --text-muted: #475569;
         --accent: #5b52e0;
         --accent-glow: rgba(91, 82, 224, 0.12);
         --accent-soft: rgba(91, 82, 224, 0.08);
@@ -86,6 +86,7 @@
             linear-gradient(var(--grid-line) 1px, transparent 1px),
             linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
         background-size: 40px 40px;
+        opacity: 0.45;
         pointer-events: none;
         z-index: 0;
     }
@@ -162,7 +163,7 @@
         border-radius: 999px;
         border: 1px solid var(--border);
         background: var(--surface);
-        color: var(--text-muted);
+        color: var(--text);
         font-size: 0.82rem;
         font-weight: 700;
     }
@@ -175,8 +176,8 @@
     }
 
     .chip.accent {
-        background: var(--accent-soft);
-        border-color: rgba(108,99,255,0.26);
+        background: color-mix(in srgb, var(--accent) 14%, var(--surface));
+        border-color: color-mix(in srgb, var(--accent) 32%, var(--border));
         color: var(--text);
     }
 
@@ -213,8 +214,9 @@
 
     .tab-btn.active {
         border-color: var(--accent);
-        background: linear-gradient(180deg, rgba(108,99,255,0.14), var(--surface));
+        background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 18%, var(--surface)), color-mix(in srgb, var(--accent) 8%, var(--surface)));
         box-shadow: 0 10px 24px var(--accent-glow);
+        color: var(--text);
     }
 
     .tab-icon {

--- a/styles.css
+++ b/styles.css
@@ -1605,6 +1605,8 @@ nav.navbar .dropdown[data-desktop-open="true"] .dropdown-menu {
   --review-green-step: rgba(52, 211, 153, 0.25);
   --review-h1-from: #e2e4ef;
   --review-h1-to: #9d98ff;
+  --review-body-muted: #9aa3bd;
+  --review-semantic-body: #d7dcef;
   --review-success: #34d399;
   --review-success-bg: rgba(52, 211, 153, 0.1);
   --review-warning: #f59e0b;
@@ -1627,6 +1629,8 @@ body.review-page {
   --accent-glow: var(--review-accent-glow);
   --text: var(--review-text);
   --text-muted: var(--review-muted);
+  --text-body-muted: var(--review-body-muted, var(--review-muted));
+  --semantic-body: var(--review-semantic-body, var(--review-text));
   --green: var(--review-success);
   --green-bg: var(--review-success-bg);
   --amber: var(--review-warning);
@@ -1678,6 +1682,8 @@ body.review-page.light {
   --review-green-step: rgba(5, 150, 105, 0.2);
   --review-h1-from: #1a1d2b;
   --review-h1-to: #5046e5;
+  --review-body-muted: #475569;
+  --review-semantic-body: #1e293b;
   --review-success: #059669;
   --review-success-bg: rgba(5, 150, 105, 0.08);
   --review-warning: #d97706;
@@ -1694,6 +1700,7 @@ body.review-page::before {
   inset: 0;
   background-image: linear-gradient(var(--grid-line) 1px, transparent 1px), linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
   background-size: 40px 40px;
+  opacity: 0.45;
   pointer-events: none;
   z-index: 0;
 }
@@ -1733,7 +1740,7 @@ body.review-page::before {
 .review-page h4 { font-family: 'DM Serif Display', serif; font-weight: 400; }
 .review-page h2 { font-size: 1.8rem; margin-bottom: 1.5rem; }
 .review-kicker, .course-label { font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; letter-spacing: 3px; text-transform: uppercase; color: var(--accent); margin-bottom: 0.55rem; }
-.review-subtitle, .header-subtitle, .subtitle { color: var(--text-muted); font-size: 0.98rem; max-width: 52rem; }
+.review-subtitle, .header-subtitle, .subtitle { color: var(--text-body-muted); font-size: 0.98rem; max-width: 52rem; }
 .review-meta-chips, .header-chips {
   display: flex;
   flex-wrap: wrap;
@@ -1748,13 +1755,14 @@ body.review-page::before {
   border-radius: 999px;
   border: 1px solid var(--border);
   background: var(--surface);
-  color: var(--text-muted);
+  color: var(--text-body-muted);
   font-size: 0.82rem;
   font-weight: 600;
   line-height: 1;
 }
 .review-chip i, .header-chip i, .chip i { width: 0.9rem; height: 0.9rem; color: var(--accent); flex-shrink: 0; }
-.review-chip.is-accent, .header-chip.accent, .chip.accent { background: var(--accent-soft, var(--accent-glow)); border-color: color-mix(in srgb, var(--accent) 28%, var(--border)); color: var(--text); }
+.review-chip.is-accent, .header-chip.accent, .chip.accent { background: color-mix(in srgb, var(--accent) 14%, var(--surface)); border-color: color-mix(in srgb, var(--accent) 32%, var(--border)); color: var(--text); }
+.review-chip.is-accent i, .header-chip.accent i, .chip.accent i { color: var(--accent); }
 .review-header-actions { display:flex; align-items:flex-start; justify-content:flex-end; }
 .review-theme-toggle, .theme-toggle {
   background: var(--surface2);
@@ -1807,7 +1815,7 @@ body.review-page::before {
   opacity: 0.85;
 }
 .tab-btn.review-tab-btn:hover, .review-tabs .tab-btn:hover { transform: translateY(-2px); border-color: color-mix(in srgb, var(--accent) 35%, var(--border)); box-shadow: 0 10px 24px rgba(0,0,0,0.10); }
-.tab-btn.review-tab-btn.active, .review-tabs .tab-btn.active { border-color: var(--accent); background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 14%, var(--surface)), var(--surface)); box-shadow: 0 10px 24px var(--accent-glow); }
+.tab-btn.review-tab-btn.active, .review-tabs .tab-btn.active { border-color: var(--accent); background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 18%, var(--surface)), color-mix(in srgb, var(--accent) 8%, var(--surface))); box-shadow: 0 10px 24px var(--accent-glow); color: var(--text); }
 .review-tab-icon, .tab-icon, .tab-icon-wrap {
   width: 38px;
   height: 38px;
@@ -1821,19 +1829,34 @@ body.review-page::before {
 }
 .review-tabs .tab-btn.active .review-tab-icon,
 .review-tabs .tab-btn.active .tab-icon,
-.review-tabs .tab-btn.active .tab-icon-wrap { background: color-mix(in srgb, var(--accent) 18%, var(--surface2)); }
+.review-tabs .tab-btn.active .tab-icon-wrap { background: color-mix(in srgb, var(--accent) 22%, var(--surface2)); }
+.review-tabs .tab-btn.active .review-tab-label,
+.review-tabs .tab-btn.active .tab-label { color: var(--text); }
+.review-tabs .tab-btn.active .review-tab-meta,
+.review-tabs .tab-btn.active .tab-meta,
+.review-tabs .tab-btn.active .tab-sub { color: var(--text-body-muted); }
 .review-tab-copy, .tab-copy { display:flex; flex-direction:column; gap:0.1rem; min-width:0; }
 .review-tab-label, .tab-label { color: var(--text); font-weight: 700; line-height: 1.2; }
-.review-tab-meta, .tab-meta, .tab-sub { color: var(--text-muted); font-size: 0.82rem; line-height: 1.25; }
+.review-tab-meta, .tab-meta, .tab-sub { color: var(--text-body-muted); font-size: 0.82rem; line-height: 1.25; }
 .review-page .tab-content { display:none; }
 .review-page .tab-content.active { display:block; animation: fadeUp 0.28s ease; }
 
 .review-panel, .review-card, .card, .formula-section, .info-card, .practice-stat, .problem-card, .topic-card, .section-summary-card {
+  position: relative;
   background: linear-gradient(180deg, var(--surface), color-mix(in srgb, var(--surface) 78%, var(--surface2)));
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
 }
+.review-panel::before, .review-card::before, .card::before, .formula-section::before, .section-summary-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  pointer-events: none;
+}
+.review-panel > *, .review-card > *, .card > *, .formula-section > *, .section-summary-card > * { position: relative; z-index: 1; }
 .review-card, .card, .formula-section { padding: 1.5rem; margin-bottom: 1.5rem; }
 
 .review-checklist-section, .checklist-section { margin-bottom: 2rem; }
@@ -1898,11 +1921,19 @@ body.review-page::before {
   background: linear-gradient(135deg, color-mix(in srgb, var(--surface2) 84%, transparent), var(--surface));
   box-shadow: var(--shadow);
 }
-.review-callout--exam { text-align:center; border-width: 2px; border-color: var(--accent); background: linear-gradient(135deg, var(--accent-glow), var(--red-bg)); }
-.review-callout--tip, .tip-box { background: var(--amber-bg); border-color: color-mix(in srgb, var(--amber) 35%, var(--border)); color: var(--amber); }
-.review-callout--warning, .warning-box { background: var(--red-bg); border-color: color-mix(in srgb, var(--red) 35%, var(--border)); color: var(--red); }
-.review-callout--info { background: var(--blue-bg); border-color: color-mix(in srgb, var(--blue) 35%, var(--border)); color: var(--text); }
-.review-callout--success { background: var(--green-bg); border-color: color-mix(in srgb, var(--green) 35%, var(--border)); color: var(--green); }
+.review-callout--exam { text-align:center; border-width: 2px; border-color: color-mix(in srgb, var(--accent) 52%, var(--border)); background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 16%, var(--surface)), color-mix(in srgb, var(--surface2) 88%, var(--surface))); }
+.review-callout--tip, .tip-box,
+.review-callout--warning, .warning-box,
+.review-callout--info,
+.review-callout--success { color: var(--semantic-body); }
+.review-callout--tip, .tip-box { background: color-mix(in srgb, var(--amber) 10%, var(--surface)); border-color: color-mix(in srgb, var(--amber) 35%, var(--border)); }
+.review-callout--warning, .warning-box { background: color-mix(in srgb, var(--red) 9%, var(--surface)); border-color: color-mix(in srgb, var(--red) 35%, var(--border)); }
+.review-callout--info { background: color-mix(in srgb, var(--blue) 9%, var(--surface)); border-color: color-mix(in srgb, var(--blue) 35%, var(--border)); }
+.review-callout--success { background: color-mix(in srgb, var(--green) 10%, var(--surface)); border-color: color-mix(in srgb, var(--green) 35%, var(--border)); }
+.review-callout--tip i, .tip-box i, .review-callout--tip strong, .tip-box strong { color: var(--amber); }
+.review-callout--warning i, .warning-box i, .review-callout--warning strong, .warning-box strong { color: var(--red); }
+.review-callout--info i, .review-callout--info strong { color: var(--blue); }
+.review-callout--success i, .review-callout--success strong { color: var(--green); }
 .review-summary-card, .section-summary-card { padding: 1rem 1.1rem; }
 .review-stack-gap { margin-top: 2rem; }
 .review-link-reset { text-decoration: none; }


### PR DESCRIPTION
### Motivation
- The review pages used semantic color text directly on tinted semantic backgrounds and a relatively light muted value, which produced poor contrast for paragraph-sized body copy in both themes.
- Grid overlay and accent-filled panels (chips, active tabs, CTAs, badges, and formula/status pills) made long-reading areas and formula-heavy sections visually noisy and risked unreadable foreground/background pairings.

### Description
- Introduce shared tokens `--review-body-muted` and `--review-semantic-body` and wire them through `--text-body-muted` / `--semantic-body` so paragraph-sized muted copy is darker and semantic callouts use a neutral body color while preserving colored icons/borders. (file: `styles.css`)
- Soften the page grid overlay by setting `opacity: 0.45` on the `body::before` grid and add a subtle base layer to panels via `::before` to reduce visual busyness in long-reading/formula areas. (file: `styles.css`)
- Make accent/tinted fills readable by switching chips, active tab fills, badges, and formula/status pills to tinted backgrounds with neutral foregrounds and keep the semantic color for icons/borders; update selectors such as `.review-chip`, `.chip.accent`, `.tab-btn.active`, `.badge-*`, and `.formula-badge/status-*`. (files: `styles.css`, `130Test2.html`, `130Test3.html`, `130Test4.html`)
- Replace all-amber/all-red callout text with neutral body text on a tinted background and reserve the semantic hue for the left border or icon emphasis in `.tip-box`, `.warning-box`, `.review-callout--*` and update inline CTA blocks (`#exam-cta`, `#quiz-cta`) so body copy inside them uses `--text-body-muted`. (files: `styles.css`, `130Test1.html`, `130Test2.html`, `130Test3.html`)

### Testing
- Ran a Python assertion that checks expected new token usage (`var(--text-body-muted)`) is present in `styles.css` and the test pages, and the check passed. 
- Performed a targeted grep audit for updated selectors and inline CTA blocks (`text-body-muted`, `semantic-body`, `review-callout--tip`, `.chip.accent`, `.tab-btn.active`, `badge-*`, `status-*`, `#quiz-cta`, `#exam-cta`, `body::before`) and confirmed the updates are applied. 
- Verified diffs to `styles.css`, `130Test1.html`, `130Test2.html`, `130Test3.html`, and `130Test4.html` reflect the intended changes and there were no script/runtime errors during the edit process. 
- No visual screenshots were captured in this environment, so visual QA is recommended in a browser to confirm contrast in both light and dark review themes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a11b5e088331bfbafb0d1d0db07d)