### PR TITLE
Refactor inline structural styles into shared utilities and modifiers

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -30,8 +30,6 @@
         }
 
         /* Checklist */
-        .checklist-section { margin-bottom: 2rem; }
-        .checklist-section h3 { font-family: 'DM Sans', sans-serif; font-size: 1.2rem; color: var(--accent); margin-bottom: 1rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
         .checklist-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr)); gap: 1rem; }
         .check-item { display: flex; width: 100%; align-items: center; gap: 1rem; padding: 1rem; background: var(--surface2); border-radius: 12px; border: 1px solid var(--border); cursor: pointer; transition: all 0.2s; user-select: none; }
         .check-item:hover { border-color: var(--accent); }
@@ -311,19 +309,6 @@
         .progress-bar-track { background: var(--border); border-radius: 6px; height: 8px; overflow: hidden; }
         .progress-bar-fill { height: 100%; border-radius: 6px; background: var(--accent); transition: width 0.4s ease; }
         .progress-bar-fill.complete { background: var(--green); }
-
-        /* Video link & watched state */
-        .video-link { color: var(--text); }
-        .video-link span { color: var(--text); font-weight: 500; }
-        .video-link:visited { color: var(--text); }
-        .video-link:visited span { color: var(--text); }
-        .video-link i[data-lucide] { color: var(--green) !important; flex-shrink: 0; opacity: 0.85; }
-        .video-link:hover { border-color: var(--green); }
-        .video-link:hover i[data-lucide] { opacity: 1; }
-        .video-link.watched { border-color: var(--green); background: var(--green-bg); }
-        .video-link.watched i[data-lucide] { color: var(--green) !important; opacity: 0.5; }
-        .video-link.watched span { opacity: 0.5; text-decoration: line-through; }
-        .video-link::after { content: '↗'; font-size: 0.8rem; color: var(--text); opacity: 0.35; margin-left: auto; padding-left: 0.5rem; flex-shrink: 0; }
 
 
 /* Status Badge Styling */
@@ -1238,37 +1223,37 @@
 <!-- PRACTICE TAB -->
 <div class="tab-content" id="tab-practice">
 <div class="card review-card">
-<h2 style="text-align: center; margin-bottom: 0.5rem;">Practice Generators</h2>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Practice generators are live for Test 2 topics and aligned to Sections 4.2, 4.3, and the geometry material covered before the exam.</p>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">By default, enter decimal answers rounded as directed. Repeating decimals are accepted within tolerance (for example, $0.3333$ for $0.\overline{3}$). Some generators may allow additional formats noted in the question (for example, $\pi$ forms).</p>
-<p id="coverage-audit" style="text-align: center; color: var(--text-muted); margin-bottom: 2rem; font-size: 0.9rem;"></p>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 2rem;">Select a topic to generate infinite, exam-style questions.</p>
+<h2 class="u-text-center u-mb-xs">Practice Generators</h2>
+<p class="u-text-center u-mb-sm" style="color: var(--text-muted);">Practice generators are live for Test 2 topics and aligned to Sections 4.2, 4.3, and the geometry material covered before the exam.</p>
+<p class="u-text-center u-mb-md" style="color: var(--text-muted); font-size: 0.92rem;">By default, enter decimal answers rounded as directed. Repeating decimals are accepted within tolerance (for example, $0.3333$ for $0.\overline{3}$). Some generators may allow additional formats noted in the question (for example, $\pi$ forms).</p>
+<p id="coverage-audit" class="u-text-center u-mb-lg" style="color: var(--text-muted); font-size: 0.9rem;"></p>
+<p class="u-text-center u-mb-lg" style="color: var(--text-muted);">Select a topic to generate infinite, exam-style questions.</p>
 <!-- Mock Exam CTA -->
-<div id="exam-cta" class="review-callout review-callout--exam">
-<h3 style="font-family: 'DM Serif Display', serif; font-size: 1.4rem; margin-bottom: 0.5rem;">🎯 Mock Exam Mode</h3>
-<p style="color: var(--text-body-muted, var(--text-muted)); margin-bottom: 1rem; font-size: 0.95rem;">20 exam-matched questions weighted like the real test: ~15% Section 4.2, ~15% Section 4.3, ~70% Geometry. Includes a compound interest table and a multi-part circle theorem problem.</p>
+<div id="exam-cta" class="review-callout review-callout--exam review-callout--highlight">
+<h3 class="review-callout__title review-callout__title--exam">🎯 Mock Exam Mode</h3>
+<p class="review-callout__body review-callout__body--md">20 exam-matched questions weighted like the real test: ~15% Section 4.2, ~15% Section 4.3, ~70% Geometry. Includes a compound interest table and a multi-part circle theorem problem.</p>
 <button class="btn-primary" id="btn-start-exam" onclick="startMockExam()">Start Mock Exam</button>
 </div>
 <!-- Mock Quiz CTA -->
-<div id="quiz-cta" style="background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 8%, var(--surface)), var(--surface)); border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border)); border-radius: 16px; padding: 1.5rem; margin-bottom: 2rem;">
-<h3 style="font-family: 'DM Serif Display', serif; font-size: 1.25rem; margin-bottom: 0.75rem; text-align: center;">📝 Mock Quiz Mode</h3>
-<p style="color: var(--text-body-muted, var(--text-muted)); margin-bottom: 1rem; font-size: 0.9rem; text-align: center;">Quizzes 5, 6, and 8 use 5 focused questions. Quiz 7 uses a fixed 8-question blueprint. One attempt per question.</p>
-<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75rem;">
-<button class="btn-secondary" onclick="startMockQuiz(5)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 5 — Section 4.2</div>
-<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Exponentials &amp; Interest</div>
+<div id="quiz-cta" class="review-callout review-callout--highlight u-mb-lg" style="padding: 1.5rem;">
+<h3 class="review-callout__title u-text-center">📝 Mock Quiz Mode</h3>
+<p class="review-callout__body review-callout__body--sm u-text-center">Quizzes 5, 6, and 8 use 5 focused questions. Quiz 7 uses a fixed 8-question blueprint. One attempt per question.</p>
+<div class="review-option-grid">
+<button class="btn-secondary review-option-button" onclick="startMockQuiz(5)">
+<div class="review-option-title">Quiz 5 — Section 4.2</div>
+<div class="review-option-copy">Exponentials &amp; Interest</div>
 </button>
-<button class="btn-secondary" onclick="startMockQuiz(6)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 6 — Section 4.3</div>
-<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Logarithms</div>
+<button class="btn-secondary review-option-button" onclick="startMockQuiz(6)">
+<div class="review-option-title">Quiz 6 — Section 4.3</div>
+<div class="review-option-copy">Logarithms</div>
 </button>
-<button class="btn-secondary" onclick="startMockQuiz(7)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 7 — Triangles, Lines &amp; Areas (8 Questions)</div>
-<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Similar Triangles, Parallel Lines, Triangle/Polygon Areas, DMS Conversions</div>
+<button class="btn-secondary review-option-button" onclick="startMockQuiz(7)">
+<div class="review-option-title">Quiz 7 — Triangles, Lines &amp; Areas (8 Questions)</div>
+<div class="review-option-copy">Similar Triangles, Parallel Lines, Triangle/Polygon Areas, DMS Conversions</div>
 </button>
-<button class="btn-secondary" onclick="startMockQuiz(8)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 8 — Circles</div>
-<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">DMS, Radians, Arcs, Sectors, Speed, Circle Theorems</div>
+<button class="btn-secondary review-option-button" onclick="startMockQuiz(8)">
+<div class="review-option-title">Quiz 8 — Circles</div>
+<div class="review-option-copy">DMS, Radians, Arcs, Sectors, Speed, Circle Theorems</div>
 </button>
 </div>
 </div>
@@ -1284,10 +1269,10 @@
 </div>
 <!-- Exam Results (hidden until complete) -->
 <div class="card review-card" id="exam-results" style="display: none;">
-<h2 style="text-align: center;">📊 Exam Results</h2>
-<div id="exam-score-display" style="text-align: center; font-size: 3rem; font-family: 'JetBrains Mono', monospace; color: var(--accent); margin: 1rem 0;"></div>
+<h2 class="u-text-center">📊 Exam Results</h2>
+<div id="exam-score-display" class="review-results-score"></div>
 <div id="exam-breakdown" style="margin-top: 1rem;"></div>
-<div style="text-align: center; margin-top: 1.5rem;">
+<div class="review-results-actions">
 <button class="btn-primary" onclick="endMockExam()">Back to Practice</button>
 </div>
 </div>

--- a/130Test3.html
+++ b/130Test3.html
@@ -106,8 +106,6 @@
         }
 
         /* Checklist */
-        .checklist-section { margin-bottom: 2rem; }
-        .checklist-section h3 { font-family: 'DM Sans', sans-serif; font-size: 1.2rem; color: var(--accent); margin-bottom: 1rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
         .checklist-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr)); gap: 1rem; }
         .check-item { display: flex; width: 100%; align-items: center; gap: 1rem; padding: 1rem; background: var(--surface2); border-radius: 12px; border: 1px solid var(--border); cursor: pointer; transition: all 0.2s; user-select: none; }
         .check-item:hover { border-color: var(--accent); }
@@ -388,19 +386,6 @@
         .progress-bar-track { background: var(--border); border-radius: 6px; height: 8px; overflow: hidden; }
         .progress-bar-fill { height: 100%; border-radius: 6px; background: var(--accent); transition: width 0.4s ease; }
         .progress-bar-fill.complete { background: var(--green); }
-
-        /* Video link & watched state */
-        .video-link { color: var(--text); }
-        .video-link span { color: var(--text); font-weight: 500; }
-        .video-link:visited { color: var(--text); }
-        .video-link:visited span { color: var(--text); }
-        .video-link i[data-lucide] { color: var(--green) !important; flex-shrink: 0; opacity: 0.85; }
-        .video-link:hover { border-color: var(--green); }
-        .video-link:hover i[data-lucide] { opacity: 1; }
-        .video-link.watched { border-color: var(--green); background: var(--green-bg); }
-        .video-link.watched i[data-lucide] { color: var(--green) !important; opacity: 0.5; }
-        .video-link.watched span { opacity: 0.5; text-decoration: line-through; }
-        .video-link::after { content: '↗'; font-size: 0.8rem; color: var(--text); opacity: 0.35; margin-left: auto; padding-left: 0.5rem; flex-shrink: 0; }
 
 
 /* Status Badge Styling */
@@ -1291,13 +1276,13 @@
 </div>
 <div class="tab-content" id="tab-practice">
 <div class="card card-tier-primary">
-<div class="section-lead" style="text-align: center; justify-items: center;">
+<div class="section-lead section-lead--center">
 <div class="section-eyebrow"><i data-lucide="pen-tool"></i> Interactive review</div>
-<h2 style="text-align: center; margin-bottom: 0;">Practice Generators</h2>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 0.6rem;">Practice generators are live for Unit 3 and aligned to Sections 5.1, 5.2, 5.3, 7.1, and 8.4.</p>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 1rem; font-size: 0.92rem;">By default, enter decimal answers rounded as directed. Repeating decimals are accepted within tolerance (for example, $0.6667$ for $0.\overline{6}$). Some generators may allow additional formats noted in the question (for example, $\pi$ forms), including coterminal-radian items that accept simple $\pi$ expressions.</p>
-<p id="coverage-audit" style="text-align: center; color: var(--text-muted); margin-bottom: 2rem; font-size: 0.9rem;"></p>
-<p style="text-align: center; color: var(--text-muted); margin-bottom: 0;">Select a topic to generate infinite, exam-style questions.</p>
+<h2 class="u-mb-0">Practice Generators</h2>
+<p class="u-mb-sm" style="color: var(--text-muted);">Practice generators are live for Unit 3 and aligned to Sections 5.1, 5.2, 5.3, 7.1, and 8.4.</p>
+<p class="u-mb-md" style="color: var(--text-muted); font-size: 0.92rem;">By default, enter decimal answers rounded as directed. Repeating decimals are accepted within tolerance (for example, $0.6667$ for $0.\overline{6}$). Some generators may allow additional formats noted in the question (for example, $\pi$ forms), including coterminal-radian items that accept simple $\pi$ expressions.</p>
+<p id="coverage-audit" class="u-mb-lg" style="color: var(--text-muted); font-size: 0.9rem;"></p>
+<p class="u-mb-0" style="color: var(--text-muted);">Select a topic to generate infinite, exam-style questions.</p>
 </div>
 <div class="section-summary-grid">
 <div class="section-summary-card review-summary-card">
@@ -1310,31 +1295,31 @@
 </div>
 </div>
 <!-- Mock Exam CTA -->
-<div id="exam-cta" class="review-callout review-callout--exam">
-<h3 style="font-family: 'DM Serif Display', serif; font-size: 1.4rem; margin-bottom: 0.5rem;">🎯 Mock Exam Mode</h3>
-<p style="color: var(--text-body-muted, var(--text-muted)); margin-bottom: 1rem; font-size: 0.95rem;">20 mixed Unit 3 review questions with coverage from Sections 5.1, 5.2, 5.3, 7.1, and 8.4 (at least one per section).</p>
+<div id="exam-cta" class="review-callout review-callout--exam review-callout--highlight">
+<h3 class="review-callout__title review-callout__title--exam">🎯 Mock Exam Mode</h3>
+<p class="review-callout__body review-callout__body--md">20 mixed Unit 3 review questions with coverage from Sections 5.1, 5.2, 5.3, 7.1, and 8.4 (at least one per section).</p>
 <button class="btn-primary" id="btn-start-exam" onclick="startMockExam()">Start Mock Exam</button>
 </div>
 <!-- Mock Quiz CTA -->
-<div id="quiz-cta" style="background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 10%, var(--surface)), var(--surface)); border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border)); border-radius: 16px; padding: 1.35rem 1.5rem; margin-bottom: 2rem;">
-<h3 style="font-family: 'DM Serif Display', serif; font-size: 1.25rem; margin-bottom: 0.75rem; text-align: center;">📝 Mock Quiz Mode</h3>
-<p style="color: var(--text-body-muted, var(--text-muted)); margin-bottom: 1rem; font-size: 0.9rem; text-align: center;">Each mock quiz has 5 one-attempt questions sampled from an alignment-focused pool (Quiz 10 mixes Sections 5.1 & 5.2; Quizzes 11–13 prioritize exact trig, bearings, and vector workflows).</p>
-<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75rem;">
-<button class="btn-secondary" onclick="startMockQuiz(5)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 10 — Sections 5.1–5.2 (Core Skills)</div>
-<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Coterminal angles + exact trig triangle skills</div>
+<div id="quiz-cta" class="review-callout review-callout--highlight u-mb-lg" style="padding: 1.35rem 1.5rem;">
+<h3 class="review-callout__title u-text-center">📝 Mock Quiz Mode</h3>
+<p class="review-callout__body review-callout__body--sm u-text-center">Each mock quiz has 5 one-attempt questions sampled from an alignment-focused pool (Quiz 10 mixes Sections 5.1 & 5.2; Quizzes 11–13 prioritize exact trig, bearings, and vector workflows).</p>
+<div class="review-option-grid">
+<button class="btn-secondary review-option-button" onclick="startMockQuiz(5)">
+<div class="review-option-title">Quiz 10 — Sections 5.1–5.2 (Core Skills)</div>
+<div class="review-option-copy">Coterminal angles + exact trig triangle skills</div>
 </button>
-<button class="btn-secondary" onclick="startMockQuiz(6)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 11 — Section 5.3 (Core Skills)</div>
-<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Reference angles, signs, and solving trig equations on 0°–360°</div>
+<button class="btn-secondary review-option-button" onclick="startMockQuiz(6)">
+<div class="review-option-title">Quiz 11 — Section 5.3 (Core Skills)</div>
+<div class="review-option-copy">Reference angles, signs, and solving trig equations on 0°–360°</div>
 </button>
-<button class="btn-secondary" onclick="startMockQuiz(7)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 12 — Section 7.1 (Core Skills)</div>
-<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Airplane applications, angle of elevation, and bearings</div>
+<button class="btn-secondary review-option-button" onclick="startMockQuiz(7)">
+<div class="review-option-title">Quiz 12 — Section 7.1 (Core Skills)</div>
+<div class="review-option-copy">Airplane applications, angle of elevation, and bearings</div>
 </button>
-<button class="btn-secondary" onclick="startMockQuiz(8)" style="padding: 0.85rem; text-align: left; border-radius: 12px;">
-<div style="font-weight: 600; margin-bottom: 2px;">Quiz 13 — Section 8.4 (Core Skills)</div>
-<div style="font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted));">Graph/resultant vectors and magnitude-direction conversions</div>
+<button class="btn-secondary review-option-button" onclick="startMockQuiz(8)">
+<div class="review-option-title">Quiz 13 — Section 8.4 (Core Skills)</div>
+<div class="review-option-copy">Graph/resultant vectors and magnitude-direction conversions</div>
 </button>
 </div>
 </div>
@@ -1349,11 +1334,11 @@
 </div>
 </div>
 <!-- Exam Results (hidden until complete) -->
-<div class="card review-card" id="exam-results" style="display: none;">
-<h2 style="text-align: center;">📊 Exam Results</h2>
-<div id="exam-score-display" style="text-align: center; font-size: 3rem; font-family: 'JetBrains Mono', monospace; color: var(--accent); margin: 1rem 0;"></div>
+<div class="card review-card section-lead--results" id="exam-results" style="display: none;">
+<h2>📊 Exam Results</h2>
+<div id="exam-score-display" class="review-results-score"></div>
 <div id="exam-breakdown" style="margin-top: 1rem;"></div>
-<div style="text-align: center; margin-top: 1.5rem;">
+<div class="review-results-actions">
 <button class="btn-primary" onclick="endMockExam()">Back to Practice</button>
 </div>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -1910,7 +1910,15 @@ body.review-page::before {
   text-decoration: none;
   transition: all 0.2s;
 }
+.review-video-link span, .video-link span { color: var(--text); font-weight: 500; }
+.review-video-link:visited, .video-link:visited { color: var(--text); }
+.review-video-link:visited span, .video-link:visited span { color: var(--text); }
+.review-video-link i[data-lucide], .video-link i[data-lucide] { color: var(--green, var(--accent)) !important; flex-shrink: 0; opacity: 0.85; }
 .review-video-link:hover, .video-link:hover { border-color: var(--green, var(--accent)); }
+.review-video-link:hover i[data-lucide], .video-link:hover i[data-lucide] { opacity: 1; }
+.review-video-link.watched, .video-link.watched { border-color: var(--green, var(--accent)); background: var(--green-bg); }
+.review-video-link.watched i[data-lucide], .video-link.watched i[data-lucide] { color: var(--green, var(--accent)) !important; opacity: 0.5; }
+.review-video-link.watched span, .video-link.watched span { opacity: 0.5; text-decoration: line-through; }
 .review-video-link::after, .video-link::after { content: '↗'; font-size: 0.8rem; color: var(--text); opacity: 0.35; margin-left: auto; padding-left: 0.5rem; flex-shrink: 0; }
 
 .review-callout {
@@ -1936,7 +1944,37 @@ body.review-page::before {
 .review-callout--success i, .review-callout--success strong { color: var(--green); }
 .review-summary-card, .section-summary-card { padding: 1rem 1.1rem; }
 .review-stack-gap { margin-top: 2rem; }
-.review-link-reset { text-decoration: none; }
+.review-link-reset, .video-link.review-link-reset { text-decoration: none; }
+
+.u-text-center { text-align: center; }
+.u-mb-0 { margin-bottom: 0; }
+.u-mb-xs { margin-bottom: 0.5rem; }
+.u-mb-sm { margin-bottom: 0.6rem; }
+.u-mb-md { margin-bottom: 1rem; }
+.u-mb-lg { margin-bottom: 2rem; }
+
+.section-lead--center { text-align: center; justify-items: center; }
+.section-lead--center h2,
+.section-lead--center p { text-align: center; }
+.section-lead--results h2 { text-align: center; }
+
+.review-callout--highlight {
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 10%, var(--surface)), var(--surface));
+}
+.review-callout__title { font-family: 'DM Serif Display', serif; font-size: 1.25rem; margin-bottom: 0.75rem; }
+.review-callout__title--exam { font-size: 1.4rem; margin-bottom: 0.5rem; }
+.review-callout__body { color: var(--text-body-muted, var(--text-muted)); margin-bottom: 1rem; }
+.review-callout__body--sm { font-size: 0.9rem; }
+.review-callout__body--md { font-size: 0.95rem; }
+
+.review-option-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75rem; }
+.review-option-button { padding: 0.85rem; text-align: left; border-radius: 12px; }
+.review-option-title { font-weight: 600; margin-bottom: 2px; }
+.review-option-copy { font-size: 0.8rem; color: var(--text-body-muted, var(--text-muted)); }
+
+.review-results-score { text-align: center; font-size: 3rem; font-family: 'JetBrains Mono', monospace; color: var(--accent); margin: 1rem 0; }
+.review-results-actions { text-align: center; margin-top: 1.5rem; }
 
 @media (max-width: 1024px) {
   .tabs.review-tabs.review-tabs-3, .tab-nav.review-tabs.review-tabs-3, .tabs.review-tabs.review-tabs-4, .tab-nav.review-tabs.review-tabs-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }


### PR DESCRIPTION
### Motivation
- Reduce duplicated inline `style="..."` patterns across review pages by centralizing structural presentation rules in the global stylesheet to improve maintainability. 
- Replace repeated alignment, spacing, CTA/card, and video-link overrides with small, semantic utilities and component modifiers. 

### Description
- Added a compact utility and component layer to `styles.css` including `u-text-center`, `u-mb-*` spacing utilities, `section-lead--center`, `review-callout--highlight`, `review-callout__title`, `review-callout__body`, `review-option-grid`, `review-option-button`, `review-results-score`, and `review-results-actions` for reuse across pages. 
- Consolidated video-link states into shared rules under `.review-video-link, .video-link` and moved visited/watched/hover behaviors into `styles.css`. 
- Removed duplicate checklist and video-link CSS blocks from the page-local `<style>` sections in `130Test2.html` and `130Test3.html` and replaced structural inline attributes (alignment, margin overrides, CTA heading styles, quiz option row styles, and results block styles) with the new classes. 
- Left element-specific, data-driven inline values (dynamic widths, SVG sizing, progress widths, `display:` toggles, and unique color/text values) in place. 

### Testing
- Ran a Python-based pattern audit that searched for the targeted inline patterns (`style="text-align: center`, DM Serif CTA heading inline styles, small muted copy inline margins, and `text-decoration` reset) and confirmed the targeted inline usages were removed from the audited sections (passed). 
- Ran an automated diff/inspection to verify `styles.css` contains the new utilities and that `130Test2.html` and `130Test3.html` now reference the new classes instead of the repeated inline styles (passed). 
- Verified that the repository working tree contained only the intended file modifications (`styles.css`, `130Test2.html`, `130Test3.html`) after the automated updates (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a4693d708331ad90c085d70cec97)