### PR TITLE
Make Math 114 pages evergreen

### DIFF
--- a/courses/114-module1-summary.html
+++ b/courses/114-module1-summary.html
@@ -168,27 +168,11 @@
   </p>
   <p>Example: “Three times the difference of a number and ten” → 3(x - 10).</p>
 
-  <h2>4. Assignments for Module 1</h2>
+  <h2>4. Suggested Module 1 Practice Focus</h2>
   <ul>
-    <li>
-      <strong>Homework 1 (20 questions)</strong>:
-      <ul>
-        <li>Practice entering answers (Q1–9).</li>
-        <li>Logical statements (Q10–12).</li>
-        <li>Critical thinking/logic puzzles (Q13–17).</li>
-        <li>Simplify fractions (Q18).</li>
-        <li>Round decimals (Q19–20).</li>
-      </ul>
-    </li>
-    <li>
-      <strong>Quiz 1 (10 questions)</strong>:
-      <ul>
-        <li>Rounding decimals (Q1–2).</li>
-        <li>Simplifying fractions (Q3–4).</li>
-        <li>Logical statements (Q5).</li>
-        <li>Critical thinking/logic puzzles (Q6–10).</li>
-      </ul>
-    </li>
+    <li>Homework or guided practice on answer entry, logic, fraction simplification, and decimal rounding.</li>
+    <li>A short quiz or check-in on rounding, fractions, logical statements, and critical thinking.</li>
+    <li>Any current-term due dates or submission links should be checked on the Spring assignment page or in Canvas.</li>
   </ul>
 
   <h2>5. Learning Outcomes</h2>

--- a/courses/math114-final-review.html
+++ b/courses/math114-final-review.html
@@ -67,8 +67,7 @@
       <div class="container">
         <h1>MATH 114: Final Review &amp; Exam</h1>
         <p class="subtitle">
-          Modules 13–14 and final exam materials for the closing unit and
-          cumulative review.
+          Modules 13–14 and cumulative review resources for the closing stretch of the course.
         </p>
       </div>
     </header>
@@ -82,8 +81,8 @@
             </p>
           </div>
           <div class="course-identity__item">
-            <span class="course-identity__label">Term</span>
-            <p class="course-identity__value">Spring R 2025</p>
+            <span class="course-identity__label">Format</span>
+            <p class="course-identity__value">Evergreen course guide</p>
           </div>
           <div class="course-identity__item">
             <span class="course-identity__label">Instructor</span>
@@ -99,7 +98,7 @@
             <span class="course-identity__label">Current Unit</span>
             <p class="course-identity__value">
               <span class="course-identity__pill"
-                >Modules 13–14 / Final Exam</span
+                >Modules 13–14 / Final exam</span
               >
             </p>
           </div>
@@ -125,19 +124,15 @@
           </p>
           <div class="unit-task-grid">
             <article class="unit-task-card">
-              <h3>Module 13 Homework (9A &amp; 9B)</h3>
+              <h3>Module 13 practice set</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Apr 20, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
-              <h3>Module 13 Quiz (9A &amp; 9B)</h3>
+              <h3>Module 13 check-in quiz</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Apr 21, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>
@@ -151,19 +146,15 @@
           </p>
           <div class="unit-task-grid">
             <article class="unit-task-card">
-              <h3>Module 14 Homework (9B &amp; 9C)</h3>
+              <h3>Module 14 practice set</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Apr 27, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
-              <h3>Module 14 Quiz (9B &amp; 9C)</h3>
+              <h3>Module 14 check-in quiz</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Apr 28, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>
@@ -191,7 +182,7 @@
           </div>
         </section>
         <section class="unit-module-card">
-          <h2>Final Exam</h2>
+          <h2>Final exam</h2>
           <p class="unit-module-summary">
             Use this section for the cumulative review and the final exam
             submission links so the last major course tasks stay visible and
@@ -199,19 +190,15 @@
           </p>
           <div class="unit-task-grid">
             <article class="unit-task-card">
-              <h3>Final Exam Review</h3>
+              <h3>Cumulative review assignment</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Apr 30, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
-              <h3>Final Exam</h3>
+              <h3>Final exam</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> May 1, 11:59pm</li>
-                <li><strong>Points:</strong> 140</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>
@@ -238,36 +225,24 @@
             </article>
           </div>
           <details class="unit-detail-toggle">
-            <summary>Show detailed final exam table</summary>
-            <table class="assignment-resource-table">
-              <thead>
-                <tr>
-                  <th>Exam</th>
-                  <th>Due Date</th>
-                  <th>Points</th>
-                  <th>Links</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>Final Exam Review</td>
-                  <td>Apr 30, 11:59pm</td>
-                  <td>20</td>
-                  <td>
-                    <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Final Exam</td>
-                  <td>May 1, 11:59pm</td>
-                  <td>140</td>
-                  <td>
-                    <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </details>
+          <summary>Show current-term assignment checklist</summary>
+          <table class="assignment-resource-table">
+            <thead>
+              <tr>
+                <th>Assignment / Project</th>
+                <th>Assignment Type</th>
+                <th>Current-Term Access</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>See this unit's listed tasks above</td>
+                <td>Homework, quiz, project, review, or exam</td>
+                <td><a href="math114Spring26Links.html">Open Spring assignment page</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </details>
         </section>
       </div>
       <nav class="course-sequence-nav" aria-label="Course unit navigation">

--- a/courses/math114-financial-math.html
+++ b/courses/math114-financial-math.html
@@ -67,8 +67,7 @@
       <div class="container">
         <h1>MATH 114: Financial Math Unit</h1>
         <p class="subtitle">
-          Modules 5–7 resources for percentages, finance, and pre-Test 2
-          practice.
+          Modules 5–7 concepts, archived resources, and practice tools for percentages and financial mathematics.
         </p>
       </div>
     </header>
@@ -82,8 +81,8 @@
             </p>
           </div>
           <div class="course-identity__item">
-            <span class="course-identity__label">Term</span>
-            <p class="course-identity__value">Spring R 2025</p>
+            <span class="course-identity__label">Format</span>
+            <p class="course-identity__value">Evergreen course guide</p>
           </div>
           <div class="course-identity__item">
             <span class="course-identity__label">Instructor</span>
@@ -123,19 +122,15 @@
           </p>
           <div class="unit-task-grid">
             <article class="unit-task-card">
-              <h3>Module 5 Homework (4A, 4B, 4C, 4D)</h3>
+              <h3>Module 5 practice set</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Feb 18, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
-              <h3>Module 5 Quiz (4A, 4B, 4C, 4D)</h3>
+              <h3>Module 5 check-in quiz</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Feb 19, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>
@@ -185,19 +180,15 @@
           </p>
           <div class="unit-task-grid">
             <article class="unit-task-card">
-              <h3>Module 6 Homework (5A, 5B, 5C)</h3>
+              <h3>Module 6 practice set</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Feb 23, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
-              <h3>Module 6 Quiz (5A, 5B, 5C)</h3>
+              <h3>Module 6 check-in quiz</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Feb 24, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>
@@ -242,17 +233,13 @@
             <article class="unit-task-card">
               <h3>Module 7 Homework (5D &amp; 5E)</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Mar 2, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
               <h3>Module 7 Quiz (5D &amp; 5E)</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Mar 3, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>

--- a/courses/math114-foundations.html
+++ b/courses/math114-foundations.html
@@ -68,8 +68,7 @@
       <div class="container">
         <h1>MATH 114: Orientation &amp; Foundations</h1>
         <p class="subtitle">
-          Modules 1–3 resources, assignments, and study tools for the opening
-          unit.
+          Modules 1–3 concepts, archived resources, and starter tools for the opening unit.
         </p>
       </div>
     </header>
@@ -84,8 +83,8 @@
             </p>
           </div>
           <div class="course-identity__item">
-            <span class="course-identity__label">Term</span>
-            <p class="course-identity__value">Spring R 2025</p>
+            <span class="course-identity__label">Format</span>
+            <p class="course-identity__value">Evergreen course guide</p>
           </div>
           <div class="course-identity__item">
             <span class="course-identity__label">Instructor</span>
@@ -111,19 +110,10 @@
       <section class="unit-overview-block">
         <h2>Orientation &amp; Foundations Overview</h2>
         <p>
-          This opening unit mirrors the course-home card language by bundling
-          the introductions, early quantitative reasoning practice, and starter
-          tools into one scannable place for Modules 1–3.
+          This opening unit gathers the foundational topics, archived resources, and recurring assignment types that introduce students to quantitative reasoning.
         </p>
         <ul class="unit-overview-links">
-          <li>
-            <a
-              href="../pdfs/Quantitative_Reasoning_MATH_114_Spring_R_2025.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Course syllabus</a
-            >
-          </li>
+          <li>Check Canvas for the current syllabus and section-specific policies.</li>
           <li><a href="114-module1-summary.html">Module 1 summary sheet</a></li>
           <li>
             <a
@@ -140,41 +130,31 @@
         <section class="unit-module-card">
           <h2>Module 1</h2>
           <p class="unit-module-summary">
-            Start the semester with the course checklist, first homework and
-            quiz, and a short reflection that helps students connect their math
-            background to the course.
+            Begin with orientation tasks, foundational practice, and a short reflection that helps students connect their math background to the course.
           </p>
           <div class="unit-task-grid">
             <article class="unit-task-card">
-              <h3>Course Requirements Checklist</h3>
+              <h3>Course setup and orientation tasks</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Jan 17, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
-              <h3>Module 1 Homework</h3>
+              <h3>Module 1 practice set</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Jan 19, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
-              <h3>Module 1 Quiz</h3>
+              <h3>Module 1 check-in quiz</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Jan 20, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
               <h3>Math Autobiography</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Jan 24, 11:59pm</li>
-                <li><strong>Points:</strong> 5</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>
@@ -233,17 +213,13 @@
             <article class="unit-task-card">
               <h3>Module 2 Homework (2A, 2B, 2C)</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Jan 26, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
               <h3>Module 2 Quiz (2A, 2B, 2C)</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Jan 27, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>
@@ -287,19 +263,15 @@
           </p>
           <div class="unit-task-grid">
             <article class="unit-task-card">
-              <h3>Module 3 Homework (3A &amp; 3B)</h3>
+              <h3>Module 3 practice set</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Feb 2, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
-              <h3>Module 3 Quiz (3A &amp; 3B)</h3>
+              <h3>Module 3 check-in quiz</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Feb 3, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>

--- a/courses/math114-statistics.html
+++ b/courses/math114-statistics.html
@@ -82,8 +82,8 @@
             </p>
           </div>
           <div class="course-identity__item">
-            <span class="course-identity__label">Term</span>
-            <p class="course-identity__value">Spring R 2025</p>
+            <span class="course-identity__label">Format</span>
+            <p class="course-identity__value">Evergreen course guide</p>
           </div>
           <div class="course-identity__item">
             <span class="course-identity__label">Instructor</span>
@@ -123,19 +123,15 @@
           </p>
           <div class="unit-task-grid">
             <article class="unit-task-card">
-              <h3>Module 9 Homework (6A &amp; 6B)</h3>
+              <h3>Module 9 practice set (6A &amp; 6B)</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Mar 23, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
-              <h3>Module 9 Quiz (6A &amp; 6B)</h3>
+              <h3>Module 9 check-in quiz (6A &amp; 6B)</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Mar 24, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>
@@ -182,19 +178,15 @@
           </p>
           <div class="unit-task-grid">
             <article class="unit-task-card">
-              <h3>Module 10 Homework (6C &amp; 8A)</h3>
+              <h3>Module 10 practice set (6C &amp; 8A)</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Mar 30, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
-              <h3>Module 10 Quiz (6C &amp; 8A)</h3>
+              <h3>Module 10 check-in quiz (6C &amp; 8A)</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Mar 31, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>
@@ -251,19 +243,15 @@
           </p>
           <div class="unit-task-grid">
             <article class="unit-task-card">
-              <h3>Module 11 Homework (8B &amp; 8C)</h3>
+              <h3>Module 11 practice set (8B &amp; 8C)</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Apr 6, 11:59pm</li>
-                <li><strong>Points:</strong> 20</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
             <article class="unit-task-card">
-              <h3>Module 11 Quiz (8B &amp; 8C)</h3>
+              <h3>Module 11 check-in quiz (8B &amp; 8C)</h3>
               <ul class="unit-task-meta">
-                <li><strong>Due:</strong> Apr 7, 11:59pm</li>
-                <li><strong>Points:</strong> 10</li>
-                <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
               </ul>
             </article>
           </div>

--- a/courses/math114-test1.html
+++ b/courses/math114-test1.html
@@ -81,8 +81,8 @@
             </p>
           </div>
           <div class="course-identity__item">
-            <span class="course-identity__label">Term</span>
-            <p class="course-identity__value">Spring R 2025</p>
+            <span class="course-identity__label">Format</span>
+            <p class="course-identity__value">Evergreen course guide</p>
           </div>
           <div class="course-identity__item">
             <span class="course-identity__label">Instructor</span>
@@ -108,7 +108,7 @@
         <h2>Test 1 Overview</h2>
         <p>
           This assessment page keeps the Test 1 workflow scannable: students can
-          see the review work, Project 1, the exam itself, and the supporting
+          see the review work, Project 1 or applied activity, the exam itself, and the supporting
           media for the first major checkpoint.
         </p>
       </section>
@@ -121,28 +121,22 @@
         </p>
         <div class="unit-task-grid">
           <article class="unit-task-card">
-            <h3>Project 1</h3>
+            <h3>Project 1 or applied activity</h3>
             <ul class="unit-task-meta">
-              <li><strong>Due:</strong> Feb 7, 11:59pm</li>
-              <li><strong>Points:</strong> 25</li>
-              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
-            </ul>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
+              </ul>
           </article>
           <article class="unit-task-card">
-            <h3>Test 1 Review (Ch. 2 &amp; 3)</h3>
+            <h3>Test 1 review assignment (Ch. 2 &amp; 3)</h3>
             <ul class="unit-task-meta">
-              <li><strong>Due:</strong> Feb 9, 11:59pm</li>
-              <li><strong>Points:</strong> 20</li>
-              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
-            </ul>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
+              </ul>
           </article>
           <article class="unit-task-card">
-            <h3>Test 1 (Ch. 2 &amp; 3)</h3>
+            <h3>Test 1 assessment</h3>
             <ul class="unit-task-meta">
-              <li><strong>Due:</strong> Feb 10, 11:59pm</li>
-              <li><strong>Points:</strong> 125</li>
-              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
-            </ul>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
+              </ul>
           </article>
         </div>
         <div class="unit-resource-grid">
@@ -169,7 +163,7 @@
               </li>
               <li>
                 <a href="https://youtu.be/2T34DvLslhg"
-                  >Project 1 Instructions</a
+                  >Project 1 or applied activity Instructions</a
                 >
               </li>
               <li>
@@ -194,40 +188,20 @@
           </article>
         </div>
         <details class="unit-detail-toggle">
-          <summary>Show detailed assignment table</summary>
+          <summary>Show current-term assignment checklist</summary>
           <table class="assignment-resource-table">
             <thead>
               <tr>
                 <th>Assignment / Project</th>
-                <th>Due Date</th>
-                <th>Points</th>
-                <th>Links</th>
+                <th>Assignment Type</th>
+                <th>Current-Term Access</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td>Module 4 Test 1 Review (Ch 2 &amp; Ch 3)</td>
-                <td>Feb 9, 11:59pm</td>
-                <td>20</td>
-                <td>
-                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
-                </td>
-              </tr>
-              <tr>
-                <td>Module 4 Test 1 (Ch 2 &amp; Ch 3)</td>
-                <td>Feb 10, 11:59pm</td>
-                <td>125</td>
-                <td>
-                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
-                </td>
-              </tr>
-              <tr>
-                <td>Project 1</td>
-                <td>Feb 7, 11:59pm</td>
-                <td>25</td>
-                <td>
-                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
-                </td>
+                <td>See this unit's listed tasks above</td>
+                <td>Homework, quiz, project, review, or exam</td>
+                <td><a href="math114Spring26Links.html">Open Spring assignment page</a></td>
               </tr>
             </tbody>
           </table>

--- a/courses/math114-test2.html
+++ b/courses/math114-test2.html
@@ -67,7 +67,7 @@
       <div class="container">
         <h1>MATH 114: Test 2 Unit</h1>
         <p class="subtitle">
-          Module 8 review, project, and exam materials for Chapters 4 and 5.
+          Module 8 review materials, project support, and exam preparation for Chapters 4 and 5.
         </p>
       </div>
     </header>
@@ -81,8 +81,8 @@
             </p>
           </div>
           <div class="course-identity__item">
-            <span class="course-identity__label">Term</span>
-            <p class="course-identity__value">Spring R 2025</p>
+            <span class="course-identity__label">Format</span>
+            <p class="course-identity__value">Evergreen course guide</p>
           </div>
           <div class="course-identity__item">
             <span class="course-identity__label">Instructor</span>
@@ -115,34 +115,28 @@
       <section class="unit-module-card">
         <h2>Module 8</h2>
         <p class="unit-module-summary">
-          Finish the financial math stretch with the Test 2 review, Project 2,
+          Finish the financial math stretch with the Test 2 review, Project 2 or applied activity,
           and the full exam, while keeping the formula sheet and calculator
           tools nearby.
         </p>
         <div class="unit-task-grid">
           <article class="unit-task-card">
-            <h3>Project 2</h3>
+            <h3>Project 2 or applied activity</h3>
             <ul class="unit-task-meta">
-              <li><strong>Due:</strong> Mar 7, 11:59pm</li>
-              <li><strong>Points:</strong> 25</li>
-              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
-            </ul>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
+              </ul>
           </article>
           <article class="unit-task-card">
-            <h3>Test 2 Review</h3>
+            <h3>Test 2 review assignment</h3>
             <ul class="unit-task-meta">
-              <li><strong>Due:</strong> Mar 7, 11:59pm</li>
-              <li><strong>Points:</strong> 20</li>
-              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
-            </ul>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
+              </ul>
           </article>
           <article class="unit-task-card">
-            <h3>Test 2 (Ch. 4 &amp; 5)</h3>
+            <h3>Test 2 assessment</h3>
             <ul class="unit-task-meta">
-              <li><strong>Due:</strong> Mar 19, 11:59pm</li>
-              <li><strong>Points:</strong> 125</li>
-              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
-            </ul>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
+              </ul>
           </article>
         </div>
         <div class="unit-resource-grid">
@@ -160,7 +154,7 @@
                 >
               </li>
               <li>
-                <a href="https://youtu.be/AqI10auGYWU">Help with Project 2</a>
+                <a href="https://youtu.be/AqI10auGYWU">Help with Project 2 or applied activity</a>
               </li>
             </ul>
           </article>
@@ -189,40 +183,20 @@
           </article>
         </div>
         <details class="unit-detail-toggle">
-          <summary>Show detailed assignment table</summary>
+          <summary>Show current-term assignment checklist</summary>
           <table class="assignment-resource-table">
             <thead>
               <tr>
                 <th>Assignment / Project</th>
-                <th>Due Date</th>
-                <th>Points</th>
-                <th>Links</th>
+                <th>Assignment Type</th>
+                <th>Current-Term Access</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td>Module 8 Test 2 (Ch 4 &amp; 5)</td>
-                <td>Mar 19, 11:59pm</td>
-                <td>125</td>
-                <td>
-                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
-                </td>
-              </tr>
-              <tr>
-                <td>Module 8 Test 2 Review</td>
-                <td>Mar 7, 11:59pm</td>
-                <td>20</td>
-                <td>
-                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
-                </td>
-              </tr>
-              <tr>
-                <td>Project 2</td>
-                <td>Mar 7, 11:59pm</td>
-                <td>25</td>
-                <td>
-                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
-                </td>
+                <td>See this unit's listed tasks above</td>
+                <td>Homework, quiz, project, review, or exam</td>
+                <td><a href="math114Spring26Links.html">Open Spring assignment page</a></td>
               </tr>
             </tbody>
           </table>

--- a/courses/math114-test3.html
+++ b/courses/math114-test3.html
@@ -67,7 +67,7 @@
       <div class="container">
         <h1>MATH 114: Test 3 Unit</h1>
         <p class="subtitle">
-          Module 12 review, project, and exam resources for Chapters 6 and 8.
+          Module 12 review materials, project support, and exam preparation for Chapters 6 and 8.
         </p>
       </div>
     </header>
@@ -81,8 +81,8 @@
             </p>
           </div>
           <div class="course-identity__item">
-            <span class="course-identity__label">Term</span>
-            <p class="course-identity__value">Spring R 2025</p>
+            <span class="course-identity__label">Format</span>
+            <p class="course-identity__value">Evergreen course guide</p>
           </div>
           <div class="course-identity__item">
             <span class="course-identity__label">Instructor</span>
@@ -108,41 +108,35 @@
         <h2>Test 3 Overview</h2>
         <p>
           This page combines the third exam checkpoint into a clear to-do list
-          plus a separate resources area, so students can move from Project 3 to
+          plus a separate resources area, so students can move from Project 3 or applied activity to
           review and then into the exam.
         </p>
       </section>
       <section class="unit-module-card">
         <h2>Module 12</h2>
         <p class="unit-module-summary">
-          Close the statistics assessment cycle with Project 3 support, the
+          Close the statistics assessment cycle with Project 3 or applied activity support, the
           review assignment, and the third test on Chapters 6 and 8, all
           collected in one module page.
         </p>
         <div class="unit-task-grid">
           <article class="unit-task-card">
-            <h3>Project 3</h3>
+            <h3>Project 3 or applied activity</h3>
             <ul class="unit-task-meta">
-              <li><strong>Due:</strong> Apr 11, 11:59pm</li>
-              <li><strong>Points:</strong> 25</li>
-              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
-            </ul>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
+              </ul>
           </article>
           <article class="unit-task-card">
-            <h3>Test 3 Review</h3>
+            <h3>Test 3 review assignment</h3>
             <ul class="unit-task-meta">
-              <li><strong>Due:</strong> Apr 13, 11:59pm</li>
-              <li><strong>Points:</strong> 20</li>
-              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
-            </ul>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
+              </ul>
           </article>
           <article class="unit-task-card">
-            <h3>Test 3 (Ch. 6 &amp; 8)</h3>
+            <h3>Test 3 assessment</h3>
             <ul class="unit-task-meta">
-              <li><strong>Due:</strong> Apr 14, 11:59pm</li>
-              <li><strong>Points:</strong> 125</li>
-              <li><a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a></li>
-            </ul>
+                <li>See the <a href="math114Spring26Links.html">Spring assignment page</a> for current due dates and section-specific access.</li>
+              </ul>
           </article>
         </div>
         <div class="unit-resource-grid">
@@ -150,7 +144,7 @@
             <h3>Videos</h3>
             <ul>
               <li>
-                <a href="https://youtu.be/RUz9L_W9Mp4">Help with Project 3</a>
+                <a href="https://youtu.be/RUz9L_W9Mp4">Help with Project 3 or applied activity</a>
               </li>
             </ul>
           </article>
@@ -176,40 +170,20 @@
           </article>
         </div>
         <details class="unit-detail-toggle">
-          <summary>Show detailed assignment table</summary>
+          <summary>Show current-term assignment checklist</summary>
           <table class="assignment-resource-table">
             <thead>
               <tr>
                 <th>Assignment / Project</th>
-                <th>Due Date</th>
-                <th>Points</th>
-                <th>Links</th>
+                <th>Assignment Type</th>
+                <th>Current-Term Access</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td>Module 12 Test 3 (Ch 6 &amp; 8)</td>
-                <td>Apr 14, 11:59pm</td>
-                <td>125</td>
-                <td>
-                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
-                </td>
-              </tr>
-              <tr>
-                <td>Module 12 Test 3 Review</td>
-                <td>Apr 13, 11:59pm</td>
-                <td>20</td>
-                <td>
-                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
-                </td>
-              </tr>
-              <tr>
-                <td>Project 3</td>
-                <td>Apr 11, 11:59pm</td>
-                <td>25</td>
-                <td>
-                  <a href="math114Spring26Links.html">Open Spring 2026 assignment links page</a>
-                </td>
+                <td>See this unit's listed tasks above</td>
+                <td>Homework, quiz, project, review, or exam</td>
+                <td><a href="math114Spring26Links.html">Open Spring assignment page</a></td>
               </tr>
             </tbody>
           </table>

--- a/courses/math114.html
+++ b/courses/math114.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MATH 114: Quantitative Reasoning - Spring R 2025</title>
+  <title>MATH 114: Quantitative Reasoning</title>
   <link rel="stylesheet" href="../styles.css">
   <script src="../theme.js"></script>
 </head>
@@ -88,21 +88,20 @@
       <h2>Instructor &amp; Course Logistics</h2>
       <div class="course-meta-grid">
         <div class="course-meta-card">
-          <h3>Meeting Times</h3>
-          <p><strong>Section 002:</strong> Monday, Wednesday, Friday, 9:20 AM – 10:10 AM (DH 2443)</p>
-          <p><strong>Section 003:</strong> Monday, Wednesday, Friday, 12:00 PM – 12:50 PM (DH 2446)</p>
+          <h3>How to Use This Course Hub</h3>
+          <p>Start here for evergreen unit pages, archived learning resources, and the main course navigation.</p>
+          <p>For section-specific meeting times, office hours, and announcements, use the current Canvas course and syllabus.</p>
         </div>
         <div class="course-meta-card">
-          <h3>Instructor &amp; Office</h3>
+          <h3>Instructor &amp; Contact</h3>
           <p><strong>Instructor:</strong> Mr. Andrew Harrison Volk</p>
           <p><strong>Email:</strong> <a href="mailto:ahvolk@liberty.edu">ahvolk@liberty.edu</a></p>
           <p><strong>Office:</strong> DH 4284N</p>
         </div>
         <div class="course-meta-card">
-          <h3>Office Hours</h3>
-          <p>Tuesday (8:15 AM – 12:15 PM)</p>
-          <p>Thursday (8:15 AM – 12:15 PM)</p>
-          <p>Friday (1:00 PM – 3:00 PM)</p>
+          <h3>Evergreen Structure</h3>
+          <p>Each unit page highlights the big ideas, archived slides or videos, and the recurring assignment types students can expect.</p>
+          <p>Direct assignment access for the active term is kept on a separate page so the main course materials stay reusable.</p>
         </div>
       </div>
     </section>
@@ -110,14 +109,14 @@
     <!-- 4. Syllabus / policies -->
     <section>
       <h2>Syllabus &amp; Policies</h2>
-      <p>For the complete outline of topics, assignments, grading, attendance expectations, and course policies, review the syllabus before working through the unit materials.</p>
-      <p><a href="../pdfs/Quantitative_Reasoning_MATH_114_Spring_R_2025.pdf" target="_blank" rel="noopener noreferrer" class="button">Download Syllabus for Spring 2025</a></p>
+      <p>Review the current syllabus in Canvas for term-specific grading policies, attendance expectations, deadlines, and section logistics.</p>
+      <p>This website focuses on reusable course organization and archived learning materials rather than semester-by-semester policy details.</p>
     </section>
 
     <!-- 5. Current or featured unit -->
     <section class="welcome-section">
-      <h2>Current / Featured Unit</h2>
-      <p>The featured area highlights the latest archive module grouping so returning students can quickly continue where the course most recently ended.</p>
+      <h2>Featured Unit</h2>
+      <p>The featured area highlights a capstone unit so returning students can quickly jump to a full review page with end-of-course materials.</p>
       <div class="quick-link-grid">
         <div class="quick-link-card">
           <h3>Final Review &amp; Exam</h3>
@@ -198,19 +197,19 @@
       <p>Start here for the most frequently used course links.</p>
       <div class="quick-link-grid">
         <div class="quick-link-card">
-          <h3>Syllabus</h3>
-          <p>Review policies, grading, and the full semester schedule before you begin.</p>
-          <a href="../pdfs/Quantitative_Reasoning_MATH_114_Spring_R_2025.pdf" target="_blank" rel="noopener noreferrer" class="button">Open Syllabus</a>
+          <h3>Course Structure</h3>
+          <p>Use the unit pages to follow the course sequence, revisit archived resources, and locate the main tools used throughout MATH 114.</p>
+          <a href="#" class="button" onclick="window.scrollTo({top:0, behavior:'smooth'}); return false;">Back to Top</a>
         </div>
         <div class="quick-link-card">
           <h3>Featured Unit</h3>
-          <p>Jump directly to the current featured archive unit for the fastest path back into course materials.</p>
+          <p>Jump directly to a capstone review page for the fastest path into cumulative course materials.</p>
           <a href="math114-final-review.html" class="button">Open Final Review &amp; Exam</a>
         </div>
         <div class="quick-link-card">
-          <h3>Spring 2026 Assignment Links</h3>
-          <p>Use the dedicated Spring 2026 links page for assignment access instead of placing Canvas links directly on this course home.</p>
-          <a href="math114Spring26Links.html" class="button">Open Spring 2026 Links</a>
+          <h3>Spring Assignment Links</h3>
+          <p>Use the separate Spring assignment page for the current term's Canvas links and due-date details.</p>
+          <a href="math114Spring26Links.html" class="button">Open Spring Assignment Page</a>
         </div>
         <div class="quick-link-card">
           <h3>Common Tools</h3>

--- a/courses/math114Spring26Links.html
+++ b/courses/math114Spring26Links.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>MATH 114 Spring 2026 Assignment Links - Sections 2 and 4</title>
+<title>MATH 114 Spring Assignment Links</title>
 <style>
     :root{
       --blue:#1e3a8a;
@@ -190,29 +190,29 @@
       <span aria-hidden="true" class="breadcrumb-sep">›</span>
       <a href="math114.html">MATH 114</a>
       <span aria-hidden="true" class="breadcrumb-sep">›</span>
-      <span class="breadcrumb-current" aria-current="page">Spring 2026 Assignment Links</span>
+      <span class="breadcrumb-current" aria-current="page">Spring Assignment Links</span>
     </nav>
   </div>
 </div>
 <header class="course-header course-header--unit">
   <div class="container">
-    <h1>Spring 2026 Assignment Links</h1>
-    <p class="subtitle">Direct assignment access for MATH 114 Spring 2026 sections 2 and 4, collected in one place.</p>
+    <h1>Spring Assignment Links</h1>
+    <p class="subtitle">Direct assignment access for the active spring offering of MATH 114, collected in one place.</p>
   </div>
 </header>
 <main class="container course-page">
 
 <div class="wrap">
 <section class="hero">
-<h1>MATH 114 Spring 2026 Assignment Links</h1>
-<p class="subtitle">Spring 2026 sections 2 and 4 collected on one page for quick access.</p>
+<h1>MATH 114 Spring Assignment Links</h1>
+<p class="subtitle">Current spring sections collected on one page for quick access.</p>
 <div class="top-links">
 <a href="https://canvas.liberty.edu/courses/934591/assignments" rel="noopener" target="_blank">Open Section 2 Assignments Page</a>
 <a href="https://canvas.liberty.edu/courses/934607/assignments" rel="noopener" target="_blank">Open Section 4 Assignments Page</a>
 </div>
 </section>
 <section class="card">
-<p class="note">Each row lists the assignment once, with point values and direct Canvas links for both sections. Due dates are shown for quick reference.</p>
+<p class="note">Each row lists the assignment once, with direct Canvas links and current due-date information for the spring term.</p>
 <div class="table-wrap">
 <table>
 <thead>


### PR DESCRIPTION
## Summary
- remove current-semester logistics, due dates, and point values from the Math 114 home page and unit pages
- refocus Math 114 copy around reusable unit navigation, archived resources, and evergreen assignment descriptions
- keep the spring assignment links page as the single place for current-term Canvas links and due-date details

## Testing
- static inspection only; no runtime tests were executed
- verified the updated unit pages no longer contain embedded due dates, point values, or Spring 2025/Spring 2026 term labels outside the spring assignment page

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a5459af48331b4a52681e07e2044)