### PR TITLE
Scope Math 130 review styles under .math-review-page and update review pages

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -280,6 +280,7 @@
 
 </head>
 <body class="review-page">
+<div class="math-review-page">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
@@ -734,5 +735,6 @@ function toggleTheme(){
 
 initCL();initQuizView();initPracticeView();renderMath();
 </script>
+</div>
 </body>
 </html>

--- a/130Test2.html
+++ b/130Test2.html
@@ -768,6 +768,7 @@
 
 </head>
 <body class="review-page">
+<div class="math-review-page">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
@@ -4000,5 +4001,6 @@
         }
     }
 </script>
+</div>
 </body>
 </html>

--- a/130Test3.html
+++ b/130Test3.html
@@ -866,6 +866,7 @@
 
 </head>
 <body class="review-page">
+<div class="math-review-page">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
@@ -3555,5 +3556,6 @@
         }
     }
 </script>
+</div>
 </body>
 </html>

--- a/130Test4.html
+++ b/130Test4.html
@@ -16,315 +16,30 @@
 <script defer src="https://cdn.jsdelivr.net/npm/lucide@0.344.0/dist/umd/lucide.min.js"></script>
 
 <style>
-    :root {
-        --bg: #0f1117;
-        --surface: #181a24;
-        --surface2: #1f2233;
-        --border: #2a2d42;
-        --text: #e2e4ef;
-        --text-muted: #8b8fa8;
-        --accent: #6c63ff;
-        --accent-glow: rgba(108, 99, 255, 0.25);
-        --accent-soft: rgba(108, 99, 255, 0.12);
-        --accent-hover: #5a52d5;
-        --green: #34d399;
-        --green-bg: rgba(52, 211, 153, 0.1);
-        --amber: #f59e0b;
-        --amber-bg: rgba(245, 158, 11, 0.1);
-        --red: #f87171;
-        --red-bg: rgba(248, 113, 113, 0.1);
-        --blue: #60a5fa;
-        --blue-bg: rgba(96, 165, 250, 0.1);
-        --purple: #8b5cf6;
-        --purple-bg: rgba(139, 92, 246, 0.1);
-        --shadow: 0 8px 32px rgba(0,0,0,0.28);
-        --radius: 16px;
-        --grid-line: rgba(108, 99, 255, 0.03);
-    }
+    /* Page-specific styles only; shared Math 130 review tokens/components live in styles.css. */
 
-    body.light {
-        --bg: #f8fafc;
-        --surface: #ffffff;
-        --surface2: #f1f5f9;
-        --border: #e2e8f0;
-        --text: #0f172a;
-        --text-muted: #475569;
-        --accent: #5b52e0;
-        --accent-glow: rgba(91, 82, 224, 0.12);
-        --accent-soft: rgba(91, 82, 224, 0.08);
-        --accent-hover: #4a42c0;
-        --green: #059669;
-        --green-bg: rgba(5, 150, 105, 0.08);
-        --amber: #d97706;
-        --amber-bg: rgba(217, 119, 6, 0.08);
-        --red: #dc2626;
-        --red-bg: rgba(220, 38, 38, 0.08);
-        --blue: #2563eb;
-        --blue-bg: rgba(37, 99, 235, 0.08);
-        --purple: #7c3aed;
-        --purple-bg: rgba(124, 58, 237, 0.08);
-        --shadow: 0 8px 32px rgba(15,23,42,0.06);
-        --grid-line: rgba(91, 82, 224, 0.04);
-    }
-
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-
-    body {
-        font-family: 'DM Sans', sans-serif;
-        background: var(--bg);
-        color: var(--text);
-        line-height: 1.6;
-        min-height: 100vh;
-        transition: background-color 0.3s, color 0.3s;
-    }
-
-    body::before {
-        content: '';
-        position: fixed;
-        inset: 0;
-        background-image:
-            linear-gradient(var(--grid-line) 1px, transparent 1px),
-            linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
-        background-size: 40px 40px;
-        opacity: 0.45;
-        pointer-events: none;
-        z-index: 0;
-    }
-
-    .container {
-        position: relative;
-        z-index: 1;
-        max-width: 1040px;
-        margin: 0 auto;
-        padding: 2rem 1.25rem 4rem;
-    }
-
-    header {
-        position: relative;
-        margin-bottom: 1.5rem;
-        padding-bottom: 1.25rem;
-        border-bottom: 1px solid var(--border);
-    }
-
-    .theme-toggle {
-        position: absolute;
-        top: 0;
-        right: 0;
-        background: var(--surface2);
-        border: 1px solid var(--border);
-        color: var(--text);
-        width: 46px;
-        height: 46px;
-        border-radius: 999px;
-        cursor: pointer;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        transition: all 0.2s ease;
-    }
-
-    .theme-toggle:hover {
-        transform: translateY(-1px);
-        border-color: var(--accent);
-    }
-
-    h1, h2, h3, h4 {
-        font-family: 'DM Serif Display', serif;
-        font-weight: 400;
-        line-height: 1.1;
-    }
-
-    h1 {
-        font-size: clamp(2rem, 5vw, 3rem);
-        color: var(--accent);
-        margin-bottom: 0.35rem;
-        max-width: 820px;
-    }
-
-    .header-subtitle {
-        max-width: 760px;
-        color: var(--text-muted);
-        font-size: 1rem;
-    }
-
-    .header-chips {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.6rem;
-        margin-top: 0.95rem;
-        padding-right: 4rem;
-    }
-
-    .chip {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.45rem;
-        padding: 0.45rem 0.8rem;
-        border-radius: 999px;
-        border: 1px solid var(--border);
-        background: var(--surface);
-        color: var(--text);
-        font-size: 0.82rem;
-        font-weight: 700;
-    }
-
-    .chip i {
-        width: 0.9rem;
-        height: 0.9rem;
-        color: var(--accent);
-        flex-shrink: 0;
-    }
-
-    .chip.accent {
-        background: color-mix(in srgb, var(--accent) 14%, var(--surface));
-        border-color: color-mix(in srgb, var(--accent) 32%, var(--border));
-        color: var(--text);
-    }
-
-
-    .recommended-order-panel {
-        margin: 1rem 0 1.5rem;
-        padding: 1.35rem 1.4rem;
-        border-radius: 20px;
-        border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border));
-        background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 10%, var(--surface)), var(--surface));
-        box-shadow: var(--shadow);
-    }
-    .recommended-order-panel .order-kicker {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.45rem;
-        color: var(--accent);
-        font-size: 0.78rem;
-        font-weight: 700;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        margin-bottom: 0.7rem;
-    }
-    .recommended-order-panel h2 { margin-bottom: 0.35rem; }
-    .recommended-order-panel p { color: var(--text-muted); margin-bottom: 1rem; max-width: 70ch; }
-    .recommended-order-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 0.75rem; }
-    .recommended-order-step { background: color-mix(in srgb, var(--surface2) 78%, var(--surface)); border: 1px solid var(--border); border-radius: 14px; padding: 0.9rem 1rem; }
-    .recommended-order-step .step-num { display: block; font-family: 'JetBrains Mono', monospace; font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.35rem; }
-    .recommended-order-step strong { display: block; margin-bottom: 0.2rem; }
-    .recommended-order-step span { display: block; color: var(--text-muted); font-size: 0.88rem; }
-
-    .tabs {
-        display: grid;
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-        gap: 0.75rem;
-        margin: 1.2rem 0 1.25rem;
-    }
-
-    .tab-btn {
-        background: linear-gradient(180deg, var(--surface), var(--surface2));
-        border: 1px solid var(--border);
-        color: var(--text);
-        padding: 0.9rem 1rem;
-        border-radius: 16px;
-        font-family: 'DM Sans', sans-serif;
-        font-size: 0.98rem;
-        font-weight: 600;
-        cursor: pointer;
-        transition: all 0.2s ease;
-        display: flex;
-        align-items: center;
-        gap: 0.75rem;
-        text-align: left;
-        min-height: 78px;
-        box-shadow: 0 6px 18px rgba(0,0,0,0.06);
-    }
-
-    .tab-btn:hover {
-        transform: translateY(-2px);
-        border-color: rgba(108,99,255,0.38);
-    }
-
-    .tab-btn.active {
-        border-color: var(--accent);
-        background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 18%, var(--surface)), color-mix(in srgb, var(--accent) 8%, var(--surface)));
-        box-shadow: 0 10px 24px var(--accent-glow);
-        color: var(--text);
-    }
-
-    .tab-icon {
-        width: 38px;
-        height: 38px;
-        border-radius: 12px;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        background: var(--accent-soft);
-        color: var(--accent);
-        flex-shrink: 0;
-    }
-
-    .tab-icon i {
-        width: 1rem;
-        height: 1rem;
-    }
-
-    .tab-copy {
-        display: flex;
-        flex-direction: column;
-        gap: 0.1rem;
-        min-width: 0;
-    }
-
-    .tab-label {
-        color: var(--text);
-        font-weight: 700;
-        line-height: 1.2;
-    }
-
-    .tab-sub {
-        color: var(--text-muted);
-        font-size: 0.82rem;
-        line-height: 1.25;
-    }
-
-    .tab-content { display: none; }
-    .tab-content.active {
-        display: block;
-        animation: fadeUp 0.28s ease;
-    }
-
-    @keyframes fadeUp {
-        from { opacity: 0; transform: translateY(8px); }
-        to { opacity: 1; transform: translateY(0); }
-    }
-
-    .card {
-        background: var(--surface);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        padding: 1.5rem;
-        box-shadow: var(--shadow);
-        margin-bottom: 1rem;
-    }
-
-    .card h2 {
+    .math-review-page .card h2 {
         font-size: 1.7rem;
         margin-bottom: 0.45rem;
     }
 
-    .card h3 {
+    .math-review-page .card h3 {
         font-size: 1.25rem;
         margin-bottom: 0.55rem;
     }
 
-    .muted {
+    .math-review-page .muted {
         color: var(--text-muted);
     }
 
-    .intro-note {
+    .math-review-page .intro-note {
         display: grid;
         grid-template-columns: 1.25fr 1fr;
         gap: 1rem;
         margin-bottom: 1rem;
     }
 
-    .callout {
+    .math-review-page .callout {
         background: var(--surface2);
         border: 1px solid var(--border);
         border-left: 4px solid var(--accent);
@@ -333,35 +48,35 @@
         color: var(--text-muted);
     }
 
-    .callout strong { color: var(--text); }
+    .math-review-page .callout strong { color: var(--text); }
 
-    .mini-grid,
-    .scope-grid,
-    .formula-grid,
-    .plan-grid {
+    .math-review-page .mini-grid,
+    .math-review-page .scope-grid,
+    .math-review-page .formula-grid,
+    .math-review-page .plan-grid {
         display: grid;
         gap: 1rem;
     }
 
-    .mini-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-    .scope-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .formula-grid { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
-    .plan-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .math-review-page .mini-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .math-review-page .scope-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .math-review-page .formula-grid { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    .math-review-page .plan-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 
-    .mini-card,
-    .scope-card,
-    .formula-card,
-    .plan-card {
+    .math-review-page .mini-card,
+    .math-review-page .scope-card,
+    .math-review-page .formula-card,
+    .math-review-page .plan-card {
         background: var(--surface2);
         border: 1px solid var(--border);
         border-radius: 14px;
         padding: 1rem 1.05rem;
     }
 
-    .mini-card h4,
-    .scope-card h4,
-    .formula-card h4,
-    .plan-card h4 {
+    .math-review-page .mini-card h4,
+    .math-review-page .scope-card h4,
+    .math-review-page .formula-card h4,
+    .math-review-page .plan-card h4 {
         font-family: 'DM Sans', sans-serif;
         font-weight: 700;
         font-size: 0.98rem;
@@ -369,15 +84,15 @@
         color: var(--text);
     }
 
-    .mini-card p,
-    .scope-card p,
-    .formula-card p,
-    .plan-card p {
+    .math-review-page .mini-card p,
+    .math-review-page .scope-card p,
+    .math-review-page .formula-card p,
+    .math-review-page .plan-card p {
         color: var(--text-muted);
         font-size: 0.94rem;
     }
 
-    .schedule-table {
+    .math-review-page .schedule-table {
         width: 100%;
         border-collapse: collapse;
         overflow: hidden;
@@ -386,37 +101,37 @@
         background: var(--surface2);
     }
 
-    .schedule-table tr + tr td {
+    .math-review-page .schedule-table tr + tr td {
         border-top: 1px solid var(--border);
     }
 
-    .schedule-table td {
+    .math-review-page .schedule-table td {
         padding: 1rem 1rem;
         vertical-align: middle;
     }
 
-    .schedule-table .day {
+    .math-review-page .schedule-table .day {
         width: 150px;
         font-weight: 700;
         font-size: 1.02rem;
         white-space: nowrap;
     }
 
-    .schedule-table .event {
+    .math-review-page .schedule-table .event {
         font-size: 1.02rem;
         font-weight: 600;
     }
 
-    .schedule-table .event strong {
+    .math-review-page .schedule-table .event strong {
         font-weight: 700;
     }
 
-    .schedule-table .tags {
+    .math-review-page .schedule-table .tags {
         width: 220px;
         text-align: right;
     }
 
-    .tag {
+    .math-review-page .tag {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -431,31 +146,31 @@
         white-space: nowrap;
     }
 
-    .tag.review {
+    .math-review-page .tag.review {
         color: var(--amber);
         background: var(--amber-bg);
         border-color: var(--amber);
     }
 
-    .tag.quiz {
+    .math-review-page .tag.quiz {
         color: var(--purple);
         background: var(--purple-bg);
         border-color: var(--purple);
     }
 
-    .tag.final {
+    .math-review-page .tag.final {
         color: var(--red);
         background: var(--red-bg);
         border-color: var(--red);
     }
 
-    .tag.noclass {
+    .math-review-page .tag.noclass {
         color: var(--amber);
         background: var(--amber-bg);
         border-color: var(--amber);
     }
 
-    .eyebrow {
+    .math-review-page .eyebrow {
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
@@ -467,14 +182,14 @@
         font-weight: 800;
     }
 
-    .pill-row {
+    .math-review-page .pill-row {
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;
         margin: 0.9rem 0 0.2rem;
     }
 
-    .soft-pill {
+    .math-review-page .soft-pill {
         display: inline-flex;
         align-items: center;
         gap: 0.35rem;
@@ -487,29 +202,29 @@
         font-weight: 700;
     }
 
-    .formula-card.provided {
+    .math-review-page .formula-card.provided {
         border-color: var(--green);
         background: linear-gradient(180deg, var(--surface2), var(--green-bg));
     }
 
-    .formula-card.core {
+    .math-review-page .formula-card.core {
         border-color: var(--accent);
         background: linear-gradient(180deg, var(--surface2), var(--accent-soft));
     }
 
-    .formula-math {
+    .math-review-page .formula-math {
         font-size: 1.08rem;
         color: var(--text);
         margin: 0.25rem 0 0.45rem;
         min-height: 2.4rem;
     }
 
-    .formula-note {
+    .math-review-page .formula-note {
         color: var(--text-muted);
         font-size: 0.86rem;
     }
 
-    details.accordion {
+    .math-review-page details.accordion {
         background: var(--surface2);
         border: 1px solid var(--border);
         border-radius: 14px;
@@ -518,11 +233,11 @@
         margin-bottom: 0.8rem;
     }
 
-    details.accordion[open] {
-        border-color: rgba(108,99,255,0.32);
+    .math-review-page details.accordion[open] {
+        border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
     }
 
-    details.accordion summary {
+    .math-review-page details.accordion summary {
         list-style: none;
         cursor: pointer;
         padding: 1rem 1.05rem;
@@ -534,16 +249,16 @@
         color: var(--text);
     }
 
-    details.accordion summary::-webkit-details-marker { display: none; }
+    .math-review-page details.accordion summary::-webkit-details-marker { display: none; }
 
-    .summary-copy {
+    .math-review-page .summary-copy {
         display: flex;
         align-items: center;
         gap: 0.7rem;
         min-width: 0;
     }
 
-    .summary-icon {
+    .math-review-page .summary-icon {
         width: 34px;
         height: 34px;
         border-radius: 10px;
@@ -555,59 +270,70 @@
         flex-shrink: 0;
     }
 
-    .accordion-body {
+    .math-review-page .accordion-body {
         padding: 0 1.05rem 1rem;
         color: var(--text-muted);
     }
 
-    .accordion-body ul {
+    .math-review-page .accordion-body ul {
         padding-left: 1.1rem;
         display: grid;
         gap: 0.35rem;
     }
 
-    .foot {
+    .math-review-page .foot {
         margin-top: 1.25rem;
         color: var(--text-muted);
         font-size: 0.86rem;
         text-align: center;
     }
 
-    .katex-display { margin: 0.15rem 0; }
+    .math-review-page .katex-display { margin: 0.15rem 0; }
 
     @media (max-width: 920px) {
-        .tabs { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-        .intro-note, .scope-grid, .plan-grid { grid-template-columns: 1fr; }
-        .mini-grid { grid-template-columns: 1fr; }
+        .math-review-page .intro-note,
+        .math-review-page .scope-grid,
+        .math-review-page .plan-grid {
+            grid-template-columns: 1fr;
+        }
+
+        .math-review-page .mini-grid {
+            grid-template-columns: 1fr;
+        }
     }
 
     @media (max-width: 720px) {
-        .container { padding: 1.2rem 0.9rem 3rem; }
-        .theme-toggle {
-            position: static;
-            margin-top: 0.9rem;
+        .math-review-page .schedule-table,
+        .math-review-page .schedule-table tbody,
+        .math-review-page .schedule-table tr,
+        .math-review-page .schedule-table td {
+            display: block;
+            width: 100%;
         }
-        .header-chips { padding-right: 0; }
-        .tabs { grid-template-columns: 1fr; }
-        .schedule-table,
-        .schedule-table tbody,
-        .schedule-table tr,
-        .schedule-table td { display: block; width: 100%; }
-        .schedule-table td {
+
+        .math-review-page .schedule-table td {
             padding: 0.85rem 1rem;
         }
-        .schedule-table .day {
+
+        .math-review-page .schedule-table .day {
             padding-bottom: 0.2rem;
         }
-        .schedule-table .tags {
+
+        .math-review-page .schedule-table .tags {
             text-align: left;
             padding-top: 0.15rem;
         }
-        .tag { margin-left: 0; margin-right: 0.4rem; margin-top: 0.35rem; }
+
+        .math-review-page .tag {
+            margin-left: 0;
+            margin-right: 0.4rem;
+            margin-top: 0.35rem;
+        }
     }
 </style>
 </head>
 <body class="review-page">
+<div class="math-review-page">
 <div class="container review-shell">
     <header class="review-header">
         <div class="breadcrumb">
@@ -1072,5 +798,6 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 });
 </script>
+</div>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1619,7 +1619,8 @@ nav.navbar .dropdown[data-desktop-open="true"] .dropdown-menu {
   --review-shell-width: min(1100px, calc(100vw - 2rem));
 }
 
-body.review-page {
+body.review-page,
+.math-review-page {
   --bg: var(--review-bg);
   --surface: var(--review-surface);
   --surface2: var(--review-surface-2);
@@ -1660,7 +1661,9 @@ body.review-page {
   transition: background-color 0.3s, color 0.3s;
 }
 
-body.review-page.light {
+body.review-page.light,
+body.light .math-review-page,
+.math-review-page.is-light {
   --review-bg: #f8fafc;
   --review-surface: #ffffff;
   --review-surface-2: #f1f5f9;
@@ -1705,6 +1708,34 @@ body.review-page::before {
   z-index: 0;
 }
 
+.math-review-page {
+  position: relative;
+  width: 100%;
+  font-family: 'DM Sans', sans-serif;
+  color: var(--text);
+  isolation: isolate;
+  background:
+    radial-gradient(circle at top, color-mix(in srgb, var(--accent) 10%, transparent), transparent 36%),
+    var(--bg);
+}
+
+.math-review-page .container,
+.math-review-page main,
+.math-review-page section,
+.math-review-page header {
+  position: relative;
+  z-index: 1;
+}
+
+.math-review-page > header,
+.math-review-page .review-header {
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  padding: 0;
+  box-shadow: none;
+}
+
 .review-shell {
   width: var(--review-shell-width);
   max-width: 1100px;
@@ -1727,6 +1758,7 @@ body.review-page::before {
 
 .review-title-group { max-width: 52rem; }
 .review-header h1,
+.math-review-page h1.review-title,
 .review-page h1.review-title {
   font-family: 'DM Serif Display', serif;
   font-weight: 400;
@@ -1735,9 +1767,13 @@ body.review-page::before {
   color: var(--accent);
   margin: 0 0 0.35rem;
 }
+.math-review-page h2,
+.math-review-page h3,
+.math-review-page h4,
 .review-page h2,
 .review-page h3,
 .review-page h4 { font-family: 'DM Serif Display', serif; font-weight: 400; }
+.math-review-page h2,
 .review-page h2 { font-size: 1.8rem; margin-bottom: 1.5rem; }
 .review-kicker, .course-label { font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; letter-spacing: 3px; text-transform: uppercase; color: var(--accent); margin-bottom: 0.55rem; }
 .review-subtitle, .header-subtitle, .subtitle { color: var(--text-body-muted); font-size: 0.98rem; max-width: 52rem; }
@@ -1838,7 +1874,9 @@ body.review-page::before {
 .review-tab-copy, .tab-copy { display:flex; flex-direction:column; gap:0.1rem; min-width:0; }
 .review-tab-label, .tab-label { color: var(--text); font-weight: 700; line-height: 1.2; }
 .review-tab-meta, .tab-meta, .tab-sub { color: var(--text-body-muted); font-size: 0.82rem; line-height: 1.25; }
+.math-review-page .tab-content,
 .review-page .tab-content { display:none; }
+.math-review-page .tab-content.active,
 .review-page .tab-content.active { display:block; animation: fadeUp 0.28s ease; }
 
 .review-panel, .review-card, .card, .formula-section, .info-card, .practice-stat, .problem-card, .topic-card, .section-summary-card {
@@ -1975,6 +2013,56 @@ body.review-page::before {
 
 .review-results-score { text-align: center; font-size: 3rem; font-family: 'JetBrains Mono', monospace; color: var(--accent); margin: 1rem 0; }
 .review-results-actions { text-align: center; margin-top: 1.5rem; }
+
+.review-formula-section,
+.formula-section {
+  break-inside: avoid;
+}
+
+@media print {
+  body.review-page,
+  .math-review-page {
+    background: #fff !important;
+    color: #111827 !important;
+  }
+
+  body.review-page::before {
+    display: none;
+  }
+
+  .math-review-page {
+    width: 100%;
+  }
+
+  .math-review-page .review-card,
+  .math-review-page .card,
+  .math-review-page .formula-section,
+  .math-review-page .review-callout,
+  .math-review-page .formula-card,
+  .math-review-page .formula-item {
+    background: #fff !important;
+    box-shadow: none !important;
+    color: #111827 !important;
+    border-color: #cbd5e1 !important;
+  }
+
+  .math-review-page .review-theme-toggle,
+  .math-review-page .theme-toggle,
+  .math-review-page .tabs.review-tabs,
+  .math-review-page .quiz-selector,
+  .math-review-page .btn-primary,
+  .math-review-page .btn-secondary {
+    display: none !important;
+  }
+
+  .math-review-page .formula-box,
+  .math-review-page .review-formula-box,
+  .math-review-page .formula-math {
+    overflow: visible !important;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+}
 
 @media (max-width: 1024px) {
   .tabs.review-tabs.review-tabs-3, .tab-nav.review-tabs.review-tabs-3, .tabs.review-tabs.review-tabs-4, .tab-nav.review-tabs.review-tabs-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }


### PR DESCRIPTION
### Motivation
- Prevent global selectors like `header`, `section`, `.container`, and `main` from colliding with the richer Math 130 review layouts by scoping advanced primitives to a dedicated namespace.
- Provide a single place for review-specific tokens, tab/panel primitives, chips, callouts, and print-safe formula behavior so course pages no longer need to override broad site defaults.

### Description
- Add a scoped review namespace by introducing `.math-review-page` and related light-mode variants in `styles.css` while preserving the legacy `body.review-page` variable path so older pages remain supported.
- Move and adapt advanced review variables and components (tabbed navigation, review cards/panels, chips, semantic callouts, formula grids, and review headers) under the `.math-review-page` scope and add a small scoped container reset so generic global elements do not interfere with review layout.
- Add print-safe rules under the scoped layer to ensure formula sections, cards, and KaTeX render correctly when printed (`@media print` rules targeting `.math-review-page`).
- Wrap the Math 130 review pages (`130Test1.html`, `130Test2.html`, `130Test3.html`, and `130Test4.html`) with `<div class="math-review-page">` so they inherit the new scoped primitives, and simplify `130Test4.html` by keeping only page-specific styles scoped to `.math-review-page`.

### Testing
- Ran an HTML structural check using the built-in Python `HTMLParser` to validate markup parseability on `130Test1.html`, `130Test2.html`, `130Test3.html`, and `130Test4.html`; the parser completed successfully (passed).
- Ran a Python assertion that each review page contains the wrapper `'<div class="math-review-page">'` to confirm pages were updated; the assertion passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a65bcc8c83319f115b973ad6735f)