### PR TITLE
Fix Math 130 review page navigation (responsive menu + dropdown handling)

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -287,7 +287,11 @@
       <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
     </div>
     <div class="top-nav-actions">
-      <ul class="top-nav-links">
+      <button class="menu-toggle global-nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav-links primary-nav-utilities" aria-label="Toggle navigation">
+        <span>Menu</span>
+        <span class="menu-toggle__icon" aria-hidden="true"></span>
+      </button>
+      <ul class="top-nav-links" id="primary-nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="CV.html">About</a></li>
         <li class="dropdown">
@@ -301,7 +305,7 @@
         </li>
         <li><a href="projects.html">Tools</a></li>
       </ul>
-      <ul class="top-nav-utilities" aria-label="More">
+      <ul class="top-nav-utilities" id="primary-nav-utilities" aria-label="More">
         <li class="dropdown">
           <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
           <ul class="dropdown-menu dropdown-menu--right">
@@ -455,6 +459,22 @@
 // KaTeX
 function renderMath(){document.querySelectorAll('.k').forEach(el=>{if(el.dataset.rendered)return;try{katex.render(el.textContent,el,{throwOnError:false});el.dataset.rendered='true';}catch(e){}})}
 function renderLatexString(s){return s.replace(/\\?\\\((.+?)\\?\\\)/g,(_,t)=>{const sp=document.createElement('span');try{katex.render(t,sp,{throwOnError:false})}catch(e){sp.textContent=t}return sp.outerHTML})}
+function initTopNav(){
+  const nav=document.querySelector('.top-nav');
+  if(!nav)return;
+  const menuToggle=nav.querySelector('.menu-toggle.global-nav-toggle');
+  const navLinks=nav.querySelector('.top-nav-links');
+  const navUtilities=nav.querySelector('.top-nav-utilities');
+  const dropdowns=[...nav.querySelectorAll('.dropdown')];
+  const closeDropdowns=(keep)=>dropdowns.forEach(drop=>{if(drop!==keep){drop.removeAttribute('data-desktop-open');drop.removeAttribute('data-mobile-open');const trigger=drop.querySelector('.dropdown-trigger');if(trigger)trigger.setAttribute('aria-expanded','false');}});
+  const syncMenuState=()=>{const expanded=menuToggle && menuToggle.getAttribute('aria-expanded')==='true';nav.toggleAttribute('data-menu-open',expanded);if(navLinks)navLinks.dataset.open=expanded?'true':'false';if(navUtilities)navUtilities.dataset.open=expanded?'true':'false';if(!expanded)closeDropdowns();};
+  if(menuToggle){menuToggle.addEventListener('click',()=>{const expanded=menuToggle.getAttribute('aria-expanded')==='true';menuToggle.setAttribute('aria-expanded',String(!expanded));syncMenuState();});syncMenuState();}
+  dropdowns.forEach(drop=>{const trigger=drop.querySelector('.dropdown-trigger');if(!trigger)return;trigger.setAttribute('aria-expanded','false');trigger.addEventListener('click',(e)=>{e.stopPropagation();const mobile=window.matchMedia('(max-width: 768px)').matches;const attr=mobile?'data-mobile-open':'data-desktop-open';const isOpen=drop.getAttribute(attr)==='true';closeDropdowns(drop);if(isOpen){drop.removeAttribute(attr);trigger.setAttribute('aria-expanded','false');}else{drop.setAttribute(attr,'true');trigger.setAttribute('aria-expanded','true');}});});
+  document.addEventListener('click',(e)=>{if(!nav.contains(e.target))closeDropdowns();});
+  document.addEventListener('keydown',(e)=>{if(e.key==='Escape'){if(menuToggle){menuToggle.setAttribute('aria-expanded','false');syncMenuState();}closeDropdowns();}});
+  window.addEventListener('resize',()=>{closeDropdowns();if(menuToggle&&window.matchMedia('(min-width: 769px)').matches){menuToggle.setAttribute('aria-expanded','false');syncMenuState();}});
+}
+initTopNav();
 
 // Tab nav + fades
 const tabNav=document.getElementById('tabNav'),fadeL=document.getElementById('fade-left'),fadeR=document.getElementById('fade-right');

--- a/130Test2.html
+++ b/130Test2.html
@@ -775,7 +775,11 @@
       <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
     </div>
     <div class="top-nav-actions">
-      <ul class="top-nav-links">
+      <button class="menu-toggle global-nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav-links primary-nav-utilities" aria-label="Toggle navigation">
+        <span>Menu</span>
+        <span class="menu-toggle__icon" aria-hidden="true"></span>
+      </button>
+      <ul class="top-nav-links" id="primary-nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="CV.html">About</a></li>
         <li class="dropdown">
@@ -789,7 +793,7 @@
         </li>
         <li><a href="projects.html">Tools</a></li>
       </ul>
-      <ul class="top-nav-utilities" aria-label="More">
+      <ul class="top-nav-utilities" id="primary-nav-utilities" aria-label="More">
         <li class="dropdown">
           <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
           <ul class="dropdown-menu dropdown-menu--right">
@@ -3088,8 +3092,25 @@
         });
     }
 
+
+function initTopNav(){
+  const nav=document.querySelector('.top-nav');
+  if(!nav)return;
+  const menuToggle=nav.querySelector('.menu-toggle.global-nav-toggle');
+  const navLinks=nav.querySelector('.top-nav-links');
+  const navUtilities=nav.querySelector('.top-nav-utilities');
+  const dropdowns=[...nav.querySelectorAll('.dropdown')];
+  const closeDropdowns=(keep)=>dropdowns.forEach(drop=>{if(drop!==keep){drop.removeAttribute('data-desktop-open');drop.removeAttribute('data-mobile-open');const trigger=drop.querySelector('.dropdown-trigger');if(trigger)trigger.setAttribute('aria-expanded','false');}});
+  const syncMenuState=()=>{const expanded=menuToggle && menuToggle.getAttribute('aria-expanded')==='true';nav.toggleAttribute('data-menu-open',expanded);if(navLinks)navLinks.dataset.open=expanded?'true':'false';if(navUtilities)navUtilities.dataset.open=expanded?'true':'false';if(!expanded)closeDropdowns();};
+  if(menuToggle){menuToggle.addEventListener('click',()=>{const expanded=menuToggle.getAttribute('aria-expanded')==='true';menuToggle.setAttribute('aria-expanded',String(!expanded));syncMenuState();});syncMenuState();}
+  dropdowns.forEach(drop=>{const trigger=drop.querySelector('.dropdown-trigger');if(!trigger)return;trigger.setAttribute('aria-expanded','false');trigger.addEventListener('click',(e)=>{e.stopPropagation();const mobile=window.matchMedia('(max-width: 768px)').matches;const attr=mobile?'data-mobile-open':'data-desktop-open';const isOpen=drop.getAttribute(attr)==='true';closeDropdowns(drop);if(isOpen){drop.removeAttribute(attr);trigger.setAttribute('aria-expanded','false');}else{drop.setAttribute(attr,'true');trigger.setAttribute('aria-expanded','true');}});});
+  document.addEventListener('click',(e)=>{if(!nav.contains(e.target))closeDropdowns();});
+  document.addEventListener('keydown',(e)=>{if(e.key==='Escape'){if(menuToggle){menuToggle.setAttribute('aria-expanded','false');syncMenuState();}closeDropdowns();}});
+  window.addEventListener('resize',()=>{closeDropdowns();if(menuToggle&&window.matchMedia('(min-width: 769px)').matches){menuToggle.setAttribute('aria-expanded','false');syncMenuState();}});
+}
     // --- UI INITIATION & EVENT LISTENERS ---
     document.addEventListener('DOMContentLoaded', () => {
+        initTopNav();
         runStdPosAngleUnitTests();
         refreshIcons();
         loadState();

--- a/130Test3.html
+++ b/130Test3.html
@@ -873,7 +873,11 @@
       <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
     </div>
     <div class="top-nav-actions">
-      <ul class="top-nav-links">
+      <button class="menu-toggle global-nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav-links primary-nav-utilities" aria-label="Toggle navigation">
+        <span>Menu</span>
+        <span class="menu-toggle__icon" aria-hidden="true"></span>
+      </button>
+      <ul class="top-nav-links" id="primary-nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="CV.html">About</a></li>
         <li class="dropdown">
@@ -887,7 +891,7 @@
         </li>
         <li><a href="projects.html">Tools</a></li>
       </ul>
-      <ul class="top-nav-utilities" aria-label="More">
+      <ul class="top-nav-utilities" id="primary-nav-utilities" aria-label="More">
         <li class="dropdown">
           <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
           <ul class="dropdown-menu dropdown-menu--right">
@@ -2667,8 +2671,25 @@
         });
     }
 
+
+function initTopNav(){
+  const nav=document.querySelector('.top-nav');
+  if(!nav)return;
+  const menuToggle=nav.querySelector('.menu-toggle.global-nav-toggle');
+  const navLinks=nav.querySelector('.top-nav-links');
+  const navUtilities=nav.querySelector('.top-nav-utilities');
+  const dropdowns=[...nav.querySelectorAll('.dropdown')];
+  const closeDropdowns=(keep)=>dropdowns.forEach(drop=>{if(drop!==keep){drop.removeAttribute('data-desktop-open');drop.removeAttribute('data-mobile-open');const trigger=drop.querySelector('.dropdown-trigger');if(trigger)trigger.setAttribute('aria-expanded','false');}});
+  const syncMenuState=()=>{const expanded=menuToggle && menuToggle.getAttribute('aria-expanded')==='true';nav.toggleAttribute('data-menu-open',expanded);if(navLinks)navLinks.dataset.open=expanded?'true':'false';if(navUtilities)navUtilities.dataset.open=expanded?'true':'false';if(!expanded)closeDropdowns();};
+  if(menuToggle){menuToggle.addEventListener('click',()=>{const expanded=menuToggle.getAttribute('aria-expanded')==='true';menuToggle.setAttribute('aria-expanded',String(!expanded));syncMenuState();});syncMenuState();}
+  dropdowns.forEach(drop=>{const trigger=drop.querySelector('.dropdown-trigger');if(!trigger)return;trigger.setAttribute('aria-expanded','false');trigger.addEventListener('click',(e)=>{e.stopPropagation();const mobile=window.matchMedia('(max-width: 768px)').matches;const attr=mobile?'data-mobile-open':'data-desktop-open';const isOpen=drop.getAttribute(attr)==='true';closeDropdowns(drop);if(isOpen){drop.removeAttribute(attr);trigger.setAttribute('aria-expanded','false');}else{drop.setAttribute(attr,'true');trigger.setAttribute('aria-expanded','true');}});});
+  document.addEventListener('click',(e)=>{if(!nav.contains(e.target))closeDropdowns();});
+  document.addEventListener('keydown',(e)=>{if(e.key==='Escape'){if(menuToggle){menuToggle.setAttribute('aria-expanded','false');syncMenuState();}closeDropdowns();}});
+  window.addEventListener('resize',()=>{closeDropdowns();if(menuToggle&&window.matchMedia('(min-width: 769px)').matches){menuToggle.setAttribute('aria-expanded','false');syncMenuState();}});
+}
     // --- UI INITIATION & EVENT LISTENERS ---
     document.addEventListener('DOMContentLoaded', () => {
+        initTopNav();
         refreshIcons();
         loadState();
         applyTheme(state.theme);

--- a/130Test4.html
+++ b/130Test4.html
@@ -334,15 +334,54 @@
 </head>
 <body class="review-page">
 <div class="math-review-page">
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <div class="top-nav-branding">
+      <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    </div>
+    <div class="top-nav-actions">
+      <button class="menu-toggle global-nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav-links primary-nav-utilities" aria-label="Toggle navigation">
+        <span>Menu</span>
+        <span class="menu-toggle__icon" aria-hidden="true"></span>
+      </button>
+      <ul class="top-nav-links" id="primary-nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="CV.html">About</a></li>
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true" aria-current="page">Courses ▾</button>
+          <ul class="dropdown-menu">
+            <li><a href="learn.html">All Courses</a></li>
+            <li><a href="courses/math114.html">MATH 114</a></li>
+            <li><a href="courses/math130.html">MATH 130</a></li>
+            <li><a href="courses/physics-labs.html">Physics Labs</a></li>
+          </ul>
+        </li>
+        <li><a href="projects.html">Tools</a></li>
+      </ul>
+      <ul class="top-nav-utilities" id="primary-nav-utilities" aria-label="More">
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
+          <ul class="dropdown-menu dropdown-menu--right">
+            <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+            <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+            <li><a href="mailto:ahvolk@liberty.edu">Contact</a></li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>
 <div class="container review-shell">
     <header class="review-header">
-        <div class="breadcrumb">
-            <a href="#">Math 130</a>
-            <span>›</span>
-            <span>Final Week</span>
-            <span>›</span>
-            <span>Quiz 13 + Final Exam</span>
-        </div>
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="index.html">Home</a>
+            <span class="breadcrumb-sep" aria-hidden="true">›</span>
+            <a href="learn.html">Courses</a>
+            <span class="breadcrumb-sep" aria-hidden="true">›</span>
+            <a href="courses/math130.html">MATH 130</a>
+            <span class="breadcrumb-sep" aria-hidden="true">›</span>
+            <span class="breadcrumb-current" aria-current="page">Final Week Review</span>
+        </nav>
 
         <h1>Final Week Review</h1>
         <p class="header-subtitle review-subtitle">A simplified final-week page modeled after the earlier review pages. This one only covers the last week: Quiz 13 on vectors, reading day, and the comprehensive final.</p>
@@ -759,7 +798,24 @@
 </div>
 
 <script>
+
+function initTopNav(){
+  const nav=document.querySelector('.top-nav');
+  if(!nav)return;
+  const menuToggle=nav.querySelector('.menu-toggle.global-nav-toggle');
+  const navLinks=nav.querySelector('.top-nav-links');
+  const navUtilities=nav.querySelector('.top-nav-utilities');
+  const dropdowns=[...nav.querySelectorAll('.dropdown')];
+  const closeDropdowns=(keep)=>dropdowns.forEach(drop=>{if(drop!==keep){drop.removeAttribute('data-desktop-open');drop.removeAttribute('data-mobile-open');const trigger=drop.querySelector('.dropdown-trigger');if(trigger)trigger.setAttribute('aria-expanded','false');}});
+  const syncMenuState=()=>{const expanded=menuToggle && menuToggle.getAttribute('aria-expanded')==='true';nav.toggleAttribute('data-menu-open',expanded);if(navLinks)navLinks.dataset.open=expanded?'true':'false';if(navUtilities)navUtilities.dataset.open=expanded?'true':'false';if(!expanded)closeDropdowns();};
+  if(menuToggle){menuToggle.addEventListener('click',()=>{const expanded=menuToggle.getAttribute('aria-expanded')==='true';menuToggle.setAttribute('aria-expanded',String(!expanded));syncMenuState();});syncMenuState();}
+  dropdowns.forEach(drop=>{const trigger=drop.querySelector('.dropdown-trigger');if(!trigger)return;trigger.setAttribute('aria-expanded','false');trigger.addEventListener('click',(e)=>{e.stopPropagation();const mobile=window.matchMedia('(max-width: 768px)').matches;const attr=mobile?'data-mobile-open':'data-desktop-open';const isOpen=drop.getAttribute(attr)==='true';closeDropdowns(drop);if(isOpen){drop.removeAttribute(attr);trigger.setAttribute('aria-expanded','false');}else{drop.setAttribute(attr,'true');trigger.setAttribute('aria-expanded','true');}});});
+  document.addEventListener('click',(e)=>{if(!nav.contains(e.target))closeDropdowns();});
+  document.addEventListener('keydown',(e)=>{if(e.key==='Escape'){if(menuToggle){menuToggle.setAttribute('aria-expanded','false');syncMenuState();}closeDropdowns();}});
+  window.addEventListener('resize',()=>{closeDropdowns();if(menuToggle&&window.matchMedia('(min-width: 769px)').matches){menuToggle.setAttribute('aria-expanded','false');syncMenuState();}});
+}
 document.addEventListener('DOMContentLoaded', function () {
+    initTopNav();
     if (window.lucide) lucide.createIcons();
 
     const body = document.body;


### PR DESCRIPTION
### Motivation
- Responsive dropdowns and mobile menu were not wired on the Math 130 review pages, causing the top-nav dropdowns to fail on touch/mobile and leaving the final-week page with a broken top nav and placeholder breadcrumb. 
- The goal was to restore a shared, accessible top-nav structure and ensure dropdowns and the menu toggle behave reliably across desktop and mobile. 

### Description
- Added a shared responsive menu toggle and `primary-nav-links` / `primary-nav-utilities` IDs to `130Test1.html`, `130Test2.html`, `130Test3.html`, and restored the full top-nav and breadcrumb structure on `130Test4.html`. 
- Implemented `initTopNav()` and wired it into the pages to provide click-to-open dropdowns, close-on-outside-click and `Escape`, and mobile/desktop open-state attributes (`data-mobile-open` / `data-desktop-open`) with ARIA `aria-expanded` updates. 
- Inserted small DOM wiring to call `initTopNav()` during UI initialization (DOMContentLoaded) and ensured the new menu toggle syncs `data-menu-open`/`aria-expanded` to support the responsive CSS already present. 

### Testing
- Ran a Python presence check that verified each modified file contains `class="top-nav"`, the `menu-toggle global-nav-toggle` markup, `id="primary-nav-links"`, `id="primary-nav-utilities"`, the `function initTopNav()` definition, and an `initTopNav();` invocation; all checks passed. 
- Reviewed the generated diff/stat to confirm only the four review pages were changed and the edit sizes match the intended additions. 
- Executed repository-level validation steps used in this environment and confirmed the navigation initialization is present in `130Test1.html`, `130Test2.html`, `130Test3.html`, and `130Test4.html` (automated checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0ac41da448331bfbe5a6f08a4ca6a)