### PR TITLE
Refine tonal styling for publications and resource tables

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,9 @@
   --light-text: #fff;
   --background-color: #f8f9fa;
   --card-background: #fff;
+  --surface-container-low: #f8fbff;
+  --surface-container: #edf4fb;
+  --outline-variant: rgba(44, 62, 80, 0.22);
   --shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   --shadow-hover: 0 8px 16px rgba(0, 0, 0, 0.15);
   --border-radius: 8px;
@@ -283,14 +286,25 @@ section h2 {
 /* Publications styling */
 .publications-item {
   margin-bottom: 1rem;
-  padding-left: 1rem;
-  border-left: 3px solid var(--primary-color);
+  padding: 0.9rem 1rem 0.9rem 1.35rem;
+  background: linear-gradient(
+    90deg,
+    var(--surface-container) 0,
+    var(--surface-container-low) 22%,
+    transparent 100%
+  );
+  border-radius: calc(var(--border-radius) - 2px);
   transition: var(--transition);
 }
 
 .publications-item:hover {
   transform: translateX(5px);
-  border-left-color: var(--accent-color);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--accent-color) 10%, var(--surface-container)) 0,
+    var(--surface-container) 28%,
+    transparent 100%
+  );
 }
 
 /* Button styles */
@@ -622,24 +636,53 @@ section h2 {
 
 .assignment-resource-table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0 0.45rem;
   margin: 1rem 0 2rem;
-  background-color: var(--card-background);
-  overflow: hidden;
-  border-radius: var(--border-radius);
+  background-color: transparent;
 }
 
 .assignment-resource-table th,
 .assignment-resource-table td {
-  border: 1px solid rgba(44, 62, 80, 0.18);
-  padding: 0.75em;
+  padding: 0.9rem 1rem;
   text-align: left;
   vertical-align: top;
 }
 
 .assignment-resource-table th {
-  background-color: rgba(52, 152, 219, 0.12);
+  background-color: color-mix(in srgb, var(--primary-color) 12%, var(--surface-container));
   color: var(--secondary-color);
+}
+
+.assignment-resource-table thead th:first-child {
+  border-top-left-radius: calc(var(--border-radius) - 2px);
+  border-bottom-left-radius: calc(var(--border-radius) - 2px);
+}
+
+.assignment-resource-table thead th:last-child {
+  border-top-right-radius: calc(var(--border-radius) - 2px);
+  border-bottom-right-radius: calc(var(--border-radius) - 2px);
+}
+
+.assignment-resource-table tbody td {
+  background-color: var(--surface-container-low);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--outline-variant) 32%, transparent),
+    inset 0 -1px 0 color-mix(in srgb, var(--outline-variant) 16%, transparent);
+}
+
+.assignment-resource-table tbody tr:nth-child(even) td {
+  background-color: var(--surface-container);
+}
+
+.assignment-resource-table tbody td:first-child {
+  border-top-left-radius: calc(var(--border-radius) - 2px);
+  border-bottom-left-radius: calc(var(--border-radius) - 2px);
+}
+
+.assignment-resource-table tbody td:last-child {
+  border-top-right-radius: calc(var(--border-radius) - 2px);
+  border-bottom-right-radius: calc(var(--border-radius) - 2px);
 }
 
 .course-sequence-nav {
@@ -672,12 +715,7 @@ section h2 {
 }
 
 :root[data-theme="dark"] .assignment-resource-table th {
-  background-color: rgba(52, 152, 219, 0.22);
-}
-
-:root[data-theme="dark"] .assignment-resource-table th,
-:root[data-theme="dark"] .assignment-resource-table td {
-  border-color: rgba(240, 240, 240, 0.12);
+  background-color: color-mix(in srgb, var(--primary-color) 18%, var(--surface-container));
 }
 
 /* Footer styling */
@@ -847,6 +885,9 @@ main.error-main {
   --text-color: #f0f0f0;
   --background-color: #121212;
   --card-background: #1e1e1e;
+  --surface-container-low: #242833;
+  --surface-container: #2d3240;
+  --outline-variant: rgba(240, 240, 240, 0.16);
   --shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   --shadow-hover: 0 8px 16px rgba(0, 0, 0, 0.4);
 }
@@ -1033,10 +1074,24 @@ section:nth-child(5) {
     --card-background: Canvas;
   }
 
-  .skill-badge,
   .button,
   .download-btn {
-    border: 1px solid CanvasText;
+    border: 1px solid ButtonText;
+    forced-color-adjust: auto;
+  }
+
+  .assignment-resource-table {
+    border-collapse: collapse;
+  }
+
+  .assignment-resource-table th,
+  .assignment-resource-table td {
+    background: Canvas;
+    box-shadow: none;
+  }
+
+  .assignment-resource-table tbody tr + tr td {
+    border-top: 1px solid GrayText;
   }
 }
 /* Canonical Global Site Navbar */


### PR DESCRIPTION
### Motivation
- Replace hard, explicit line dividers in the UI with softer, tonal surfaces to reduce visual harshness while preserving structure and readability.
- Convert table cell grids into grouped rows that read as tonal bands for improved hierarchy and visual rhythm.
- Keep forced-colors accessibility support but restrict hard borders to controls that need them so the high-contrast fallback does not become the default structural pattern.

### Description
- Added tonal variables (`--surface-container-low`, `--surface-container`, and `--outline-variant`) to the root and dark theme blocks to drive soft container backgrounds and low-opacity separators.
- Replaced `.publications-item`'s `border-left` with extra inset padding, a subtle left-to-right surface gradient, rounded corners, and an accent-tinted hover wash instead of a hard line.
- Reworked `.assignment-resource-table` to use `border-collapse: separate` with `border-spacing` and per-row backgrounds, increased cell padding, tinted header backgrounds using `color-mix`, alternating row tones, inset ghost separators via low-opacity `color-mix` shadows, and rounded row edges instead of 1px cell borders.
- Scoped `@media (forced-colors: active)` to apply explicit borders only to interactive elements (`.button`, `.download-btn`) and provide simplified, accessible table separation (Canvas backgrounds and a single `border-top` between body rows) rather than restoring a full hard grid.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff issues, which succeeded.
- Ran `git status --short` to confirm only the intended file changed, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c0cc48608331906945e7a8a5bf5f)