### PR TITLE
Refactor list styling for editorial content

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -129,13 +129,6 @@
   --nav-mobile-panel-end: rgba(242, 244, 241, 0.9);
   --nav-mobile-menu-surface: rgba(255, 255, 255, 0.96);
 }
-/* No bullet points */
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
 /* Base styles */
 body {
   font-family: var(--type-body-family);
@@ -182,6 +175,53 @@ a {
 
 a:hover {
   color: var(--tertiary);
+}
+
+
+.list-reset,
+.list-reset ul,
+.list-reset ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.top-nav-links,
+.top-nav-utilities,
+.dropdown-menu,
+.highlights-list,
+.unit-task-meta,
+.cv-section-nav #nav-menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+:where(.course-page, .review-shell, .summary-sheet, .question-guide, .answer-content) :where(ul, ol):not(.list-reset):not(.top-nav-links):not(.top-nav-utilities):not(.dropdown-menu):not(.highlights-list):not(.unit-task-meta):not(.math130-summary-list) {
+  padding-left: 1.5rem;
+  margin: 1rem 0;
+}
+
+:where(.course-page, .review-shell, .summary-sheet, .question-guide, .answer-content) :where(li):not(.highlights-list li):not(.math130-summary-list li) + li {
+  margin-top: 0.55rem;
+}
+
+:where(.course-page, .review-shell, .summary-sheet, .question-guide, .answer-content) ul:not(.list-reset):not(.top-nav-links):not(.top-nav-utilities):not(.dropdown-menu):not(.highlights-list):not(.unit-task-meta):not(.math130-summary-list) {
+  list-style: disc;
+}
+
+:where(.course-page, .review-shell, .summary-sheet, .question-guide, .answer-content) ol:not(.list-reset):not(.top-nav-links):not(.top-nav-utilities):not(.dropdown-menu):not(.highlights-list):not(.unit-task-meta):not(.math130-summary-list) {
+  list-style: decimal;
+}
+
+:where(.course-page, .review-shell, .summary-sheet, .question-guide, .answer-content) :where(ul, ol):not(.list-reset):not(.top-nav-links):not(.top-nav-utilities):not(.dropdown-menu):not(.highlights-list):not(.unit-task-meta):not(.math130-summary-list) ::marker {
+  color: var(--secondary);
+  font-weight: 700;
+}
+
+:where(.course-page, .review-shell, .summary-sheet, .question-guide, .answer-content) :where(ul, ol) :where(ul, ol):not(.list-reset):not(.top-nav-links):not(.top-nav-utilities):not(.dropdown-menu):not(.highlights-list):not(.unit-task-meta):not(.math130-summary-list) {
+  margin-top: 0.55rem;
+  margin-bottom: 0.35rem;
 }
 
 /* Header styling */


### PR DESCRIPTION
### Motivation

- The global `ul { list-style: none; }` reset removed native list semantics across the site, hurting readability of editorial/course content. 
- Navigation and small utility lists still need marker suppression for layout, so resets should be scoped to those components only.
- Restore readable defaults (padding, spacing, markers) for article/course/review wrappers so instructional lists regain clear hierarchy.

### Description

- Removed the global `ul { list-style: none; margin: 0; padding: 0; }` rule from `styles.css` and added a reusable `.list-reset` utility that suppresses markers when intentionally applied. 
- Applied scoped list-reset rules for known component selectors: `.top-nav-links`, `.top-nav-utilities`, `.dropdown-menu`, `.highlights-list`, `.unit-task-meta`, and `#nav-menu` inside `.cv-section-nav`. 
- Added editorial/content defaults scoped to wrappers used for instructional pages (`.course-page`, `.review-shell`, `.summary-sheet`, `.question-guide`, `.answer-content`) to restore left padding, vertical spacing between items, default `disc`/`decimal` markers, nested-list spacing, and a marker style that uses `var(--secondary)` and `font-weight: 700`.
- Kept component exceptions such as `.list-reset`, nav lists, and `.math130-summary-list` from the editorial rules so navigation/cards/layouts are unaffected.

### Testing

- Ran repository searches (`rg`) to locate existing list-related selectors and confirm the targeted component classes are present and accounted for; results matched the intended scope. 
- Executed a small Python assertion script that confirmed the global `ul` reset was removed and that `.list-reset` and the new scoped selectors exist in `styles.css`, which printed `styles.css list refactor checks passed`.
- Ran a Python scan over `courses/*.html` to verify course/review wrappers (e.g. `.course-page`, `.summary-sheet`, `.review-shell`, `.question-guide`, `.answer-content`) are present so the editorial list rules will apply; the automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d3daec1c8331b4479d86f301f0b1)