### PR TITLE
Refine editorial link treatments and surface primitives; add .marketing-card variant

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     </section>
     
     <div class="card-container">
-      <div class="card">
+      <div class="card marketing-card">
         <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube Channel" title="YouTube Channel">
           <div class="card-icon">📺</div>
         </a>
@@ -74,7 +74,7 @@
         <a href="https://www.youtube.com/learnabundantly" class="button youtube-button">Watch Now</a>
       </div>
       
-      <div class="card">
+      <div class="card marketing-card">
         <a href="CV.html" aria-label="About" title="About">
           <div class="card-icon">👤</div>
         </a>
@@ -83,7 +83,7 @@
         <a href="CV.html" class="button">View CV</a>
       </div>
       
-      <div class="card">
+      <div class="card marketing-card">
         <a href="learn.html" aria-label="Learning Resources" title="Learning Resources">
           <div class="card-icon">📚</div>
         </a>
@@ -91,7 +91,7 @@
         <p>Access a collection of learning resources for mathematics, physics, and engineering students, including guides, problem sets, and reference materials.</p>
         <a href="learn.html" class="button">Start Learning</a>
       </div>
-      <div class="card">
+      <div class="card marketing-card">
         <a href="projects.html" aria-label="Tools" title="Tools">
           <div class="card-icon">🔧</div>
         </a>
@@ -99,7 +99,7 @@
         <p>Explore featured tools, classroom activities, reference pages, and other practical resources collected on the Tools page.</p>
         <a href="projects.html" class="button">Explore Tools</a>
       </div>
-      <div class="card">
+      <div class="card marketing-card">
         <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer" aria-label="Liberty University Math Club" title="Liberty University Math Club">
           <div class="card-icon">🧮</div>
         </a>
@@ -107,7 +107,7 @@
         <p>Join the Math Club to explore advanced topics, collaborate on problem sets, and engage with fellow math enthusiasts.</p>
         <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer" class="button">Learn More</a>
       </div>
-      <div class="card">
+      <div class="card marketing-card">
         <a href="mailto:ahvolk@liberty.edu" aria-label="Contact Prof. Volk" title="Contact Prof. Volk">
           <div class="card-icon">✉️</div>
         </a>

--- a/learn.html
+++ b/learn.html
@@ -57,21 +57,21 @@
     </section>
 
     <div class="card-container">
-      <div class="card">
+      <div class="card marketing-card">
         <div class="card-icon">📊</div>
         <h2>MATH 114</h2>
         <p>Visit the Quantitative Reasoning home page for unit materials, policies, logistics, and review tools.</p>
         <a href="courses/math114.html" class="button">Open MATH 114</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <div class="card-icon">📐</div>
         <h2>MATH 130</h2>
         <p>Open the Advanced Technical Mathematics home page for unit links, study resources, and exam review materials.</p>
         <a href="courses/math130.html" class="button">Open MATH 130</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <div class="card-icon">🧪</div>
         <h2>Physics Labs</h2>
         <p>Browse the physics lab home page to find PHYS 103, PHYS 201L/231L, and PHYS 202L/232L resources.</p>

--- a/projects.html
+++ b/projects.html
@@ -66,7 +66,7 @@
     </section>
 
     <div class="card-container">
-      <div class="card">
+      <div class="card marketing-card">
         <a href="projects/ResearchMentorship/MathJournals.html" aria-label="Undergraduate Math Journals" title="Undergraduate Math Journals">
           <div class="card-icon">📖</div>
         </a>
@@ -75,7 +75,7 @@
         <a href="projects/ResearchMentorship/MathJournals.html" class="button">Explore Resource</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="projects/PrayerAppV1/index.html" aria-label="PrayerAppV1" title="PrayerAppV1">
           <div class="card-icon">🙏</div>
         </a>
@@ -84,7 +84,7 @@
         <a href="projects/PrayerAppV1/index.html" class="button">Open App</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="projects/NormalDistributionGame.html" aria-label="Normal Distribution Game" title="Normal Distribution Game">
           <div class="card-icon">🎲</div>
         </a>
@@ -93,7 +93,7 @@
         <a href="projects/NormalDistributionGame.html" class="button">Launch Activity</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="projects/PHYS103LUO/KinematicsShortAnswer.html" aria-label="PHYS 103 Kinematics Short Answer" title="PHYS 103 Kinematics Short Answer">
           <div class="card-icon">🚗</div>
         </a>
@@ -102,7 +102,7 @@
         <a href="projects/PHYS103LUO/KinematicsShortAnswer.html" class="button">View Resource</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="projects/QuestionSpinner/questionspinner.html" aria-label="Question Spinner" title="Question Spinner">
           <div class="card-icon">🎡</div>
         </a>
@@ -111,7 +111,7 @@
         <a href="projects/QuestionSpinner/questionspinner.html" class="button">Open Spinner</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="bookings.html" aria-label="Book a Meeting with Professor Volk" title="Book a Meeting with Professor Volk">
           <div class="card-icon">📅</div>
         </a>
@@ -120,7 +120,7 @@
         <a href="bookings.html" class="button">Open Guide</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="Taskflow.html" aria-label="Taskflow" title="Taskflow">
           <div class="card-icon">🗂️</div>
         </a>
@@ -129,7 +129,7 @@
         <a href="Taskflow.html" class="button">Open Page</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="Unit3Practice.html" aria-label="Unit 3 Practice" title="Unit 3 Practice">
           <div class="card-icon">🧮</div>
         </a>
@@ -138,7 +138,7 @@
         <a href="Unit3Practice.html" class="button">Open Practice</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="chessboard.html" aria-label="Chessboard" title="Chessboard">
           <div class="card-icon">♟️</div>
         </a>
@@ -147,7 +147,7 @@
         <a href="chessboard.html" class="button">Open Board</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="employeepay.html" aria-label="Employee Pay" title="Employee Pay">
           <div class="card-icon">💵</div>
         </a>
@@ -156,7 +156,7 @@
         <a href="employeepay.html" class="button">View Page</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="growth.html" aria-label="Growth" title="Growth">
           <div class="card-icon">📈</div>
         </a>
@@ -165,7 +165,7 @@
         <a href="growth.html" class="button">Open Page</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="infographic.html" aria-label="Infographic" title="Infographic">
           <div class="card-icon">🖼️</div>
         </a>
@@ -174,7 +174,7 @@
         <a href="infographic.html" class="button">View Infographic</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="courses/data-sheet-for-electric-circuits.html" aria-label="Electric Circuits Data Sheet" title="Electric Circuits Data Sheet">
           <div class="card-icon">🔌</div>
         </a>
@@ -183,7 +183,7 @@
         <a href="courses/data-sheet-for-electric-circuits.html" class="button">Open Resource</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="courses/final-exam-review-guide.html" aria-label="Final Exam Review Guide" title="Final Exam Review Guide">
           <div class="card-icon">📝</div>
         </a>
@@ -192,7 +192,7 @@
         <a href="courses/final-exam-review-guide.html" class="button">Open Review</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="courses/knowledgegrowth.html" aria-label="Knowledge Growth" title="Knowledge Growth">
           <div class="card-icon">🌱</div>
         </a>
@@ -201,7 +201,7 @@
         <a href="courses/knowledgegrowth.html" class="button">View Page</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="courses/lab6-krules.html" aria-label="Lab 6 K-Rules" title="Lab 6 K-Rules">
           <div class="card-icon">🧪</div>
         </a>
@@ -210,7 +210,7 @@
         <a href="courses/lab6-krules.html" class="button">Open Lab Page</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="courses/test3-formulas.html" aria-label="Test 3 Formulas" title="Test 3 Formulas">
           <div class="card-icon">📚</div>
         </a>
@@ -219,7 +219,7 @@
         <a href="courses/test3-formulas.html" class="button">View Formulas</a>
       </div>
 
-      <div class="card">
+      <div class="card marketing-card">
         <a href="courses/test4-formulas.html" aria-label="Test 4 Formulas" title="Test 4 Formulas">
           <div class="card-icon">📘</div>
         </a>

--- a/styles.css
+++ b/styles.css
@@ -169,12 +169,31 @@ h6 {
 
 a {
   color: var(--secondary);
-  text-decoration: none;
-  transition: var(--transition);
+  text-decoration-line: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.16em;
+  text-decoration-color: color-mix(in srgb, var(--secondary) 72%, transparent);
+  transition: color 0.2s ease, text-decoration-color 0.2s ease, text-decoration-thickness 0.2s ease, background-size 0.2s ease;
 }
 
-a:hover {
+a:hover,
+a:focus-visible {
   color: var(--tertiary);
+  text-decoration-color: currentColor;
+  text-decoration-thickness: 0.12em;
+}
+
+:where(.page-shell-main, .course-page, .review-shell, .summary-sheet, .question-guide, .answer-content, .publications-item, .experience-item, .education-item, #research, #publications, #philosophy, #overview) :where(p, li, dd, figcaption, blockquote) a {
+  text-decoration-color: color-mix(in srgb, var(--secondary) 82%, transparent);
+  text-decoration-thickness: 0.09em;
+  text-underline-offset: 0.18em;
+}
+
+:where(.page-shell-main, .course-page, .review-shell, .summary-sheet, .question-guide, .answer-content, .publications-item, .experience-item, .education-item, #research, #publications, #philosophy, #overview) :where(p, li, dd, figcaption, blockquote) a:hover,
+:where(.page-shell-main, .course-page, .review-shell, .summary-sheet, .question-guide, .answer-content, .publications-item, .experience-item, .education-item, #research, #publications, #philosophy, #overview) :where(p, li, dd, figcaption, blockquote) a:focus-visible {
+  color: var(--tertiary);
+  text-decoration-color: currentColor;
+  text-decoration-thickness: 0.13em;
 }
 
 
@@ -347,11 +366,11 @@ nav.navbar {
   position: sticky;
   top: 0;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(242, 244, 241, 0.84));
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-container-lowest) 92%, transparent), color-mix(in srgb, var(--surface-container-low) 88%, transparent));
   z-index: 999;
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-  box-shadow: 0 12px 28px rgba(0, 29, 23, 0.06);
+  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--ghost-outline) 72%, transparent);
 }
 
 nav.navbar .nav-container {
@@ -402,8 +421,7 @@ nav.navbar button.dropdown-trigger:focus-visible {
   position: absolute;
   top: calc(100% - 2px);
   left: 0;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(242, 244, 241, 0.92));
+  background: var(--glass-surface);
   min-width: 200px;
   margin-top: 0.35rem;
   padding: 0.35rem;
@@ -413,7 +431,7 @@ nav.navbar button.dropdown-trigger:focus-visible {
     opacity 0.3s ease,
     visibility 0.3s ease;
   border-radius: var(--radius-md);
-  box-shadow: 0 18px 36px rgba(0, 29, 23, 0.08);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 82%, transparent);
   z-index: 1000;
 }
 
@@ -581,33 +599,34 @@ section h2 {
   gap: var(--spacing-8);
 }
 
-.card {
-  background:
-    linear-gradient(180deg, rgba(220, 230, 224, 0.2), rgba(255, 255, 255, 0)),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(242, 244, 241, 0.92));
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-6);
+.marketing-card {
   width: 100%;
   max-width: 300px;
+  border-radius: var(--radius-lg);
   transition: var(--transition);
-  box-shadow: 0 14px 32px rgba(0, 29, 23, 0.05);
 }
 
-.card:hover {
+.marketing-card:hover {
   transform: translateY(-3px);
   background:
-    linear-gradient(180deg, rgba(220, 230, 224, 0.3), rgba(255, 255, 255, 0.02)),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(242, 244, 241, 0.96));
-  box-shadow: 0 20px 40px rgba(0, 29, 23, 0.08);
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-container-low) 88%, transparent), transparent),
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-container-lowest) 96%, transparent), color-mix(in srgb, var(--surface-container-low) 92%, transparent));
 }
 
-.card h2 {
+.marketing-card h2 {
   color: var(--secondary-color);
   margin-top: 0;
 }
 
-.card p {
+.marketing-card p {
   margin-bottom: 1.5rem;
+}
+
+.marketing-card > a:not(.button),
+.marketing-card > a:not(.button):hover,
+.marketing-card > a:not(.button):focus-visible {
+  display: inline-block;
+  text-decoration: none;
 }
 
 .card-icon {
@@ -1358,7 +1377,7 @@ section:nth-child(5) {
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border-bottom: none;
-  box-shadow: 0 14px 32px rgba(0, 29, 23, 0.06);
+  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--ghost-outline) 70%, transparent);
 }
 
 .top-nav-inner {
@@ -1437,7 +1456,7 @@ section:nth-child(5) {
   line-height: 1.2;
   padding: 0.45rem 0.75rem;
   border-radius: 999px;
-  transition: color 0.2s ease, background-color 0.2s ease;
+  transition: color 0.2s ease, background-color 0.2s ease, text-decoration-color 0.2s ease;
 }
 
 .top-nav-links > li > a:hover,
@@ -1456,6 +1475,10 @@ section:nth-child(5) {
 .top-nav-utilities .dropdown-menu a:focus-visible {
   color: var(--secondary);
   background: color-mix(in srgb, var(--accent-action) 10%, transparent);
+  text-decoration-line: underline;
+  text-decoration-thickness: 0.1em;
+  text-underline-offset: 0.22em;
+  text-decoration-color: currentColor;
   outline: none;
 }
 
@@ -1569,10 +1592,9 @@ section:nth-child(5) {
   margin: 0;
   padding: 0.4rem;
   list-style: none;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(242, 244, 241, 0.92));
+  background: var(--glass-surface);
   border-radius: 0.75rem;
-  box-shadow: 0 18px 36px rgba(0, 29, 23, 0.08);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 82%, transparent);
 }
 
 .top-nav-links .dropdown:hover .dropdown-menu,
@@ -1616,12 +1638,12 @@ section:nth-child(5) {
   border: none;
   border-radius: 0.85rem;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(242, 244, 241, 0.86));
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-container-lowest) 96%, transparent), color-mix(in srgb, var(--surface-container-low) 92%, transparent));
   color: var(--secondary-color);
   font: inherit;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 10px 24px rgba(0, 29, 23, 0.06);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 76%, transparent);
 }
 
 .menu-toggle.global-nav-toggle .menu-toggle__icon::before {
@@ -1652,10 +1674,10 @@ section:nth-child(5) {
   position: sticky;
   top: 4.6rem;
   z-index: 900;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(242, 244, 241, 0.92));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--glass-surface) 92%, transparent), color-mix(in srgb, var(--surface-container-low) 94%, transparent));
   border-top: none;
   border-bottom: none;
-  box-shadow: none;
+  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--ghost-outline) 72%, transparent);
 }
 
 .cv-section-nav .cv-section-nav__inner {
@@ -1708,9 +1730,9 @@ section:nth-child(5) {
   min-width: 220px;
   margin: 0;
   padding: 0.35rem;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(242, 244, 241, 0.88));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface-container-lowest) 96%, transparent), color-mix(in srgb, var(--surface-container-low) 90%, transparent));
   border-radius: 0.75rem;
-  box-shadow: 0 18px 36px rgba(0, 29, 23, 0.08);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 76%, transparent);
   opacity: 0;
   visibility: hidden;
 }
@@ -1764,7 +1786,7 @@ section:nth-child(5) {
     padding: 0.6rem;
     border-radius: 1rem;
     background: linear-gradient(180deg, var(--nav-mobile-panel-start), var(--nav-mobile-panel-end));
-    box-shadow: 0 18px 36px rgba(0, 29, 23, 0.06);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 78%, transparent);
   }
 
   .top-nav-links[data-open="true"],
@@ -2207,11 +2229,19 @@ body.review-page::before {
 .math-review-page .tab-content.active,
 .review-page .tab-content.active { display:block; animation: fadeUp 0.28s ease; }
 
-.review-panel, .review-card, .card, .formula-section, .info-card, .practice-stat, .problem-card, .topic-card, .section-summary-card {
+.card {
+  position: relative;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-container-lowest) 96%, transparent), color-mix(in srgb, var(--surface-container-low) 94%, transparent));
+  border-radius: var(--radius-lg);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 82%, transparent);
+}
+
+.review-panel, .review-card, .formula-section, .info-card, .practice-stat, .problem-card, .topic-card, .section-summary-card {
   position: relative;
   background: linear-gradient(180deg, var(--surface), color-mix(in srgb, var(--surface) 78%, var(--surface2)));
   border-radius: var(--radius);
-  box-shadow: 0 16px 34px rgba(0, 0, 0, 0.08);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 80%, transparent);
 }
 .review-panel::before, .review-card::before, .card::before, .formula-section::before, .section-summary-card::before {
   content: '';
@@ -2222,7 +2252,8 @@ body.review-page::before {
   pointer-events: none;
 }
 .review-panel > *, .review-card > *, .card > *, .formula-section > *, .section-summary-card > * { position: relative; z-index: 1; }
-.review-card, .card, .formula-section { padding: var(--spacing-6); margin-bottom: 1.5rem; }
+.review-card, .formula-section { padding: var(--spacing-6); margin-bottom: 1.5rem; }
+.card { padding: var(--spacing-6); margin-bottom: 1.5rem; }
 
 .review-checklist-section, .checklist-section { margin-bottom: var(--spacing-8); }
 .review-checklist-section > h3, .checklist-section > h3 { font-family: var(--type-body-family); font-size: 1.2rem; color: var(--accent); margin-bottom: 1rem; padding-bottom: 0.7rem; background: linear-gradient(180deg, transparent calc(100% - 0.45rem), color-mix(in srgb, var(--accent) 10%, transparent)); }


### PR DESCRIPTION
### Motivation
- Align global CSS with the editorial guidance in `WebDesign.md` by restoring visible inline link affordances in prose and making hover/focus treatments rely on underline/weight as well as color. 
- Remove decorative drop shadows from shared UI surfaces and replace them with tonal layering and ghost-outline tokens to match the system's "no-shadow / tonal stacking" guidance. 
- Prevent homepage/marketing cards from inheriting review-page chrome by separating generic card primitives from page-specific variants.

### Description
- Replaced the broad `a { text-decoration: none; }` pattern with typographic link defaults that use accessible underlines and added scoped selectors (prose contexts such as `.page-shell-main`, `.course-page`, `.publications-item`, etc.) to strengthen underline affordances for body-copy links while keeping component links (nav, buttons, utility links) visually compact. (`styles.css` near the `a { ... }` block).
- Replaced decorative `box-shadow` elevation on the navbar, dropdowns, mobile nav panel, and menu-toggle with tonal/ghost treatments using `--glass-surface`, `--surface-container-*`, and `--ghost-outline` tokens (removed large rgba shadows and switched to inset outlines/backdrop patterns). (`styles.css` nav and dropdown sections).
- Introduced a `marketing-card` class as the landing/marketing/home variant and moved the previous homepage hover/background behavior into that class, leaving the shared `.card` primitive for review/editorial contexts and changing `.card` to use subtle tonal backgrounds and an inset ghost-outline instead of heavy shadows. (`styles.css` card sections).
- Updated landing pages to use the new marketing variant by adding `marketing-card` to landing card markup on `index.html`, `learn.html`, and `projects.html` so those grids no longer inherit review-specific chrome.

### Testing
- Ran `git diff --check` to validate whitespace and basic style issues, which returned no errors. 
- Executed a small Python sanity script that checked brace balance in `styles.css` (balance = 0) and counted `marketing-card` occurrences in the modified pages to confirm the markup change, and the checks completed successfully. 
- Performed targeted grep/inspection for remaining `box-shadow` usages and verified key nav/dropdown/card locations were converted to `--glass-surface` / `--ghost-outline` patterns; results matched the intended replacements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d7473d58833189002977d0f5b6a8)