### PR TITLE
Redesign homepage into curated editorial layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,75 +49,112 @@
     </nav>
   </div>
 </div>
-<header class="page-shell-header">
+<header class="page-shell-header home-shell-header">
   <div class="container">
     <div class="page-shell-header__eyebrow">Home</div>
-    <h1>Welcome to Prof. Volk's Office</h1>
-    <p class="subtitle">Exploring education, engineering, mathematics, physics, and growth.</p>
+    <h1>Prof. Volk's digital curator space for learning, tools, and thoughtful scholarship.</h1>
+    <p class="subtitle">A guided front door for students, colleagues, and curious learners who want clear explanations, practical resources, and a humane approach to mathematics, physics, and engineering.</p>
   </div>
 </header>
-  
-  <main class="container page-shell-main">
-    <section class="welcome-section">
-      <h2>Hello, I'm glad you're here!</h2>
-      <p>Welcome to my personal website. I'm passionate about education, engineering, and creating resources to help others learn. Please explore the various sections of my site to discover more about my work, projects, and educational content.</p>
-      <h3>-Professor Andrew H. Volk</h3>
+
+  <main class="container page-shell-main home-main">
+    <section class="home-stage home-hero" aria-labelledby="home-hero-title">
+      <div class="hero-copy-column">
+        <p class="home-kicker">Digital Curator</p>
+        <h2 id="home-hero-title">Learn from an authored collection of courses, tools, and teaching resources.</h2>
+        <p class="hero-lead">Instead of a wall of equal links, this homepage points you toward the most useful places first: structured learning materials, classroom-ready tools, and the background behind the work.</p>
+        <p class="hero-support">Whether you are preparing for a class, reviewing a concept, or exploring how these subjects connect, start with the destination that matches your next step.</p>
+        <div class="hero-cta-cluster" aria-label="Primary actions">
+          <a href="learn.html" class="button">Start learning</a>
+          <a href="projects.html" class="button button-secondary">Explore tools</a>
+          <a href="CV.html" class="hero-tertiary-link">View CV and teaching profile</a>
+        </div>
+      </div>
+
+      <article class="highlighted-destination-card">
+        <p class="home-kicker">Featured destination</p>
+        <h3>Learning resources built for clarity and momentum.</h3>
+        <p>Browse course pages, reference material, and guided explanations designed to help students move from confusion to confidence without losing the bigger picture.</p>
+        <ul class="supporting-link-list">
+          <li>Course hubs for mathematics and physics</li>
+          <li>Structured materials for independent review</li>
+          <li>Readable explanations anchored in real teaching practice</li>
+        </ul>
+        <a href="learn.html" class="button">Open learning resources</a>
+      </article>
     </section>
-    
-    <div class="card-container">
-      <div class="card marketing-card">
-        <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube Channel" title="YouTube Channel">
-          <div class="card-icon">📺</div>
-        </a>
-        <h2>YouTube Channel</h2>
-        <p>Visit my YouTube channel "Learn Abundantly" for educational videos, tutorials, and in-depth explanations on various topics in math, physics, and engineering.</p>
-        <a href="https://www.youtube.com/learnabundantly" class="button youtube-button">Watch Now</a>
+
+    <section class="home-stage home-band home-band-support" aria-labelledby="featured-paths-title">
+      <div class="band-intro">
+        <p class="home-kicker">Primary destinations</p>
+        <h2 id="featured-paths-title">Choose the path that fits how you want to engage.</h2>
+        <p>These are the highest-priority entry points for most visitors: study the material, use the tools, or get context on the person and philosophy behind the work.</p>
       </div>
-      
-      <div class="card marketing-card">
-        <a href="CV.html" aria-label="About" title="About">
-          <div class="card-icon">👤</div>
-        </a>
-        <h2>About</h2>
-        <p>Learn more about my background, education, professional experience, and the journey that led me to create educational content and resources.</p>
-        <a href="CV.html" class="button">View CV</a>
+      <div class="supporting-card-grid">
+        <article class="supporting-card">
+          <div class="card-icon" aria-hidden="true">📚</div>
+          <h3>Learn</h3>
+          <p>Move into course pages, study guides, and teaching materials organized for students who want dependable structure.</p>
+          <a href="learn.html">Browse courses and resources</a>
+        </article>
+        <article class="supporting-card supporting-card--offset">
+          <div class="card-icon" aria-hidden="true">🔧</div>
+          <h3>Projects &amp; Tools</h3>
+          <p>Use practical classroom tools, interactive resources, and reference pages that support day-to-day learning.</p>
+          <a href="projects.html">Explore tools and projects</a>
+        </article>
+        <article class="supporting-card">
+          <div class="card-icon" aria-hidden="true">👤</div>
+          <h3>CV &amp; Background</h3>
+          <p>See academic background, experience, and the broader teaching story that shapes the resources on this site.</p>
+          <a href="CV.html">Read the profile</a>
+        </article>
       </div>
-      
-      <div class="card marketing-card">
-        <a href="learn.html" aria-label="Learning Resources" title="Learning Resources">
-          <div class="card-icon">📚</div>
-        </a>
-        <h2>Learning Resources</h2>
-        <p>Access a collection of learning resources for mathematics, physics, and engineering students, including guides, problem sets, and reference materials.</p>
-        <a href="learn.html" class="button">Start Learning</a>
+    </section>
+
+    <section class="home-stage home-band home-band-media" aria-labelledby="beyond-site-title">
+      <div class="band-intro">
+        <p class="home-kicker">Secondary band</p>
+        <h2 id="beyond-site-title">Keep learning beyond the homepage.</h2>
+        <p>For visitors who prefer video or want a lighter-touch way to stay connected, these supporting destinations extend the core teaching work without competing with the main entry points above.</p>
       </div>
-      <div class="card marketing-card">
-        <a href="projects.html" aria-label="Tools" title="Tools">
-          <div class="card-icon">🔧</div>
-        </a>
-        <h2>Tools</h2>
-        <p>Explore featured tools, classroom activities, reference pages, and other practical resources collected on the Tools page.</p>
-        <a href="projects.html" class="button">Explore Tools</a>
+      <div class="supporting-card-grid supporting-card-grid--two-up">
+        <article class="supporting-card">
+          <div class="card-icon" aria-hidden="true">📺</div>
+          <h3>Learn Abundantly on YouTube</h3>
+          <p>Watch lessons, walkthroughs, and educational videos that complement the written resources across the site.</p>
+          <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">Visit the channel</a>
+        </article>
+        <article class="supporting-card supporting-card--quiet">
+          <div class="card-icon" aria-hidden="true">✍️</div>
+          <h3>Why this site exists</h3>
+          <p>The goal is simple: gather trustworthy teaching materials and practical tools in one place so learners can spend more energy understanding than searching.</p>
+        </article>
       </div>
-      <div class="card marketing-card">
-        <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer" aria-label="Liberty University Math Club" title="Liberty University Math Club">
-          <div class="card-icon">🧮</div>
-        </a>
-        <h2>Liberty University Math Club</h2>
-        <p>Join the Math Club to explore advanced topics, collaborate on problem sets, and engage with fellow math enthusiasts.</p>
-        <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer" class="button">Learn More</a>
+    </section>
+
+    <section class="home-stage home-tertiary" aria-labelledby="community-links-title">
+      <div>
+        <p class="home-kicker">Community &amp; contact</p>
+        <h2 id="community-links-title">A quieter place for external and community links.</h2>
       </div>
-      <div class="card marketing-card">
-        <a href="mailto:ahvolk@liberty.edu" aria-label="Contact Prof. Volk" title="Contact Prof. Volk">
-          <div class="card-icon">✉️</div>
-        </a>
-        <h2>Contact Prof. Volk</h2>
-        <p>Have questions or suggestions? Email me directly for any inquiries or feedback.</p>
-        <a href="mailto:ahvolk@liberty.edu" class="button">Email Prof. Volk</a>
+      <div class="tertiary-link-columns">
+        <div class="tertiary-link-group">
+          <h3>Community</h3>
+          <ul class="supporting-link-list supporting-link-list--compact">
+            <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Liberty University Math Club</a></li>
+            <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">Learn Abundantly YouTube</a></li>
+          </ul>
+        </div>
+        <div class="tertiary-link-group">
+          <h3>Contact</h3>
+          <p>Questions, collaboration ideas, or feedback are always welcome.</p>
+          <a href="mailto:ahvolk@liberty.edu" class="hero-tertiary-link">Email Prof. Volk</a>
+        </div>
       </div>
-    </div>
+    </section>
   </main>
-  
+
   <footer>
     <div class="container">
       <p>&copy; <span id="current-year">2025</span> Andrew H. Volk. All rights reserved.</p>

--- a/styles.css
+++ b/styles.css
@@ -582,6 +582,238 @@ section h2 {
   margin-bottom: 1.5rem;
 }
 
+
+.button-secondary {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0)), var(--secondary);
+}
+
+.button-secondary:hover,
+.button-secondary:focus-visible {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0)), color-mix(in srgb, var(--secondary) 78%, var(--primary-container));
+  color: var(--light-text);
+}
+
+.home-main {
+  padding-top: var(--spacing-16);
+  padding-bottom: var(--spacing-16);
+}
+
+.home-stage + .home-stage {
+  margin-top: var(--spacing-24);
+}
+
+.home-kicker {
+  margin: 0 0 var(--spacing-4);
+  font-family: var(--type-meta-family);
+  font-size: var(--meta-sm);
+  font-weight: var(--meta-weight);
+  letter-spacing: var(--meta-tracking);
+  text-transform: uppercase;
+  color: var(--tertiary);
+}
+
+.home-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(320px, 1.1fr);
+  gap: clamp(var(--spacing-8), 5vw, var(--spacing-16));
+  align-items: start;
+}
+
+.hero-copy-column {
+  max-width: 36rem;
+}
+
+.hero-copy-column h2 {
+  margin-bottom: var(--spacing-5);
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  line-height: 1.08;
+}
+
+.hero-lead {
+  font-size: 1.1rem;
+  color: var(--on-surface);
+}
+
+.hero-support {
+  max-width: 34rem;
+  color: var(--on-surface-variant);
+}
+
+.hero-cta-cluster {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-4);
+  align-items: center;
+  margin-top: var(--spacing-8);
+}
+
+.hero-tertiary-link {
+  font-weight: 600;
+}
+
+.highlighted-destination-card {
+  position: relative;
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0)),
+    linear-gradient(135deg, rgba(0, 29, 23, 0.96), rgba(0, 52, 43, 0.92));
+  color: var(--light-text);
+  transform: translateY(var(--spacing-8));
+}
+
+.highlighted-destination-card h3,
+.highlighted-destination-card p,
+.highlighted-destination-card li,
+.highlighted-destination-card a {
+  color: var(--light-text);
+}
+
+.highlighted-destination-card h3 {
+  margin-bottom: var(--spacing-4);
+  font-size: clamp(1.9rem, 3vw, 2.4rem);
+}
+
+.highlighted-destination-card .button:hover,
+.highlighted-destination-card .button:focus-visible {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0)), var(--secondary);
+}
+
+.supporting-link-list {
+  margin: var(--spacing-6) 0 var(--spacing-8);
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: var(--spacing-3);
+}
+
+.supporting-link-list li {
+  position: relative;
+  padding-left: 1.25rem;
+}
+
+.supporting-link-list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.7em;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--secondary) 78%, white);
+}
+
+.home-band {
+  padding: clamp(1.75rem, 4vw, 3rem);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.7), rgba(242, 244, 241, 0.92));
+}
+
+.band-intro {
+  max-width: 42rem;
+  margin-bottom: var(--spacing-10);
+}
+
+.band-intro h2 {
+  margin-bottom: var(--spacing-4);
+}
+
+.supporting-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--spacing-6);
+  align-items: start;
+}
+
+.supporting-card-grid--two-up {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.supporting-card {
+  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(242, 244, 241, 0.88));
+}
+
+.supporting-card h3 {
+  margin-bottom: var(--spacing-3);
+}
+
+.supporting-card p:last-child {
+  margin-bottom: 0;
+}
+
+.supporting-card--offset {
+  margin-top: var(--spacing-8);
+}
+
+.supporting-card--quiet {
+  background: linear-gradient(180deg, rgba(225, 227, 224, 0.75), rgba(242, 244, 241, 0.78));
+}
+
+.home-tertiary {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  gap: var(--spacing-10);
+  padding: clamp(1.5rem, 3vw, 2.5rem) 0 0;
+}
+
+.tertiary-link-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--spacing-6);
+}
+
+.tertiary-link-group {
+  padding: 1.4rem 1.5rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.74), rgba(242, 244, 241, 0.88));
+}
+
+.supporting-link-list--compact {
+  margin-bottom: 0;
+}
+
+.supporting-link-list--compact a {
+  font-weight: 600;
+}
+
+@media (max-width: 960px) {
+  .home-hero,
+  .home-tertiary,
+  .supporting-card-grid,
+  .supporting-card-grid--two-up,
+  .tertiary-link-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .highlighted-destination-card,
+  .supporting-card--offset {
+    transform: none;
+    margin-top: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .home-main {
+    padding-top: var(--spacing-12);
+    padding-bottom: var(--spacing-12);
+  }
+
+  .home-stage + .home-stage {
+    margin-top: var(--spacing-20);
+  }
+
+  .hero-cta-cluster {
+    align-items: stretch;
+  }
+
+  .hero-cta-cluster .button,
+  .hero-cta-cluster .hero-tertiary-link {
+    width: 100%;
+  }
+}
+
 /* YouTube-specific styles */
 .youtube-button {
   background-color: #ff0000;


### PR DESCRIPTION
### Motivation
- Align the homepage with the "Digital Curator" marketing brief by moving away from an evenly tiled welcome/cards grid toward a staged, authored homepage composition. 
- Surface the highest-priority destinations (learning materials, tools/projects, and CV/profile) in the first visual tier while demoting lower-priority links to secondary/tertiary locations. 
- Introduce selective asymmetry and larger vertical rhythm so the homepage feels editorial and intentional rather than uniformly modular. 
- Preserve the existing navigation and theme toggle while making the main content feel authored and hierarchical.

### Description
- Replaced the old `welcome-section` + `.card-container` block in `index.html` with staged sections: `.home-hero`, `.home-band` (support/media), and `.home-tertiary` for community/contact links, and updated hero copy to a stronger value proposition. 
- Promoted `learn.html`, `projects.html`, and `CV.html` into the primary CTA cluster and the supporting-card grid, and moved YouTube/Math Club/contact into secondary/tertiary bands. 
- Added page-specific markup classes such as `home-shell-header`, `home-main`, `home-stage`, `hero-copy-column`, `highlighted-destination-card`, `supporting-card-grid`, `supporting-card--offset`, and `tertiary-link-columns`. 
- Appended scoped homepage styles to `styles.css` including `.button-secondary`, `.home-main`, `.home-kicker`, `.home-hero` grid and typography, `.highlighted-destination-card` visual treatment, supporting-card grid and modifiers, tertiary link group styles, and responsive media query adjustments using existing spacing tokens and color tokens.

### Testing
- Automated HTML parse using Python's `html.parser` completed successfully for the updated `index.html`. 
- File-level smoke checks (file parsing and line-count inspections) ran and reported the modified files are present and parseable without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d8f30714833191fe8a0b1c15b256)