### PR TITLE
Fix dark-mode gradients and replace hardcoded light surfaces with tokens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,7 @@
 :root {
   color-scheme: light;
   --ink-strong: #001d17;
-  --ink-soft: #4b5752;
+  --ink-soft: #3d4a44;
   --ink-inverse: #ffffff;
   --ink-earth: #3e271f;
 
@@ -68,7 +68,7 @@
   --title-md: 1.25rem;
   --body-md: 1rem;
   --body-sm: 0.95rem;
-  --meta-sm: 0.78rem;
+  --meta-sm: 0.82rem;
   --meta-tracking: 0.12em;
   --meta-weight: 600;
   --line-height-body: 1.7;
@@ -116,14 +116,50 @@
   );
   --gradient-editorial-tier: linear-gradient(
     180deg,
-    rgba(220, 230, 224, 0.3),
+    rgba(220, 230, 224, 0.15),
     rgba(255, 255, 255, 0)
   );
+  --gradient-editorial-hover-tier: linear-gradient(
+    180deg,
+    rgba(220, 230, 224, 0.24),
+    rgba(255, 255, 255, 0)
+  );
+  --gradient-editorial-hover-panel: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.9),
+    rgba(242, 244, 241, 0.94)
+  );
+  --gradient-card-surface: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.94),
+    rgba(242, 244, 241, 0.88)
+  );
+  --gradient-card-surface-hover: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.98),
+    rgba(242, 244, 241, 0.9)
+  );
+  --gradient-publication-surface: linear-gradient(
+    90deg,
+    rgba(58, 102, 92, 0.12),
+    rgba(58, 102, 92, 0.03) 24%,
+    transparent 70%
+  ),
+  linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(242, 244, 241, 0.72));
+  --gradient-publication-surface-hover: linear-gradient(
+    90deg,
+    rgba(13, 80, 213, 0.14),
+    rgba(58, 102, 92, 0.06) 28%,
+    transparent 74%
+  ),
+  linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(242, 244, 241, 0.82));
   --glass-surface: rgba(255, 255, 255, 0.85);
   --ghost-outline: rgba(192, 200, 196, 0.15);
   --ambient-outline: rgba(192, 200, 196, 0.32);
   --elevation-veil: rgba(255, 255, 255, 0.66);
   --elevation-veil-strong: rgba(255, 255, 255, 0.82);
+  --gradient-footer-surface: linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(220, 230, 224, 0.18) 14%, rgba(232, 235, 231, 0.98)),
+    linear-gradient(180deg, rgba(242, 244, 241, 0.96), rgba(232, 235, 231, 0.98));
   --nav-surface-start: rgba(255, 255, 255, 0.88);
   --nav-surface-end: rgba(242, 244, 241, 0.78);
   --context-surface-start: rgba(255, 255, 255, 0.68);
@@ -389,8 +425,8 @@ section {
 
 section:hover {
   background:
-    linear-gradient(180deg, rgba(220, 230, 224, 0.36), rgba(255, 255, 255, 0)),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(242, 244, 241, 0.94));
+    var(--gradient-editorial-hover-tier),
+    var(--gradient-editorial-hover-panel);
   box-shadow: 0 18px 36px rgba(0, 29, 23, 0.06);
 }
 
@@ -444,17 +480,13 @@ section h2 {
   margin-bottom: 1rem;
   padding: 1rem 1.15rem;
   border-radius: var(--radius-md);
-  background:
-    linear-gradient(90deg, rgba(58, 102, 92, 0.12), rgba(58, 102, 92, 0.03) 24%, transparent 70%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(242, 244, 241, 0.72));
+  background: var(--gradient-publication-surface);
   transition: var(--transition);
 }
 
 .publications-item:hover {
   transform: translateX(5px);
-  background:
-    linear-gradient(90deg, rgba(13, 80, 213, 0.14), rgba(58, 102, 92, 0.06) 28%, transparent 74%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(242, 244, 241, 0.82));
+  background: var(--gradient-publication-surface-hover);
 }
 
 /* Button styles */
@@ -830,7 +862,7 @@ section h2 {
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 1rem;
   align-items: stretch;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(242, 244, 241, 0.88));
+  background: var(--gradient-card-surface);
   box-shadow: 0 16px 34px rgba(0, 29, 23, 0.05);
   border-radius: var(--border-radius);
   padding: 1rem 1.25rem;
@@ -895,7 +927,7 @@ section h2 {
 .course-meta-card,
 .quick-link-card,
 .unit-overview-block {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(242, 244, 241, 0.88));
+  background: var(--gradient-card-surface);
   border-radius: var(--border-radius);
   padding: 1.25rem;
   box-shadow: 0 16px 34px rgba(0, 29, 23, 0.05);
@@ -938,7 +970,7 @@ section h2 {
 }
 
 .unit-module-card {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(242, 244, 241, 0.88));
+  background: var(--gradient-card-surface);
   border-radius: var(--border-radius);
   padding: var(--spacing-6);
   box-shadow: 0 16px 34px rgba(0, 29, 23, 0.05);
@@ -1032,7 +1064,7 @@ section h2 {
   border-collapse: separate;
   border-spacing: 0;
   margin: 1rem 0 2rem;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(242, 244, 241, 0.88));
+  background: var(--gradient-card-surface);
   overflow: hidden;
   border-radius: var(--border-radius);
   box-shadow: 0 14px 32px rgba(0, 29, 23, 0.05);
@@ -1098,9 +1130,7 @@ section h2 {
 
 /* Footer styling */
 footer {
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(220, 230, 224, 0.18) 14%, rgba(232, 235, 231, 0.98)),
-    linear-gradient(180deg, rgba(242, 244, 241, 0.96), rgba(232, 235, 231, 0.98));
+  background: var(--gradient-footer-surface);
   color: var(--secondary-color);
   text-align: center;
   padding: 2.75rem 0 2.25rem;
@@ -1322,6 +1352,54 @@ main.error-main {
     rgba(43, 53, 49, 0.94),
     rgba(24, 32, 29, 0.92)
   );
+  --gradient-editorial-panel: linear-gradient(
+    180deg,
+    rgba(43, 53, 49, 0.82),
+    rgba(24, 32, 29, 0.9)
+  );
+  --gradient-editorial-tier: linear-gradient(
+    180deg,
+    rgba(37, 46, 43, 0.3),
+    rgba(17, 22, 20, 0)
+  );
+  --gradient-editorial-hover-tier: linear-gradient(
+    180deg,
+    rgba(43, 53, 49, 0.4),
+    rgba(17, 22, 20, 0)
+  );
+  --gradient-editorial-hover-panel: linear-gradient(
+    180deg,
+    rgba(49, 60, 56, 0.88),
+    rgba(24, 32, 29, 0.96)
+  );
+  --gradient-card-surface: linear-gradient(
+    180deg,
+    rgba(43, 53, 49, 0.82),
+    rgba(24, 32, 29, 0.9)
+  );
+  --gradient-card-surface-hover: linear-gradient(
+    180deg,
+    rgba(49, 60, 56, 0.9),
+    rgba(24, 32, 29, 0.96)
+  );
+  --gradient-publication-surface: linear-gradient(
+    90deg,
+    rgba(126, 168, 255, 0.12),
+    rgba(58, 102, 92, 0.1) 24%,
+    transparent 70%
+  ),
+  linear-gradient(180deg, rgba(43, 53, 49, 0.82), rgba(24, 32, 29, 0.9));
+  --gradient-publication-surface-hover: linear-gradient(
+    90deg,
+    rgba(126, 168, 255, 0.2),
+    rgba(58, 102, 92, 0.12) 28%,
+    transparent 74%
+  ),
+  linear-gradient(180deg, rgba(49, 60, 56, 0.88), rgba(24, 32, 29, 0.96));
+  --elevation-veil: rgba(17, 22, 20, 0.66);
+  --elevation-veil-strong: rgba(17, 22, 20, 0.82);
+  --gradient-footer-surface: linear-gradient(180deg, transparent, rgba(37, 46, 43, 0.18) 14%, rgba(24, 32, 29, 0.98)),
+    linear-gradient(180deg, rgba(24, 32, 29, 0.96), rgba(17, 22, 20, 0.98));
 }
 
 :root[data-theme="dark"] .profile-image {
@@ -1333,7 +1411,7 @@ main.error-main {
   font-size: var(--meta-sm);
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: #aaa;
+  color: var(--on-surface-variant);
 }
 
 /* Theme Toggle Button Styling */
@@ -1364,6 +1442,10 @@ main.error-main {
 :focus {
   outline: 2px solid var(--primary-color);
   outline-offset: 2px;
+}
+
+:root[data-theme="dark"] :focus {
+  outline-color: var(--secondary);
 }
 
 /* Animations */


### PR DESCRIPTION
### Motivation
- Dark-mode surfaces were rendering bright white patches because several gradients and component backgrounds used hardcoded white `rgba(...)` values and the dark theme did not override all gradient tokens.
- Small meta text and focus outlines were also marginal in contrast for dark mode and very small meta typography in light mode.

### Description
- Introduce tokenized surface and hover gradients (e.g. `--gradient-editorial-panel`, `--gradient-editorial-tier`, `--gradient-editorial-hover-*`, `--gradient-card-surface`, `--gradient-publication-surface`, `--gradient-footer-surface`) and reduce the light-mode editorial tier opacity to lessen washout.
- Replace hardcoded white-based backgrounds on `section`, `.publications-item`, `.course-identity`, `.course-meta-card`, `.quick-link-card`, `.unit-overview-block`, `.unit-module-card`, `.assignment-resource-table`, and `footer` with the new gradient tokens so surfaces adapt to theme switches.
- Add matching dark-theme overrides in `:root[data-theme="dark"]` for the new gradient tokens and update elevation veil tokens for dark surfaces.
- Improve contrast and accessibility by increasing `--meta-sm` from `0.78rem` to `0.82rem`, darkening `--ink-soft`, changing `.item-date` in dark mode to use `var(--on-surface-variant)`, and adding a dark-mode focus override to use `var(--secondary)` as the outline color.

### Testing
- Ran the preflight check `git diff --check` with no reported issues.
- Captured repository status and current revision (`git status --short` and `git rev-parse --short HEAD`) to verify the working tree and changes.
- Visual/browser screenshot testing was not executed in this environment, so a quick visual verification in a browser is recommended after deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c10c4bd7808331abd7c84388728653)