### PR TITLE
Separate promotional/card styles and add reading-first wrappers for course content

### DIFF
--- a/courses/constant-acceleration-lab-manual.html
+++ b/courses/constant-acceleration-lab-manual.html
@@ -5,7 +5,7 @@
 <script src="../theme.js"></script>
     <link rel="stylesheet" href="../styles.css">
 </head>
-<body>
+<body class="reading-page reading-page--lab">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
@@ -40,6 +40,7 @@
     </div>
   </div>
 </nav>
+<main class="reading-flow">
 
 <div class="page-context-bar">
   <div class="container">
@@ -134,5 +135,6 @@
 <h2>8. Conclusion:</h2>
 <p>In this lab, you have investigated the motion of a cart on an inclined plane and determined its acceleration using the kinematic equations. You have also learned how to analyze position vs. time, velocity vs. time, and acceleration vs. time graphs. By understanding the relationship between displacement, velocity, acceleration, and time, you have gained a deeper understanding of the principles of kinematics.</p>
 
+</main>
 </body>
 </html>

--- a/courses/density-lab-manual.html
+++ b/courses/density-lab-manual.html
@@ -5,7 +5,7 @@
 <script src="../theme.js"></script>
     <link rel="stylesheet" href="../styles.css">
 </head>
-<body>
+<body class="reading-page reading-page--lab">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
@@ -40,6 +40,7 @@
     </div>
   </div>
 </nav>
+<main class="reading-flow">
 
 <div class="page-context-bar">
   <div class="container">
@@ -127,5 +128,6 @@
 <h2>8. Conclusion:</h2>
 <p>In this lab, you have learned how to determine the density of various solid and liquid substances using different methods. You have also learned how to estimate and propagate uncertainties in your density measurements. By understanding the relationship between mass, volume, and density, you have gained a deeper understanding of the properties of matter.</p>
 
+</main>
 </body>
 </html>

--- a/courses/electrical-circuits-lab-manual.html
+++ b/courses/electrical-circuits-lab-manual.html
@@ -29,7 +29,7 @@
 </style>
     <link rel="stylesheet" href="../styles.css">
 </head>
-<body>
+<body class="reading-page reading-page--lab">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
@@ -64,6 +64,7 @@
     </div>
   </div>
 </nav>
+<main class="reading-flow">
 
 <div class="page-context-bar">
   <div class="container">
@@ -267,5 +268,6 @@
  </li>
 </ol>
 
+</main>
 </body>
 </html>

--- a/courses/final-exam-review-guide.html
+++ b/courses/final-exam-review-guide.html
@@ -121,10 +121,10 @@
     <p class="subtitle">A cumulative MATH 114 review sheet that organizes concepts, formulas, and calculator suggestions by question type.</p>
   </div>
 </header>
-<main class="container course-page py-6 md:py-8">
+<main class="container course-page reading-page py-6 md:py-8">
 
 
-    <div class="container mx-auto max-w-4xl bg-white p-6 rounded-lg shadow-md">
+    <article class="reading-flow reading-flow--wide">
         <h1 class="text-2xl font-bold text-center mb-6 border-b pb-3 text-blue-700">Final Exam Review Guide</h1>
 
         <div class="question-guide">
@@ -513,7 +513,7 @@
             </ul>
         </div>
 
-    </div>
+    </article>
 </main>
 </body>
 </html>

--- a/courses/hookes-law-lab-manual.html
+++ b/courses/hookes-law-lab-manual.html
@@ -2,8 +2,11 @@
 <html>
 <head>
 <title>Hooke's Law Lab Manual</title>
+<script src="../theme.js"></script>
+<link rel="stylesheet" href="../styles.css">
 </head>
-<body>
+<body class="reading-page reading-page--lab">
+<main class="reading-flow">
 
 <h1>Hooke's Law Lab Manual</h1>
 
@@ -73,5 +76,6 @@
 <h2>8. Conclusion:</h2>
 <p>In this lab, you have investigated the relationship between the force applied to a spring and its extension and determined the spring constant (k) of the spring. You have also learned how to calculate the elastic potential energy stored in a spring. By understanding Hooke's Law and the behavior of springs, you have gained a deeper understanding of the principles of elasticity.</p>
 
+</main>
 </body>
 </html>

--- a/courses/latent-heat-of-fusion-lab-manual.html
+++ b/courses/latent-heat-of-fusion-lab-manual.html
@@ -2,8 +2,11 @@
 <html>
 <head>
 <title>Latent Heat of Fusion Lab Manual</title>
+<script src="../theme.js"></script>
+<link rel="stylesheet" href="../styles.css">
 </head>
-<body>
+<body class="reading-page reading-page--lab">
+<main class="reading-flow">
 
 <h1>Latent Heat of Fusion Lab Manual</h1>
 
@@ -72,5 +75,6 @@
 <h2>8. Conclusion:</h2>
 <p>In this lab, you have determined the latent heat of fusion of ice using calorimetry. You have also learned how to apply the principle of calorimetry to measure heat transfer and analyze the energy involved in melting a solid substance. By understanding the concept of latent heat of fusion, you have gained a deeper understanding of the principles of thermodynamics and phase changes.</p>
 
+</main>
 </body>
 </html>

--- a/courses/math114-final-review.html
+++ b/courses/math114-final-review.html
@@ -97,7 +97,7 @@
         </div>
       </div>
     </div>
-    <main class="container course-page">
+    <main class="container course-page reading-page">
       <section class="unit-overview-block">
         <h2>Final Review &amp; Exam Overview</h2>
         <p>

--- a/courses/measurement-lab-manual.html
+++ b/courses/measurement-lab-manual.html
@@ -2,8 +2,11 @@
 <html>
 <head>
 <title>Measurement Lab Manual</title>
+<script src="../theme.js"></script>
+<link rel="stylesheet" href="../styles.css">
 </head>
-<body>
+<body class="reading-page reading-page--lab">
+<main class="reading-flow">
 
 <h1>Measurement Lab Manual</h1>
 
@@ -211,5 +214,6 @@
 <h2>8. Conclusion:</h2>
 <p>In this lab, you have learned how to use various measuring instruments, collect data, and analyze the uncertainties associated with your measurements. You have also gained a better understanding of the importance of accurate measurements in physics.</p>
 
+</main>
 </body>
 </html>

--- a/courses/reflection-and-refraction-lab-manual.html
+++ b/courses/reflection-and-refraction-lab-manual.html
@@ -2,8 +2,11 @@
 <html>
 <head>
 <title>Reflection and Refraction Lab Manual</title>
+<script src="../theme.js"></script>
+<link rel="stylesheet" href="../styles.css">
 </head>
-<body>
+<body class="reading-page reading-page--lab">
+<main class="reading-flow">
 
 <h1>Reflection and Refraction Lab Manual</h1>
 
@@ -84,5 +87,6 @@
 <h2>8. Conclusion:</h2>
 <p>In this lab, you have investigated the laws of reflection and refraction, determined the index of refraction of different materials, and understood the phenomenon of total internal reflection. You have also learned how to apply Snell's Law to analyze the behavior of light at interfaces. By understanding the principles of reflection and refraction, you have gained a deeper understanding of the nature of light and its interaction with matter.</p>
 
+</main>
 </body>
 </html>

--- a/courses/simple-pendulum-lab-manual.html
+++ b/courses/simple-pendulum-lab-manual.html
@@ -2,8 +2,11 @@
 <html>
 <head>
 <title>Simple Pendulum Lab Manual</title>
+<script src="../theme.js"></script>
+<link rel="stylesheet" href="../styles.css">
 </head>
-<body>
+<body class="reading-page reading-page--lab">
+<main class="reading-flow">
 
 <h1>Simple Pendulum Lab Manual</h1>
 
@@ -73,5 +76,6 @@
 <h2>8. Conclusion:</h2>
 <p>In this lab, you have investigated the relationship between the period of a simple pendulum and its length and determined the acceleration due to gravity (g) using a simple pendulum. You have also learned how to analyze the motion of a simple pendulum using the small-angle approximation. By understanding the factors that affect the period of a simple pendulum, you have gained a deeper understanding of the principles of oscillatory motion.</p>
 
+</main>
 </body>
 </html>

--- a/courses/sound-lab-manual.html
+++ b/courses/sound-lab-manual.html
@@ -2,8 +2,11 @@
 <html>
 <head>
 <title>Sound Lab Manual</title>
+<script src="../theme.js"></script>
+<link rel="stylesheet" href="../styles.css">
 </head>
-<body>
+<body class="reading-page reading-page--lab">
+<main class="reading-flow">
 
 <h1>Sound Lab Manual</h1>
 
@@ -67,5 +70,6 @@
 <h2>8. Conclusion:</h2>
 <p>In this lab, you have determined the speed of sound in air by measuring the resonant frequencies of an air column in a closed tube. You have also investigated the relationship between frequency and wavelength of sound waves and learned about the phenomenon of resonance. By understanding the properties of sound waves and resonance, you have gained a deeper understanding of the principles of acoustics.</p>
 
+</main>
 </body>
 </html>

--- a/courses/spectroscopy-lab-manual.html
+++ b/courses/spectroscopy-lab-manual.html
@@ -2,8 +2,11 @@
 <html>
 <head>
 <title>Spectroscopy Lab Manual</title>
+<script src="../theme.js"></script>
+<link rel="stylesheet" href="../styles.css">
 </head>
-<body>
+<body class="reading-page reading-page--lab">
+<main class="reading-flow">
 
 <h1>Spectroscopy Lab Manual</h1>
 
@@ -73,5 +76,6 @@
 <h2>8. Conclusion:</h2>
 <p>In this lab, you have observed the emission spectra of different elements and identified them based on their unique spectral lines. You have also learned about the Bohr model of the atom and the relationship between atomic structure and emission spectra. By understanding the principles of spectroscopy, you have gained a deeper understanding of the nature of light and matter and the quantum world.</p>
 
+</main>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
 </header>
 
   <main class="container page-shell-main home-main">
-    <section class="home-stage home-hero" aria-labelledby="home-hero-title">
+    <section class="home-stage home-hero feature-section" aria-labelledby="home-hero-title">
       <div class="hero-copy-column">
         <p class="home-kicker">Digital Curator</p>
         <h2 id="home-hero-title">Learn from an authored collection of courses, tools, and teaching resources.</h2>
@@ -84,7 +84,7 @@
       </article>
     </section>
 
-    <section class="home-stage home-band home-band-support" aria-labelledby="featured-paths-title">
+    <section class="home-stage home-band home-band-support promo-band" aria-labelledby="featured-paths-title">
       <div class="band-intro">
         <p class="home-kicker">Primary destinations</p>
         <h2 id="featured-paths-title">Choose the path that fits how you want to engage.</h2>
@@ -112,7 +112,7 @@
       </div>
     </section>
 
-    <section class="home-stage home-band home-band-media" aria-labelledby="beyond-site-title">
+    <section class="home-stage home-band home-band-media promo-band" aria-labelledby="beyond-site-title">
       <div class="band-intro">
         <p class="home-kicker">Secondary band</p>
         <h2 id="beyond-site-title">Keep learning beyond the homepage.</h2>
@@ -133,7 +133,7 @@
       </div>
     </section>
 
-    <section class="home-stage home-tertiary" aria-labelledby="community-links-title">
+    <section class="home-stage home-tertiary editorial-panel" aria-labelledby="community-links-title">
       <div>
         <p class="home-kicker">Community &amp; contact</p>
         <h2 id="community-links-title">A quieter place for external and community links.</h2>

--- a/projects.html
+++ b/projects.html
@@ -60,7 +60,7 @@
 </header>
   
   <main class="container page-shell-main">
-    <section class="welcome-section">
+    <section class="welcome-section editorial-panel">
       <h2>Highlighted Works</h2>
       <p>Below are some of my featured projects, each dedicated to advancing education, engineering, or mathematics.</p>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -285,20 +285,13 @@ a:focus-visible {
 
 /* Header styling */
 header {
-  background:
-    radial-gradient(circle at top center, rgba(255, 255, 255, 0.08), transparent 38%),
-    var(--gradient-library-glow);
-  color: var(--light-text);
-  text-align: center;
-  padding: clamp(4rem, 8vw, 6.5rem) 0;
-  position: relative;
-  border: none;
+  margin: 0;
+  padding: clamp(2.5rem, 5vw, 4rem) 0;
 }
 
 header h1 {
   margin: 0;
   font-size: var(--display-md);
-  color: var(--light-text);
 }
 
 .page-shell-header {
@@ -352,6 +345,125 @@ header h1 {
 .page-shell-main {
   padding-top: var(--spacing-12);
   padding-bottom: var(--spacing-12);
+}
+
+
+.reading-page {
+  --reading-measure: clamp(42rem, 88vw, 48rem);
+  --reading-block-space: clamp(1.75rem, 3vw, 2.5rem);
+  display: grid;
+  gap: var(--spacing-10);
+}
+
+.reading-page > * {
+  min-width: 0;
+}
+
+.reading-flow,
+.reading-surface,
+.reading-block {
+  max-width: var(--reading-measure);
+  width: 100%;
+  margin-inline: auto;
+}
+
+.reading-flow {
+  background: var(--surface-container-low);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: none;
+}
+
+.reading-flow > * + * {
+  margin-top: var(--reading-block-space);
+}
+
+.reading-flow h1,
+.reading-flow h2,
+.reading-flow h3,
+.reading-flow h4 {
+  color: var(--secondary-color);
+}
+
+.reading-flow h1,
+.reading-page > h1,
+.reading-page .reading-title {
+  margin-bottom: var(--spacing-8);
+}
+
+.reading-flow h2,
+.reading-page h2 {
+  margin-top: var(--spacing-12);
+  margin-bottom: var(--spacing-4);
+}
+
+.reading-flow h3,
+.reading-page h3 {
+  margin-top: var(--spacing-8);
+  margin-bottom: var(--spacing-3);
+}
+
+.reading-flow p,
+.reading-flow ul,
+.reading-flow ol,
+.reading-flow pre,
+.reading-flow table,
+.reading-flow blockquote,
+.reading-page .reading-block {
+  margin-bottom: 0;
+}
+
+.reading-page .reading-block,
+.reading-page .question-guide,
+.reading-page .unit-overview-block,
+.reading-page .unit-module-card,
+.reading-page .summary-sheet,
+.reading-page .practice-sheet {
+  max-width: var(--reading-measure);
+  margin-inline: auto;
+  background: var(--surface-container-low);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.35rem, 2.6vw, 2rem);
+  box-shadow: none;
+}
+
+.reading-page .question-guide,
+.reading-page .unit-module-card,
+.reading-page .unit-overview-block,
+.reading-page .summary-sheet,
+.reading-page .practice-sheet {
+  margin-bottom: 0;
+}
+
+.reading-page .unit-task-card,
+.reading-page .unit-resource-card,
+.reading-page .course-meta-card,
+.reading-page .quick-link-card {
+  background: var(--surface-container-lowest);
+  box-shadow: none;
+}
+
+.reading-page .unit-task-grid,
+.reading-page .unit-resource-grid {
+  gap: 0.85rem;
+}
+
+.reading-page .question-guide + .question-guide,
+.reading-page .unit-module-card + .unit-module-card,
+.reading-page .reading-block + .reading-block {
+  margin-top: var(--spacing-6);
+}
+
+.reading-page :where(p, li) {
+  max-width: 72ch;
+}
+
+.reading-page :where(pre, table) {
+  overflow-x: auto;
+}
+
+.reading-page :where(p, li, dd, figcaption, blockquote) a {
+  text-decoration-color: color-mix(in srgb, var(--secondary) 82%, transparent);
 }
 
 .subtitle {
@@ -408,26 +520,14 @@ main {
   padding: var(--spacing-12) 0;
 }
 
-/* Section styling */
+/* Section defaults */
 section {
-  background:
-    var(--gradient-editorial-tier),
-    var(--gradient-editorial-panel);
-  border-radius: var(--radius-lg);
-  padding: clamp(2rem, 4vw, 3rem);
-  margin-bottom: var(--section-space);
-  transition: var(--transition);
-  outline: 1px solid transparent;
-  -webkit-animation: fadeIn 0.5s ease-out forwards;
-  animation: fadeIn 0.5s ease-out forwards;
-  opacity: 0;
+  margin: 0 0 var(--section-space);
+  padding: 0;
 }
 
-section:hover {
-  background:
-    var(--gradient-editorial-hover-tier),
-    var(--gradient-editorial-hover-panel);
-  box-shadow: 0 18px 36px rgba(0, 29, 23, 0.06);
+section:last-child {
+  margin-bottom: 0;
 }
 
 section h2 {
@@ -435,6 +535,33 @@ section h2 {
   margin-bottom: var(--spacing-5);
   padding-bottom: 0;
   border-bottom: none;
+}
+
+.editorial-panel,
+.marketing-card,
+.feature-section,
+.promo-band {
+  position: relative;
+  background:
+    var(--gradient-editorial-tier),
+    var(--gradient-editorial-panel);
+  border-radius: var(--radius-lg);
+  padding: clamp(2rem, 4vw, 3rem);
+  transition: var(--transition);
+  outline: 1px solid transparent;
+  -webkit-animation: fadeIn 0.5s ease-out forwards;
+  animation: fadeIn 0.5s ease-out forwards;
+  opacity: 0;
+}
+
+.editorial-panel:hover,
+.marketing-card:hover,
+.feature-section:hover,
+.promo-band:hover {
+  background:
+    var(--gradient-editorial-hover-tier),
+    var(--gradient-editorial-hover-panel);
+  box-shadow: 0 18px 36px rgba(0, 29, 23, 0.06);
 }
 
 /* Two-column layout */
@@ -1267,7 +1394,10 @@ main.error-main {
     color: black;
   }
 
-  section,
+  .editorial-panel,
+  .feature-section,
+  .promo-band,
+  .marketing-card,
   .container {
     margin: 0;
     padding: 0.5in;
@@ -1472,19 +1602,19 @@ main.error-main {
  }
 
 /* Stagger section animations for smoother page load */
-section:nth-child(1) {
+:is(.editorial-panel, .feature-section, .promo-band, .marketing-card):nth-child(1) {
   animation-delay: 0.05s;
 }
-section:nth-child(2) {
+:is(.editorial-panel, .feature-section, .promo-band, .marketing-card):nth-child(2) {
   animation-delay: 0.1s;
 }
-section:nth-child(3) {
+:is(.editorial-panel, .feature-section, .promo-band, .marketing-card):nth-child(3) {
   animation-delay: 0.15s;
 }
-section:nth-child(4) {
+:is(.editorial-panel, .feature-section, .promo-band, .marketing-card):nth-child(4) {
   animation-delay: 0.2s;
 }
-section:nth-child(5) {
+:is(.editorial-panel, .feature-section, .promo-band, .marketing-card):nth-child(5) {
   animation-delay: 0.25s;
 }
 
@@ -1543,7 +1673,10 @@ section:nth-child(5) {
     padding: 0 1rem;
   }
 
-  section {
+  .editorial-panel,
+  .feature-section,
+  .promo-band,
+  .marketing-card {
     padding: var(--spacing-6);
   }
 


### PR DESCRIPTION
### Motivation
- Prevent raw `section` elements from receiving promotional card treatments so long-form instructional pages read like essays rather than marketing cards. 
- Provide explicit component classes for dramatic/editorial surfaces so entry points can retain the layered gradients and hover lift without affecting course material. 
- Improve reading ergonomics for dense course material by constraining measure, stabilizing heading rhythm, and removing default shadows/hover lift.

### Description
- Reduce broad `header`, `main`, and `section` rules to safe layout/typography defaults and move gradient/rounded/hover effects onto new explicit classes: `.editorial-panel`, `.marketing-card`, `.feature-section`, and `.promo-band` in `styles.css`.
- Add reading-first wrappers and surfaces (`.reading-page`, `.reading-flow`, `.reading-block`, constrained measure ~`42rem–48rem`, predictable heading spacing, no default drop shadows) that use existing tokens from `WebDesign.md` to preserve the design system.
- Apply the new editorial/marketing classes to homepage and projects entry points (`index.html`, `projects.html`) so those pages keep the dramatic treatments while generic `section` elements remain neutral.
- Apply the reading wrappers to dense course/review and lab-manual pages under `courses/` (e.g., `math114-final-review.html`, `final-exam-review-guide.html`, and multiple `*-lab-manual.html` files) and add missing `../styles.css`/`../theme.js` includes where needed so the wrappers render correctly.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and the check completed with no reported problems. 
- Ran a structural Python check that verifies matching brace counts in `styles.css` and balanced `main`/`article` open-close usage in modified HTML files, and it passed for all changed files. 
- Performed file diffs to confirm targeted HTML changes and CSS insertions; no automated visual tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c10f93a34483318f832aab37507c97)