### PR TITLE
Standardize interactive tool page styling

### DIFF
--- a/130Test4.html
+++ b/130Test4.html
@@ -368,6 +368,9 @@
           </ul>
         </li>
       </ul>
+      <button aria-label="Toggle dark and light theme" class="theme-toggle review-theme-toggle" id="theme-toggle-btn" title="Toggle Theme">
+        <i data-lucide="moon"></i>
+      </button>
     </div>
   </div>
 </nav>
@@ -392,11 +395,7 @@
             <span class="chip"><i data-lucide="graduation-cap"></i> Final Exam: Thu, 5/7</span>
             <span class="chip"><i data-lucide="layers-3"></i> Final week only</span>
         </div>
-
-        <button class="theme-toggle review-theme-toggle" id="themeToggle" aria-label="Toggle theme">
-            <i data-lucide="sun-moon"></i>
-        </button>
-    </header>
+</header>
 
 
     <section class="recommended-order-panel" aria-label="Recommended study order">
@@ -822,7 +821,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const savedTheme = localStorage.getItem('math130-final-theme');
     if (savedTheme === 'light') body.classList.add('light');
 
-    const themeToggle = document.getElementById('themeToggle');
+    const themeToggle = document.getElementById('theme-toggle-btn');
     themeToggle?.addEventListener('click', function () {
         body.classList.toggle('light');
         localStorage.setItem('math130-final-theme', body.classList.contains('light') ? 'light' : 'dark');

--- a/Taskflow.html
+++ b/Taskflow.html
@@ -19,9 +19,9 @@
 
     /* Each “box” or node in the flowchart */
     .node {
-      background: #f9f9f9;
-      border: 2px solid #ccc;
-      border-radius: 8px;
+      background: var(--surface-container-lowest);
+      border: 1px solid var(--ghost-outline);
+      border-radius: var(--radius-md);
       text-align: center;
       width: 250px;
       padding: 10px;
@@ -39,7 +39,7 @@
       height: 0;
       border-left: 8px solid transparent;
       border-right: 8px solid transparent;
-      border-top: 20px solid #ccc;
+      border-top: 20px solid color-mix(in srgb, var(--secondary) 20%, var(--ghost-outline));
       transform: translateX(-50%);
     }
 
@@ -50,7 +50,7 @@
 
     /* Simple emphasis for “Yes” / “No” connectors */
     .decision {
-      color: #007BFF;
+      color: var(--secondary);
       font-weight: bold;
     }
 
@@ -64,15 +64,20 @@
 
 
     <link rel="stylesheet" href="styles.css">
+    <script src="theme.js" defer></script>
 </head>
-<body>
+<body class="tool-page-body">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
       <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
     </div>
     <div class="top-nav-actions">
-      <ul class="top-nav-links">
+      <button class="menu-toggle global-nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav-links primary-nav-utilities" aria-label="Toggle navigation">
+        <span>Menu</span>
+        <span class="menu-toggle__icon" aria-hidden="true"></span>
+      </button>
+      <ul class="top-nav-links" id="primary-nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="CV.html">About</a></li>
         <li class="dropdown">
@@ -86,7 +91,7 @@
         </li>
         <li><a href="projects.html">Tools</a></li>
       </ul>
-      <ul class="top-nav-utilities" aria-label="More">
+      <ul class="top-nav-utilities" id="primary-nav-utilities" aria-label="More">
         <li class="dropdown">
           <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
           <ul class="dropdown-menu dropdown-menu--right">
@@ -101,9 +106,15 @@
   </div>
 </nav>
 
-  <h1>Should You Work On That Task Right Now?</h1>
-  
-  <div class="flowchart">
+  <main class="tool-page-main">
+  <section class="tool-page-shell">
+    <header class="tool-callout">
+      <span class="tool-eyebrow">Interactive Tool</span>
+      <h1>Should You Work On That Task Right Now?</h1>
+      <p>A lightweight review-style flowchart for triaging your next teaching task.</p>
+    </header>
+
+  <div class="flowchart tool-control-panel">
     
     <!-- Start Node -->
     <div class="node">
@@ -191,5 +202,7 @@
       </div>
     </div>
   </div>
+  </section>
+</main>
 </body>
 </html>

--- a/Unit3Practice.html
+++ b/Unit3Practice.html
@@ -12,11 +12,8 @@
             padding-bottom: 3rem;
         }
         .practice-sheet {
-            background: var(--card-bg, #fff);
-            border: 1px solid var(--border-color, #d9e2ec);
-            border-radius: 18px;
-            box-shadow: 0 16px 34px rgba(15, 23, 42, 0.08);
-            padding: 2rem;
+            display: grid;
+            gap: var(--spacing-5);
         }
         .practice-sheet h2 {
             color: #2980b9;
@@ -39,20 +36,19 @@
         }
         .assessment {
             font-size: 0.9rem;
-            color: #52616b;
+            color: var(--on-surface-variant);
             font-weight: bold;
-            background-color: #ecf0f1;
+            background: var(--surface-container-highest);
             padding: 0.2rem 0.5rem;
             border-radius: 4px;
             display: inline-block;
             margin-bottom: 0.5rem;
         }
         .practice-sheet ul {
-            background: #fff;
+            background: var(--surface-container-lowest);
             padding: 1.5rem 2.5rem;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-            border: 1px solid #e0e0e0;
+            border-radius: var(--radius-md);
+            border: 1px solid var(--ghost-outline);
         }
         .practice-sheet li {
             margin-bottom: 0.8rem;
@@ -61,9 +57,9 @@
             margin-bottom: 0;
         }
         .image-placeholder {
-            background-color: #e8f4f8;
-            border: 1px dashed #3498db;
-            color: #2980b9;
+            background: var(--surface-container-highest);
+            border: 1px dashed color-mix(in srgb, var(--secondary) 40%, var(--ghost-outline));
+            color: var(--secondary);
             padding: 1rem;
             text-align: center;
             border-radius: 4px;
@@ -86,14 +82,18 @@
         }
     </style>
 </head>
-<body>
+<body class="tool-page-body">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
       <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
     </div>
     <div class="top-nav-actions">
-      <ul class="top-nav-links">
+      <button class="menu-toggle global-nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav-links primary-nav-utilities" aria-label="Toggle navigation">
+        <span>Menu</span>
+        <span class="menu-toggle__icon" aria-hidden="true"></span>
+      </button>
+      <ul class="top-nav-links" id="primary-nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="CV.html">About</a></li>
         <li class="dropdown">
@@ -107,7 +107,7 @@
         </li>
         <li><a href="projects.html">Tools</a></li>
       </ul>
-      <ul class="top-nav-utilities" aria-label="More">
+      <ul class="top-nav-utilities" id="primary-nav-utilities" aria-label="More">
         <li class="dropdown">
           <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
           <ul class="dropdown-menu dropdown-menu--right">

--- a/chessboard.html
+++ b/chessboard.html
@@ -99,15 +99,20 @@
 
 
     <link rel="stylesheet" href="styles.css">
+    <script src="theme.js" defer></script>
 </head>
-<body class="bg-gray-100 p-4 md:p-8 flex flex-col items-center min-h-screen">
+<body class="tool-page-body">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
       <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
     </div>
     <div class="top-nav-actions">
-      <ul class="top-nav-links">
+      <button class="menu-toggle global-nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav-links primary-nav-utilities" aria-label="Toggle navigation">
+        <span>Menu</span>
+        <span class="menu-toggle__icon" aria-hidden="true"></span>
+      </button>
+      <ul class="top-nav-links" id="primary-nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="CV.html">About</a></li>
         <li class="dropdown">
@@ -121,7 +126,7 @@
         </li>
         <li><a href="projects.html">Tools</a></li>
       </ul>
-      <ul class="top-nav-utilities" aria-label="More">
+      <ul class="top-nav-utilities" id="primary-nav-utilities" aria-label="More">
         <li class="dropdown">
           <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
           <ul class="dropdown-menu dropdown-menu--right">
@@ -136,8 +141,9 @@
   </div>
 </nav>
 
+<main class="tool-page-main">
 
-    <div class="w-full max-w-6xl bg-white rounded-lg shadow-xl p-6 md:p-8">
+    <div class="tool-page-shell w-full max-w-6xl">
         <h1 class="text-2xl md:text-3xl font-bold text-center text-gray-800 mb-6">
             <span class="lucide mr-2">&#xe9a2;</span>
             Exponential Growth: Rice on a Chessboard
@@ -147,14 +153,14 @@
 
             <div class="w-full lg:w-1/2 xl:w-2/5">
                 <h2 class="text-lg font-semibold text-gray-700 mb-3 text-center">Chessboard (Click a Square)</h2>
-                <div id="chessboard" class="aspect-square w-full max-w-md mx-auto bg-white border-2 border-gray-300 rounded-md overflow-hidden shadow-md">
+                <div id="chessboard" class="aspect-square w-full max-w-md mx-auto tool-chart-box overflow-hidden">
                     </div>
-                <div id="info-box" class="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-lg text-center">
+                <div id="info-box" class="mt-4 tool-result-panel text-center">
                     <p class="text-sm text-gray-600">Selected Square: <strong id="selected-square" class="text-blue-700">-</strong></p>
                     <p class="text-sm text-gray-600 mt-1">Grains on this square:</p>
                     <p id="grains-on-square" class="text-lg font-bold text-blue-800 break-words">-</p>
                 </div>
-                 <div class="mt-4 p-4 bg-green-50 border border-green-200 rounded-lg text-center">
+                 <div class="mt-4 tool-info-box text-center">
                      <p class="text-sm text-gray-600">Total Grains on Board:</p>
                      <p id="total-grains" class="text-xl font-bold text-green-800 break-words">-</p>
                 </div>
@@ -163,7 +169,7 @@
             <div class="w-full lg:w-1/2 xl:w-3/5">
                  <div>
                     <h2 class="text-lg font-semibold text-gray-700 mb-3 text-center">Grains up to Selected Square (Linear Scale)</h2>
-                    <div id="linear-chart-container" class="bg-gray-50 p-4 rounded-lg border border-gray-200 shadow-inner min-h-[300px] md:min-h-[400px]">
+                    <div id="linear-chart-container" class="tool-chart-box min-h-[300px] md:min-h-[400px]">
                         <svg id="linear-rice-chart" class="w-full h-full"></svg>
                     </div>
                      <p class="text-xs text-gray-500 mt-2 text-center">Linear scale shows true magnitude (early squares become tiny).</p>
@@ -432,6 +438,7 @@
         document.addEventListener('DOMContentLoaded', initialize);
 
     </script>
+</main>
 
 </body>
 </html>

--- a/employeepay.html
+++ b/employeepay.html
@@ -4,47 +4,40 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="styles.css">
+    <script src="theme.js" defer></script>
     <title>Who Earns More? Fixed vs. Doubling Pay</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         /* Basic body styling */
         body {
-            background-color: #f0f9ff; /* Light blue background */
+            background-color: var(--surface);
         }
         /* Ensure chart container takes up space */
         .chart-container {
-            position: relative;
-            height: 55vh; /* Slightly smaller height */
-            width: 90vw; /* Adjust width as needed */
-            max-width: 900px; /* Max width for larger screens */
-            margin: 1.5rem auto; /* Center the chart */
-            margin-bottom: 3rem; /* Add space between charts */
-            background-color: #ffffff; /* White background for chart area */
-            border-radius: 0.75rem; /* Rounded corners */
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Soft shadow */
-            padding: 1rem; /* Padding inside chart container */
+            height: 55vh;
+            margin-bottom: 3rem;
         }
         /* Styling for the person intro boxes */
         .person-box {
-            background-color: #ffffff;
-            border-radius: 0.75rem;
-            padding: 1rem;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
             text-align: center;
-            border: 2px solid; /* Add border for definition */
+            border: 1px solid var(--ghost-outline);
         }
     </style>
 
 </head>
-<body class="p-4 md:p-8">
+<body class="tool-page-body">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
       <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
     </div>
     <div class="top-nav-actions">
-      <ul class="top-nav-links">
+      <button class="menu-toggle global-nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav-links primary-nav-utilities" aria-label="Toggle navigation">
+        <span>Menu</span>
+        <span class="menu-toggle__icon" aria-hidden="true"></span>
+      </button>
+      <ul class="top-nav-links" id="primary-nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="CV.html">About</a></li>
         <li class="dropdown">
@@ -58,7 +51,7 @@
         </li>
         <li><a href="projects.html">Tools</a></li>
       </ul>
-      <ul class="top-nav-utilities" aria-label="More">
+      <ul class="top-nav-utilities" id="primary-nav-utilities" aria-label="More">
         <li class="dropdown">
           <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
           <ul class="dropdown-menu dropdown-menu--right">
@@ -73,8 +66,9 @@
   </div>
 </nav>
 
+<main class="tool-page-main">
 
-    <h1 class="text-2xl md:text-4xl font-bold text-center text-sky-800 mb-6">
+    <section class="tool-page-shell max-w-6xl mx-auto"><h1 class="text-2xl md:text-4xl font-bold text-center text-sky-800 mb-6">
         Who Earns More Money?
     </h1>
 
@@ -82,12 +76,12 @@
         Let's see how two people get paid for 30 days of work! One gets the same amount each day, and the other starts super small, but their pay doubles every day. Watch what happens!
     </p>
     <div class="max-w-3xl mx-auto mb-10 grid grid-cols-1 md:grid-cols-2 gap-6 px-4">
-        <div class="person-box border-blue-400">
+        <div class="person-box tool-info-box border-blue-400">
             <span class="text-5xl mb-2 block" role="img" aria-label="Steady Worker">👨‍💼</span>
             <h3 class="text-xl font-semibold text-blue-700 mb-1">Person 1: Steady Sam</h3>
             <p class="text-gray-600">Gets <strong class="font-bold">$1,000</strong> every single day.</p>
         </div>
-        <div class="person-box border-red-400">
+        <div class="person-box tool-info-box border-red-400">
              <span class="text-5xl mb-2 block" role="img" aria-label="Rocket Growth">🚀</span>
             <h3 class="text-xl font-semibold text-red-700 mb-1">Person 2: Doubling Penny</h3>
             <p class="text-gray-600">Starts with <strong class="font-bold">1 penny</strong> ($0.01). Pay <strong class="font-bold">doubles</strong> each day!</p>
@@ -96,14 +90,14 @@
     <h2 class="text-xl md:text-2xl font-semibold text-center text-sky-700 mb-4">
         Chart 1: Seeing the Start (Log View)
     </h2>
-    <div class="chart-container">
+    <div class="chart-container tool-chart-box">
         <canvas id="earningsChartLog"></canvas>
     </div>
 
     <h2 class="text-xl md:text-2xl font-semibold text-center text-sky-700 mt-10 mb-4">
         Chart 2: Seeing the End (Normal View)
     </h2>
-    <div class="chart-container">
+    <div class="chart-container tool-chart-box">
         <canvas id="earningsChartLinear"></canvas>
     </div>
 
@@ -257,6 +251,7 @@
             }
         });
     </script>
+</main>
 
 </body>
 </html>

--- a/growth.html
+++ b/growth.html
@@ -18,15 +18,20 @@
 
 
     <link rel="stylesheet" href="styles.css">
+    <script src="theme.js" defer></script>
 </head>
-<body class="bg-gray-100 p-4 md:p-8">
+<body class="tool-page-body">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
       <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
     </div>
     <div class="top-nav-actions">
-      <ul class="top-nav-links">
+      <button class="menu-toggle global-nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav-links primary-nav-utilities" aria-label="Toggle navigation">
+        <span>Menu</span>
+        <span class="menu-toggle__icon" aria-hidden="true"></span>
+      </button>
+      <ul class="top-nav-links" id="primary-nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="CV.html">About</a></li>
         <li class="dropdown">
@@ -40,7 +45,7 @@
         </li>
         <li><a href="projects.html">Tools</a></li>
       </ul>
-      <ul class="top-nav-utilities" aria-label="More">
+      <ul class="top-nav-utilities" id="primary-nav-utilities" aria-label="More">
         <li class="dropdown">
           <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
           <ul class="dropdown-menu dropdown-menu--right">
@@ -55,14 +60,15 @@
   </div>
 </nav>
 
-    <div class="max-w-4xl mx-auto bg-white p-6 rounded-lg shadow-md">
+<main class="tool-page-main">
+    <div class="tool-page-shell max-w-4xl mx-auto">
         <h1 class="text-3xl font-bold text-center text-indigo-700 mb-8 border-b pb-4">Math Quiz Prep: Linear, Exponential & Logistic Growth</h1>
 
-        <div class="question-block bg-blue-50 p-4 rounded-lg mb-6 shadow-sm border border-blue-100">
+        <div class="question-block tool-control-panel mb-6">
             <h2 class="text-xl font-bold text-blue-800 mb-3">1. Defining Growth Types</h2>
             <p class="mb-2 text-gray-700"><strong>Question:</strong> Explain the fundamental difference between how a quantity changes in linear growth versus exponential growth.</p>
-            <button class="reveal-button mt-2 px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm shadow">Reveal Answer</button>
-            <div class="answer-content hidden bg-white p-3 mt-3 rounded border border-gray-200">
+            <button class="reveal-button tool-button mt-2 px-3 py-1 text-sm">Reveal Answer</button>
+            <div class="answer-content tool-result-panel hidden mt-3">
                 <p class="font-semibold text-gray-800">Answer:</p>
                 <ul class="list-disc list-inside ml-4 mt-2 text-gray-700">
                     <li><strong>Linear Growth:</strong> Adds a <strong class="text-blue-600">constant amount</strong> per time unit. The rate of change is constant. Example: Saving exactly $50 each month.</li>
@@ -71,11 +77,11 @@
             </div>
         </div>
 
-        <div class="question-block bg-green-50 p-4 rounded-lg mb-6 shadow-sm border border-green-100">
+        <div class="question-block tool-control-panel mb-6">
              <h2 class="text-xl font-bold text-green-800 mb-3">2. Identifying Growth Type</h2>
              <p class="mb-2 text-gray-700"><strong>Question:</strong> Identify the growth type for each scenario:</p>
-             <button class="reveal-button mt-2 px-3 py-1 bg-green-500 text-white rounded hover:bg-green-600 text-sm shadow">Reveal Answer</button>
-             <div class="answer-content hidden bg-white p-3 mt-3 rounded border border-gray-200 space-y-3">
+             <button class="reveal-button tool-button mt-2 px-3 py-1 text-sm">Reveal Answer</button>
+             <div class="answer-content tool-result-panel hidden mt-3 space-y-3">
                  <div>
                      <p><strong>Scenario A:</strong> A town's population increases by 1,000 people every year.</p>
                      <p class="pl-4 text-gray-700"><strong>Answer:</strong> <span class="font-semibold text-green-700">Linear</span> (constant amount added).</p>
@@ -87,11 +93,11 @@
              </div>
         </div>
 
-        <div class="question-block bg-yellow-50 p-4 rounded-lg mb-6 shadow-sm border border-yellow-100">
+        <div class="question-block tool-control-panel mb-6">
             <h2 class="text-xl font-bold text-yellow-800 mb-3">3. Calculating Exponential Growth</h2>
             <p class="mb-2 text-gray-700"><strong>Question:</strong> A mold culture starts with 50 spores and doubles every 6 hours. How many spores will there be after 24 hours?</p>
-            <button class="reveal-button mt-2 px-3 py-1 bg-yellow-500 text-white rounded hover:bg-yellow-600 text-sm shadow">Reveal Answer</button>
-            <div class="answer-content hidden bg-white p-3 mt-3 rounded border border-gray-200">
+            <button class="reveal-button tool-button mt-2 px-3 py-1 text-sm">Reveal Answer</button>
+            <div class="answer-content tool-result-panel hidden mt-3">
                 <p class="font-semibold text-gray-800">Solution:</p>
                 <ol class="list-decimal list-inside ml-4 mt-2 text-gray-700">
                     <li>Determine the number of doubling periods: 24 hours / 6 hours/period = 4 periods.</li>
@@ -102,11 +108,11 @@
             </div>
         </div>
 
-        <div class="question-block bg-purple-50 p-4 rounded-lg mb-6 shadow-sm border border-purple-100">
+        <div class="question-block tool-control-panel mb-6">
             <h2 class="text-xl font-bold text-purple-800 mb-3">4. Using the Rule of 70</h2>
             <p class="mb-2 text-gray-700"><strong>Question:</strong> If an investment is growing at an average rate of 5% per year, use the Rule of 70 to estimate how long it will take for the investment to double.</p>
-            <button class="reveal-button mt-2 px-3 py-1 bg-purple-500 text-white rounded hover:bg-purple-600 text-sm shadow">Reveal Answer</button>
-            <div class="answer-content hidden bg-white p-3 mt-3 rounded border border-gray-200">
+            <button class="reveal-button tool-button mt-2 px-3 py-1 text-sm">Reveal Answer</button>
+            <div class="answer-content tool-result-panel hidden mt-3">
                  <p class="font-semibold text-gray-800">Formula:</p>
                  <p class="ml-4 text-gray-700">Doubling Time ≈ 70 / (percentage growth rate)</p>
                  <p class="font-semibold text-gray-800 mt-2">Calculation:</p>
@@ -115,11 +121,11 @@
              </div>
         </div>
 
-        <div class="question-block bg-red-50 p-4 rounded-lg mb-6 shadow-sm border border-red-100">
+        <div class="question-block tool-control-panel mb-6">
              <h2 class="text-xl font-bold text-red-800 mb-3">5. Understanding Carrying Capacity</h2>
              <p class="mb-2 text-gray-700"><strong>Question:</strong> Imagine deer living in a forest. What factors might limit the deer population from growing infinitely? What term do we use for the maximum sustainable population size in that environment?</p>
-             <button class="reveal-button mt-2 px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 text-sm shadow">Reveal Answer</button>
-             <div class="answer-content hidden bg-white p-3 mt-3 rounded border border-gray-200">
+             <button class="reveal-button tool-button mt-2 px-3 py-1 text-sm">Reveal Answer</button>
+             <div class="answer-content tool-result-panel hidden mt-3">
                  <p class="font-semibold text-gray-800">Answer:</p>
                  <ul class="list-disc list-inside ml-4 mt-2 text-gray-700">
                      <li><strong>Limiting Factors:</strong> Availability of food, water, space; presence of predators; disease.</li>
@@ -129,11 +135,11 @@
              </div>
          </div>
 
-        <div class="question-block bg-indigo-50 p-4 rounded-lg mb-6 shadow-sm border border-indigo-100">
+        <div class="question-block tool-control-panel mb-6">
             <h2 class="text-xl font-bold text-indigo-800 mb-3">6. Comparing Doubling Time Formulas</h2>
             <p class="mb-2 text-gray-700"><strong>Question:</strong> When might it be acceptable to use the quick estimate from the Rule of 70, and when might you need a more precise formula (using logarithms)?</p>
-            <button class="reveal-button mt-2 px-3 py-1 bg-indigo-500 text-white rounded hover:bg-indigo-600 text-sm shadow">Reveal Answer</button>
-            <div class="answer-content hidden bg-white p-3 mt-3 rounded border border-gray-200">
+            <button class="reveal-button tool-button mt-2 px-3 py-1 text-sm">Reveal Answer</button>
+            <div class="answer-content tool-result-panel hidden mt-3">
                 <p class="font-semibold text-gray-800">Answer:</p>
                 <ul class="list-disc list-inside ml-4 mt-2 text-gray-700">
                     <li><strong>Rule of 70:</strong> Good for <strong class="text-indigo-600">quick mental estimates</strong>, especially for common growth rates (e.g., 1% to 10%). It's an approximation.</li>
@@ -142,11 +148,11 @@
             </div>
         </div>
 
-        <div class="question-block bg-pink-50 p-4 rounded-lg mb-6 shadow-sm border border-pink-100">
+        <div class="question-block tool-control-panel mb-6">
             <h2 class="text-xl font-bold text-pink-800 mb-3">7. Explaining Logistic Growth</h2>
             <p class="mb-2 text-gray-700"><strong>Question:</strong> Describe the shape of a logistic growth curve. What happens to the growth rate during the different phases?</p>
-            <button class="reveal-button mt-2 px-3 py-1 bg-pink-500 text-white rounded hover:bg-pink-600 text-sm shadow">Reveal Answer</button>
-            <div class="answer-content hidden bg-white p-3 mt-3 rounded border border-gray-200">
+            <button class="reveal-button tool-button mt-2 px-3 py-1 text-sm">Reveal Answer</button>
+            <div class="answer-content tool-result-panel hidden mt-3">
                 <p class="font-semibold text-gray-800">Answer:</p>
                  <ul class="list-disc list-inside ml-4 mt-2 text-gray-700">
                     <li><strong>Shape:</strong> It's an <strong class="text-pink-600">S-shaped curve</strong>.</li>
@@ -162,11 +168,11 @@
             </div>
         </div>
 
-        <div class="question-block bg-teal-50 p-4 rounded-lg mb-6 shadow-sm border border-teal-100">
+        <div class="question-block tool-control-panel mb-6">
             <h2 class="text-xl font-bold text-teal-800 mb-3">8. Calculating Population Growth Rate</h2>
             <p class="mb-2 text-gray-700"><strong>Question:</strong> A country has 25 births per 1,000 people and 10 deaths per 1,000 people annually. What is its natural population growth rate as a percentage?</p>
-            <button class="reveal-button mt-2 px-3 py-1 bg-teal-500 text-white rounded hover:bg-teal-600 text-sm shadow">Reveal Answer</button>
-            <div class="answer-content hidden bg-white p-3 mt-3 rounded border border-gray-200">
+            <button class="reveal-button tool-button mt-2 px-3 py-1 text-sm">Reveal Answer</button>
+            <div class="answer-content tool-result-panel hidden mt-3">
                 <p class="font-semibold text-gray-800">Solution:</p>
                 <ol class="list-decimal list-inside ml-4 mt-2 text-gray-700">
                     <li>Find the net increase per 1,000 people: Birth Rate - Death Rate = 25 - 10 = 15 per 1,000.</li>
@@ -177,11 +183,11 @@
             </div>
         </div>
 
-         <div class="question-block bg-orange-50 p-4 rounded-lg mb-6 shadow-sm border border-orange-100">
+         <div class="question-block tool-control-panel mb-6">
             <h2 class="text-xl font-bold text-orange-800 mb-3">9. Applying Growth Concepts</h2>
             <p class="mb-2 text-gray-700"><strong>Question:</strong> Give one real-world example where linear growth might be a suitable model, and one where exponential growth is more appropriate (at least initially).</p>
-             <button class="reveal-button mt-2 px-3 py-1 bg-orange-500 text-white rounded hover:bg-orange-600 text-sm shadow">Reveal Answer</button>
-             <div class="answer-content hidden bg-white p-3 mt-3 rounded border border-gray-200">
+             <button class="reveal-button tool-button mt-2 px-3 py-1 text-sm">Reveal Answer</button>
+             <div class="answer-content tool-result-panel hidden mt-3">
                 <p class="font-semibold text-gray-800">Answer Examples:</p>
                 <ul class="list-disc list-inside ml-4 mt-2 text-gray-700">
                     <li><strong>Linear:</strong> Water level rising in a cylindrical tank being filled at a constant rate; Salary increasing by a fixed amount ($2000) each year.</li>
@@ -190,11 +196,11 @@
             </div>
         </div>
 
-        <div class="question-block bg-lime-50 p-4 rounded-lg mb-6 shadow-sm border border-lime-100">
+        <div class="question-block tool-control-panel mb-6">
             <h2 class="text-xl font-bold text-lime-800 mb-3">10. Exponential Calculation Practice</h2>
             <p class="mb-2 text-gray-700"><strong>Question:</strong> If you start with $500 and it grows by 8% each year, how much money will you have after 3 years?</p>
-            <button class="reveal-button mt-2 px-3 py-1 bg-lime-500 text-white rounded hover:bg-lime-600 text-sm shadow">Reveal Answer</button>
-            <div class="answer-content hidden bg-white p-3 mt-3 rounded border border-gray-200">
+            <button class="reveal-button tool-button mt-2 px-3 py-1 text-sm">Reveal Answer</button>
+            <div class="answer-content tool-result-panel hidden mt-3">
                 <p class="font-semibold text-gray-800">Solution Method 1 (Step-by-step):</p>
                 <ul class="list-disc list-inside ml-4 mt-2 text-gray-700">
                     <li>Year 1: <code class="bg-gray-200 text-gray-800 px-2 py-1 rounded text-sm">$500 × 1.08 = $540</code></li>
@@ -238,5 +244,6 @@
             });
         });
     </script>
+</main>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1413,6 +1413,207 @@ main.error-main {
 }
 
 /* Print styles */
+
+
+.tool-page-body {
+  background:
+    radial-gradient(circle at top, color-mix(in srgb, var(--secondary) 8%, transparent), transparent 28%),
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-container-low) 86%, transparent), transparent 22%),
+    var(--surface);
+}
+
+.tool-page-main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--spacing-10) var(--container-space) var(--section-space);
+}
+
+.tool-page-shell,
+.practice-sheet,
+.tool-surface-card {
+  background: var(--surface-container-lowest);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.25rem, 2vw, 2rem);
+  box-shadow: 0 20px 42px color-mix(in srgb, var(--surface-tint) 8%, transparent);
+}
+
+.tool-page-shell {
+  display: grid;
+  gap: var(--spacing-8);
+}
+
+.tool-panel,
+.tool-control-panel,
+.tool-result-panel,
+.tool-callout,
+.tool-chart-box,
+.tool-info-box,
+.review-callout,
+.recommended-order-panel,
+.journey-panel {
+  background: var(--surface-container-low);
+  border: 1px solid var(--ghost-outline);
+  border-radius: var(--radius-lg);
+  box-shadow: none;
+}
+
+.tool-panel,
+.tool-control-panel,
+.tool-result-panel,
+.tool-callout,
+.tool-chart-box,
+.tool-info-box {
+  padding: clamp(1rem, 1.8vw, 1.4rem);
+}
+
+.tool-control-panel,
+.tool-chart-box,
+.tool-info-box,
+.review-option-button,
+.recommended-order-step,
+.journey-step,
+.practice-stat,
+.stat-card,
+.person-box,
+.chart-container {
+  background: var(--surface-container-lowest);
+  border: 1px solid var(--ghost-outline);
+  border-radius: var(--radius-md);
+  box-shadow: none;
+}
+
+.tool-result-panel,
+#info-box,
+.review-results-panel {
+  background: var(--surface-container-highest);
+}
+
+.tool-callout,
+.review-callout,
+.recommended-order-panel,
+.journey-panel {
+  border-color: color-mix(in srgb, var(--secondary) 24%, var(--ghost-outline));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--secondary) 7%, var(--surface-container-low)), var(--surface-container-low));
+}
+
+.tool-chart-box,
+.chart-container,
+#linear-chart-container {
+  background: var(--surface-container-lowest);
+}
+
+.tool-eyebrow,
+.journey-kicker,
+.recommended-order-panel .order-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--secondary);
+  margin-bottom: 0.7rem;
+}
+
+.tool-button,
+.tool-button--secondary,
+.btn-primary,
+.btn-secondary,
+.quiz-start-btn,
+.practice-start-btn,
+.solution-toggle,
+.practice-action-btn,
+.review-topic-btn,
+.print-btn,
+.reset-btn,
+.quiz-next-btn {
+  border-radius: var(--radius-md);
+  font-family: var(--type-body-family);
+  transition: var(--transition), box-shadow 0.2s ease;
+}
+
+.tool-button,
+.btn-primary,
+.quiz-start-btn,
+.practice-start-btn,
+.quiz-next-btn {
+  background: var(--primary-container);
+  color: var(--on-primary);
+  box-shadow: none;
+}
+
+.tool-button:hover,
+.tool-button:focus-visible,
+.btn-primary:hover,
+.btn-primary:focus-visible,
+.quiz-start-btn:hover,
+.quiz-start-btn:focus-visible,
+.practice-start-btn:hover,
+.practice-start-btn:focus-visible,
+.quiz-next-btn:hover,
+.quiz-next-btn:focus-visible {
+  background: color-mix(in srgb, var(--primary-container) 88%, var(--secondary));
+}
+
+.tool-button--secondary,
+.btn-secondary,
+.solution-toggle,
+.practice-action-btn,
+.review-topic-btn,
+.print-btn,
+.reset-btn {
+  background: var(--surface-container-lowest);
+  color: var(--on-surface);
+  border: 1px solid var(--ghost-outline);
+}
+
+.tool-button--secondary:hover,
+.tool-button--secondary:focus-visible,
+.btn-secondary:hover,
+.btn-secondary:focus-visible,
+.solution-toggle:hover,
+.solution-toggle:focus-visible,
+.practice-action-btn:hover,
+.practice-action-btn:focus-visible,
+.review-topic-btn:hover,
+.review-topic-btn:focus-visible,
+.print-btn:hover,
+.print-btn:focus-visible,
+.reset-btn:hover,
+.reset-btn:focus-visible {
+  border-color: color-mix(in srgb, var(--secondary) 48%, var(--ghost-outline));
+  background: color-mix(in srgb, var(--secondary) 8%, var(--surface-container-lowest));
+  color: var(--secondary);
+}
+
+.tool-button:focus-visible,
+.tool-button--secondary:focus-visible,
+.tool-panel :is(button, a, input, select, textarea):focus-visible,
+.tool-page-shell :is(button, a, input, select, textarea):focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--secondary) 36%, transparent);
+  outline-offset: 2px;
+}
+
+.chart-container {
+  position: relative;
+  min-height: 320px;
+  width: min(100%, 900px);
+  margin: 1.5rem auto;
+  padding: 1rem;
+}
+
+.person-box {
+  text-align: center;
+  padding: 1rem;
+}
+
+.tool-page-main h1,
+.tool-page-main h2,
+.tool-page-main h3 {
+  color: var(--primary);
+}
+
 @media print {
   nav,
   .download-container,
@@ -2756,6 +2957,8 @@ body.review-page::before {
 .formula-section {
   break-inside: avoid;
 }
+
+
 
 @media print {
   body.review-page,


### PR DESCRIPTION
### Motivation
- Treat standalone interactive tools and review pages as a distinct page type and bring them into the shared editorial presentation layer for consistent surfaces and accessibility. 
- Replace ad-hoc, page-local visual rules (heavy borders, shadows) with token-driven surface tiers and ghost-outline focus styles to match the design system. 
- Unify nav markup so all pages use the canonical list-based `top-nav` structure with a menu toggle and theme control for predictable behavior. 

### Description
- Add a reusable tool/review presentation layer to `styles.css` with classes such as `tool-page-body`, `tool-page-main`, `tool-page-shell`, `tool-control-panel`, `tool-result-panel`, `tool-chart-box`, `tool-info-box`, and `tool-button`, and map them to surface tokens like `--surface-container-low` and `--ghost-outline`. 
- Update standalone tool/review HTML pages (`Taskflow.html`, `growth.html`, `chessboard.html`, `employeepay.html`, `Unit3Practice.html`) to use the canonical `top-nav` list-based markup (`.top-nav-links` / `#primary-nav-links` and `.top-nav-utilities` / `#primary-nav-utilities`), include the `menu-toggle` control, and add the `theme.js` hook where needed. 
- Replace repeated inline/local visual rules in pages with the new reusable classes (control panels, result panels, callouts, chart/info boxes, tool-specific buttons) and wrap tool content with `main.tool-page-main` / `section.tool-page-shell` for consistent spacing and hierarchy. 
- Move the `130Test4.html` theme toggle into the canonical nav cluster and update the page script to target `#theme-toggle-btn`; also remove a duplicated CSS block from `styles.css` that was introduced during integration. 

### Testing
- Ran a `python` assertion that verified each updated HTML file contains exactly one `nav` with `class="top-nav"`, includes `id="primary-nav-links"` and `id="primary-nav-utilities"`, and has matched `<main>`/`</main>` tags, and the assertion passed. 
- Reviewed the change summary with `git diff --stat` and inspected targeted diffs for `styles.css`, `Taskflow.html`, `growth.html`, `chessboard.html`, `employeepay.html`, `Unit3Practice.html`, and `130Test4.html`; the review confirmed the intended replacements and class migrations. 
- Confirmed removal of the duplicate `tool-page-body` block from `styles.css` and re-ran the structural assertions after the cleanup; all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c113bb0a3c833189a7dd511a50699d)