### PR TITLE
Revise homepage copy to prioritize Learn and clarify CTAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
   <div class="container">
     <div class="page-shell-header__eyebrow">Home</div>
     <h1>Prof. Volk's digital curator space for learning, tools, and thoughtful scholarship.</h1>
-    <p class="subtitle">A guided front door for students, colleagues, and curious learners who want clear explanations, practical resources, and a humane approach to mathematics, physics, and engineering.</p>
+    <p class="subtitle">An editorial gateway to courses, tools, and academic work in mathematics, physics, and engineering.</p>
   </div>
 </header>
 
@@ -61,72 +61,72 @@
     <section class="home-stage home-hero feature-section" aria-labelledby="home-hero-title">
       <div class="hero-copy-column">
         <p class="home-kicker">Digital Curator</p>
-        <h2 id="home-hero-title">Learn from an authored collection of courses, tools, and teaching resources.</h2>
-        <p class="hero-lead">A clear front door for students, colleagues, and curious learners who want dependable explanations, practical teaching tools, and a humane approach to mathematics, physics, and engineering.</p>
+        <h2 id="home-hero-title">A curated learning site for mathematics, physics, and engineering.</h2>
+        <p class="hero-lead">Built for students, colleagues, and independent learners. Start in Learn to enter through the course material first.</p>
         <div class="hero-cta-cluster" aria-label="Primary actions">
-          <a href="learn.html" class="button">Start learning</a>
-          <a href="projects.html" class="button button-secondary">Explore tools</a>
+          <a href="learn.html" class="button">Start in Learn</a>
+          <a href="projects.html" class="button button-secondary">See the tools</a>
         </div>
         <p class="hero-tertiary-wrap"><a href="CV.html" class="hero-tertiary-link">View CV and teaching profile</a></p>
       </div>
 
       <article class="highlighted-destination-card">
-        <p class="home-kicker">Featured destination</p>
-        <h3>Learning resources built for clarity, sequence, and momentum.</h3>
-        <p>Begin with course hubs, guided explanations, and reference material shaped by classroom teaching rather than a directory of equal links.</p>
+        <p class="home-kicker">Recommended start</p>
+        <h3>Start with the course pathway.</h3>
+        <p>Learn is the front door because it gathers the core course pages, study sequences, and guided explanations in one place.</p>
         <ul class="supporting-link-list">
-          <li>Course pathways for mathematics and physics</li>
-          <li>Structured support for review and independent study</li>
-          <li>Readable explanations anchored in real teaching practice</li>
+          <li>Begin with organized course hubs</li>
+          <li>Continue into review and reference pages</li>
+          <li>Branch into tools or background once you are oriented</li>
         </ul>
-        <a href="learn.html" class="button">Open learning resources</a>
+        <a href="learn.html" class="button">Enter Learn</a>
       </article>
     </section>
 
     <section class="home-stage home-start-here" aria-labelledby="featured-paths-title">
       <div class="band-intro home-start-here__intro">
-        <p class="home-kicker">Start here</p>
-        <h2 id="featured-paths-title">Follow the path that best matches your next step.</h2>
-        <p>Learn comes first, tools support the work, and the CV offers background when you want the broader teaching context.</p>
+        <p class="home-kicker">Main paths</p>
+        <h2 id="featured-paths-title">Three paths, one clear priority.</h2>
+        <p>Learn is the primary destination for most visitors. Projects &amp; tools exists for applied support, and the CV exists for professional context.</p>
       </div>
       <div class="supporting-card-grid home-start-grid">
         <article class="supporting-card supporting-card--feature">
           <div class="card-icon" aria-hidden="true">📚</div>
-          <p class="home-kicker">Learn first</p>
-          <h3>Enter through the teaching materials.</h3>
-          <p>Course pages, study guides, and carefully ordered explanations are the primary destination for most visitors and the best place to begin.</p>
-          <a href="learn.html">Browse courses and resources</a>
+          <p class="home-kicker">Primary path</p>
+          <h3>Learn</h3>
+          <p>Choose this path for the main body of teaching material: courses, study guides, and structured review.</p>
+          <a href="learn.html">Browse Learn</a>
         </article>
         <div class="home-start-sidebar">
           <article class="supporting-card supporting-card--sidebar">
             <div class="card-icon" aria-hidden="true">🔧</div>
-            <p class="home-kicker">Then tools</p>
+            <p class="home-kicker">Support path</p>
             <h3>Projects &amp; tools</h3>
-            <p>Use practical classroom tools, interactive resources, and reference pages that support day-to-day learning.</p>
+            <p>Choose this path for calculators, interactive tools, and project work that support what you study in Learn.</p>
             <a href="projects.html">Explore tools and projects</a>
           </article>
-          <p class="start-here-secondary-link"><span>About &amp; CV</span> <a href="CV.html">Read the profile</a></p>
+          <p class="start-here-secondary-link"><span>Background path</span> <a href="CV.html">Read the CV and profile</a></p>
         </div>
       </div>
     </section>
 
     <section class="home-stage home-support-strip" aria-labelledby="beyond-site-title">
       <div class="home-support-strip__media">
-        <p class="home-kicker">Watch</p>
-        <h2 id="beyond-site-title">Learn Abundantly on YouTube</h2>
-        <p>Watch lessons, walkthroughs, and educational videos that complement the written resources across the site.</p>
+        <p class="home-kicker">Beyond the site</p>
+        <h2 id="beyond-site-title">Continue beyond the site through video, community, and contact.</h2>
+        <p>Visit the YouTube channel for lesson-based follow-up, then use the community and contact links below when you want to stay connected off-site.</p>
         <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">Visit the channel</a>
       </div>
       <div class="home-support-strip__mission">
-        <p class="home-kicker">Mission</p>
-        <p>The site exists to gather trustworthy teaching materials and practical tools in one place so learners can spend more energy understanding than searching.</p>
+        <p class="home-kicker">Follow-up</p>
+        <p>These external links belong in the final supporting layer of the homepage: useful after the main navigation choice, never in place of it.</p>
       </div>
     </section>
 
     <section class="home-stage home-community-links" aria-labelledby="community-links-title">
       <div>
         <p class="home-kicker">Community &amp; contact</p>
-        <h2 id="community-links-title">A quiet set of links near the footer.</h2>
+        <h2 id="community-links-title">Stay connected off-site.</h2>
       </div>
       <div class="community-link-row">
         <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Liberty University Math Club</a>


### PR DESCRIPTION
### Motivation

- Clarify homepage messaging to make the `Learn` pathway the primary entry and reduce ambiguity in labels and CTAs.
- Reframe supporting pathways and external links so visitors are guided through a single prioritized navigation flow.

### Description

- Reworded the page subtitle, hero title, and hero lead to emphasize a curated, learn-first site structure.
- Updated primary CTAs and button labels (`Start in Learn`, `See the tools`, `Enter Learn`, etc.) to be more directive and consistent.
- Revised featured-destination and start-here card copy and kicker labels to present `Learn`, `Projects & tools`, and `CV` as distinct, ordered paths.
- Updated supporting section copy for community, YouTube, and follow-up to position external resources as secondary to the main Learn pathway.

### Testing

- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c119e68570833182e1617a6a7415a7)