### PR TITLE
Refactor CV to document-first, linear professional layout

### DIFF
--- a/CV.html
+++ b/CV.html
@@ -92,496 +92,380 @@
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
             <ul id="nav-menu">
-                <li class="cv-nav-group">
-                    <button class="cv-nav-trigger" type="button" aria-expanded="false" aria-controls="cv-nav-about">About</button>
-                    <ul class="dropdown-menu" id="cv-nav-about">
-                        <li><a href="#about">Biography</a></li>
-                        <li><a href="#philosophy">Teaching Philosophy</a></li>
-                    </ul>
-                </li>
-                <li class="cv-nav-group">
-                    <button class="cv-nav-trigger" type="button" aria-expanded="false" aria-controls="cv-nav-academics">Academic Record</button>
-                    <ul class="dropdown-menu" id="cv-nav-academics">
-                        <li><a href="#summary">Profile</a></li>
-                        <li><a href="#record">Education &amp; Credentials</a></li>
-                        <li><a href="#courses">Courses Taught</a></li>
-                        <li><a href="#publications">Publications</a></li>
-                        <li><a href="#research">Research Interests</a></li>
-                    </ul>
-                </li>
-                <li class="cv-nav-group">
-                    <button class="cv-nav-trigger" type="button" aria-expanded="false" aria-controls="cv-nav-experience">Experience</button>
-                    <ul class="dropdown-menu" id="cv-nav-experience">
-                        <li><a href="#experience">Professional Experience</a></li>
-                        <li><a href="#presentations">Conference Presentations</a></li>
-                    </ul>
-                </li>
-                <li class="cv-nav-group">
-                    <button class="cv-nav-trigger" type="button" aria-expanded="false" aria-controls="cv-nav-service">Service</button>
-                    <ul class="dropdown-menu" id="cv-nav-service">
-                        <li><a href="#community">Community &amp; Church Service</a></li>
-                        <li><a href="#mentoring">Advising &amp; Mentoring</a></li>
-                        <li><a href="#youtube">Educational Media</a></li>
-                    </ul>
-                </li>
-                <li><a class="cv-nav-link" href="#honors">Honors &amp; Awards</a></li>
+                <li><a class="cv-nav-link" href="#summary">Summary</a></li>
+                <li><a class="cv-nav-link" href="#education">Education</a></li>
+                <li><a class="cv-nav-link" href="#experience">Experience</a></li>
+                <li><a class="cv-nav-link" href="#publications">Publications</a></li>
+                <li><a class="cv-nav-link" href="#presentations">Presentations</a></li>
+                <li><a class="cv-nav-link" href="#teaching">Teaching</a></li>
+                <li><a class="cv-nav-link" href="#service">Service &amp; Mentoring</a></li>
+                <li><a class="cv-nav-link" href="#honors">Honors</a></li>
             </ul>
         </div>
     </nav>
 
     <main class="container cv-page">
-        <section id="summary" class="cv-band cv-band--summary">
-            <div class="cv-band__header">
-                <p class="section-kicker">Profile</p>
+        <section id="summary" class="cv-intro">
+            <div class="cv-intro__main">
+                <p class="section-kicker">Professional Profile</p>
                 <h2>Professional Summary</h2>
+                <p>
+                    Assistant Professor of Mathematics and Physics with experience spanning university teaching,
+                    secondary mathematics leadership, curriculum design, and educational technology. His work centers
+                    on helping students grow through clear instruction, mastery-oriented assessment, and mathematically
+                    humane teaching practices.
+                </p>
+                <p>
+                    Current scholarship and presentations focus on mathematics education, reflective practice, digital
+                    tools for learning, and interdisciplinary inquiry that connects mathematics to broader human questions.
+                </p>
             </div>
-            <div class="summary-grid">
-                <div class="summary-copy">
-                    <p>
-                        Dedicated Assistant Professor and researcher with significant experience in
-                        <strong>mathematics education, physics instruction, and curriculum design</strong>.
-                        Proven track record of integrating technology and assessment strategies to
-                        <em>enhance student engagement</em> and foster academic growth.
-                    </p>
-                    <p>
-                        Active in collaborative teaching initiatives, peer-reviewed scholarship, and
-                        conference presentation with a focus on mastery-based learning, reflective
-                        practice, and accessible mathematics instruction.
-                    </p>
-                </div>
-                <aside class="cv-panel highlight-panel">
-                    <h3>Selected Highlights</h3>
-                    <ul class="highlights-list">
-                        <li>Recipient of multiple teaching and service awards, including the VCTM William C. Lowry Math Educator of the Year Award.</li>
-                        <li>Authored and co-authored publications in mathematics pedagogy and educational technology.</li>
-                        <li>Presented interdisciplinary work spanning mathematics education, digital humanities, and reflective teaching practice.</li>
+            <aside class="cv-facts-rail" aria-label="Professional facts and distinctions">
+                <section class="cv-fact-group">
+                    <h3>Licensure</h3>
+                    <ul class="compact-list">
+                        <li>Virginia Collegiate Professional License</li>
+                        <li>Secondary Mathematics (6–12)</li>
+                        <li>Secondary Physics (6–12)</li>
                     </ul>
-                </aside>
-            </div>
-        </section>
-
-        <section id="record" class="cv-band cv-band--academic">
-            <div class="cv-band__header">
-                <p class="section-kicker">Academic Record</p>
-                <h2>Education, credentials, and teaching portfolio</h2>
-            </div>
-            <div class="cv-record-grid">
-                <section id="education" class="cv-panel cv-panel--timeline">
-                    <h3>Education</h3>
-                    <div class="education-item">
-                        <div class="item-header">
-                            <span class="item-title">Ph.D. Engineering Education (ABD)</span>
-                            <span class="item-date">Current</span>
-                        </div>
-                        <div class="item-subtitle">Mississippi State University · Starkville, MS</div>
-                    </div>
-                    <div class="education-item">
-                        <div class="item-header">
-                            <span class="item-title">M.A. Science Education (Secondary Physics)</span>
-                            <span class="item-date">July 2023</span>
-                        </div>
-                        <div class="item-subtitle">Western Governors University · Salt Lake City, UT</div>
-                        <p class="item-note">32 credit hours</p>
-                    </div>
-                    <div class="education-item">
-                        <div class="item-header">
-                            <span class="item-title">M.S. Mathematics</span>
-                            <span class="item-date">May 2021</span>
-                        </div>
-                        <div class="item-subtitle">Central Methodist University · Fayette, MO</div>
-                        <p class="item-note">32 credit hours</p>
-                    </div>
-                    <div class="education-item">
-                        <div class="item-header">
-                            <span class="item-title">M.Ed. Instructional Design</span>
-                            <span class="item-date">November 2018</span>
-                        </div>
-                        <div class="item-subtitle">Western Governors University · Salt Lake City, UT</div>
-                        <p class="item-note">30 credit hours</p>
-                    </div>
-                    <div class="education-item">
-                        <div class="item-header">
-                            <span class="item-title">B.S. Mathematics &amp; B.A. Spanish</span>
-                            <span class="item-date">May 2011</span>
-                        </div>
-                        <div class="item-subtitle">Liberty University · Lynchburg, VA</div>
-                        <p class="item-note">184 credit hours</p>
-                    </div>
                 </section>
-
-                <section class="cv-panel cv-panel--stacked">
-                    <div class="cv-mini-panel">
-                        <h3>Licensure &amp; Certifications</h3>
-                        <ul class="compact-list">
-                            <li>Virginia Department of Education Collegiate Professional License</li>
-                            <li>Secondary Math License (6–12)</li>
-                            <li>Secondary Physics License (6–12)</li>
-                        </ul>
-                    </div>
-                    <div class="cv-mini-panel">
-                        <h3>Professional Memberships</h3>
-                        <ul class="compact-list">
-                            <li>Virginia Council of Teachers of Mathematics</li>
-                        </ul>
-                    </div>
+                <section class="cv-fact-group">
+                    <h3>Memberships</h3>
+                    <ul class="compact-list">
+                        <li>Virginia Council of Teachers of Mathematics</li>
+                    </ul>
                 </section>
-            </div>
-
-            <section id="courses" class="cv-panel cv-panel--courses">
-                <h3>Courses Taught</h3>
-                <div class="course-groups">
-                    <article class="course-group-card">
-                        <h4>Liberty University</h4>
-                        <ul class="compact-list">
-                            <li>PHYS 103: Elements of Physics Lab</li>
-                            <li>PHYS 201L/231L: Physics Lab</li>
-                            <li>PHYS 202L/232L: Physics Lab</li>
-                            <li>MATH 100: Fundamentals of Mathematics</li>
-                            <li>MATH 105: Algebra for Non-STEM Majors</li>
-                            <li>MATH 110: Intermediate Algebra</li>
-                            <li>MATH 114: Quantitative Reasoning</li>
-                            <li>MATH 121: College Algebra</li>
-                            <li>ENGI 220: Engineering Economy</li>
-                        </ul>
-                    </article>
-                    <article class="course-group-card">
-                        <h4>Franklin University</h4>
-                        <ul class="compact-list">
-                            <li>MATH 280: Intro to Probability/Stats</li>
-                        </ul>
-                    </article>
-                </div>
-            </section>
+                <section class="cv-fact-group cv-fact-group--featured">
+                    <h3>Selected Highlights</h3>
+                    <ul class="compact-list compact-list--tight">
+                        <li>VCTM William C. Lowry Math Educator of the Year.</li>
+                        <li>Multiple publications in mathematics pedagogy and educational technology.</li>
+                        <li>Ongoing teaching, mentoring, and curriculum leadership at Liberty University.</li>
+                    </ul>
+                </section>
+            </aside>
         </section>
 
-        <section id="about" class="cv-band cv-band--narrative">
-            <div class="cv-band__header">
-                <p class="section-kicker">About</p>
-                <h2>Biography</h2>
+        <section id="education" class="cv-section">
+            <div class="cv-section__header">
+                <p class="section-kicker">Education</p>
+                <h2>Academic Preparation</h2>
             </div>
-            <p>
-                Mr. Andrew Volk serves as an Assistant Professor at Liberty University. He began his career
-                as a mathematics teacher after graduating with a B.S. degree in Mathematics from Liberty in 2011
-                and has taught in multiple school districts and levels with a focus on promoting student growth.
-                He has also occasionally worked as a Software Engineer and/or developer.
-            </p>
-            <p>
-                With multiple master's degrees in Mathematics, Science Education, and Instructional Design,
-                Mr. Volk brings a diverse educational background to his work. Currently pursuing a Ph.D. in
-                Engineering Education at Mississippi State University, he is particularly interested in teaching
-                for growth and mastery, assessment practices, and connecting the human elements of mathematics
-                to make the subject more accessible and engaging.
-            </p>
+            <div class="cv-entries">
+                <article class="cv-entry">
+                    <div class="item-header">
+                        <span class="item-title">Ph.D. Engineering Education (ABD)</span>
+                        <span class="item-date">Current</span>
+                    </div>
+                    <div class="item-subtitle"><strong>Mississippi State University</strong> · Starkville, Mississippi</div>
+                </article>
+                <article class="cv-entry">
+                    <div class="item-header">
+                        <span class="item-title">M.A. Science Education (Secondary Physics)</span>
+                        <span class="item-date">July 2023</span>
+                    </div>
+                    <div class="item-subtitle"><strong>Western Governors University</strong> · Salt Lake City, Utah</div>
+                    <p class="item-note">32 credit hours.</p>
+                </article>
+                <article class="cv-entry">
+                    <div class="item-header">
+                        <span class="item-title">M.S. Mathematics</span>
+                        <span class="item-date">May 2021</span>
+                    </div>
+                    <div class="item-subtitle"><strong>Central Methodist University</strong> · Fayette, Missouri</div>
+                    <p class="item-note">32 credit hours.</p>
+                </article>
+                <article class="cv-entry">
+                    <div class="item-header">
+                        <span class="item-title">M.Ed. Instructional Design</span>
+                        <span class="item-date">November 2018</span>
+                    </div>
+                    <div class="item-subtitle"><strong>Western Governors University</strong> · Salt Lake City, Utah</div>
+                    <p class="item-note">30 credit hours.</p>
+                </article>
+                <article class="cv-entry">
+                    <div class="item-header">
+                        <span class="item-title">B.S. Mathematics and B.A. Spanish</span>
+                        <span class="item-date">May 2011</span>
+                    </div>
+                    <div class="item-subtitle"><strong>Liberty University</strong> · Lynchburg, Virginia</div>
+                    <p class="item-note">184 credit hours.</p>
+                </article>
+            </div>
         </section>
 
-        <section id="philosophy" class="cv-band cv-band--narrative-alt">
-            <div class="cv-band__header">
-                <p class="section-kicker">Pedagogy</p>
-                <h2>Teaching Philosophy</h2>
+        <section id="experience" class="cv-section">
+            <div class="cv-section__header">
+                <p class="section-kicker">Appointments &amp; Experience</p>
+                <h2>Academic and Professional Appointments</h2>
             </div>
-            <p>
-                Learning is about <em>change and growth</em>. It is not simply about gaining knowledge or facts,
-                but rather changing who the learner is and growing to be something new and better than they were
-                before. In that way, teaching becomes focused on growing, developing, and cultivating the student
-                as a person.
-            </p>
-            <p>
-                A central emphasis throughout this career has been helping students develop mindsets for growth,
-                empowering them to take control of their learning, and providing an environment where progress can
-                be seen in ways that reach beyond a letter grade.
-            </p>
-        </section>
-
-        <section id="experience" class="cv-band cv-band--experience">
-            <div class="cv-band__header">
-                <p class="section-kicker">Professional Experience</p>
-                <h2>Academic and instructional appointments</h2>
-            </div>
-            <div class="cv-timeline">
-                <div class="experience-item">
+            <div class="cv-entries">
+                <article class="cv-entry cv-entry--current">
                     <div class="item-header">
                         <span class="item-title">Assistant Professor of Mathematics and Physics</span>
                         <span class="item-date">2020 – Present</span>
                     </div>
-                    <div class="item-subtitle">Liberty University</div>
-                </div>
-                <div class="experience-item">
+                    <div class="item-subtitle"><strong>Liberty University</strong></div>
+                    <p>Current faculty appointment focused on mathematics and physics instruction, curriculum development, and student learning.</p>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
                         <span class="item-title">Online Instructor of General Math and Science</span>
                         <span class="item-date">2023 – Present</span>
                     </div>
-                    <div class="item-subtitle">Liberty University Online</div>
-                </div>
-                <div class="experience-item">
+                    <div class="item-subtitle"><strong>Liberty University Online</strong></div>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
                         <span class="item-title">Subject Matter Expert for MATH 114</span>
                         <span class="item-date">2022 – Present</span>
                     </div>
-                    <div class="item-subtitle">Liberty University</div>
-                    <p>Design, development, and evaluation of Quantitative Reasoning (MATH 114) for the residential program.</p>
-                </div>
-                <div class="experience-item">
+                    <div class="item-subtitle"><strong>Liberty University</strong></div>
+                    <p>Designs, develops, and evaluates Quantitative Reasoning for the residential program.</p>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
                         <span class="item-title">Faculty in Statistics (Online Adjunct)</span>
                         <span class="item-date">2021 – 2022</span>
                     </div>
-                    <div class="item-subtitle">Franklin University</div>
-                </div>
-                <div class="experience-item">
+                    <div class="item-subtitle"><strong>Franklin University</strong></div>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
                         <span class="item-title">Math Department Chair and Teacher</span>
                         <span class="item-date">2017 – 2020</span>
                     </div>
-                    <div class="item-subtitle">Lynchburg City Schools · Lynchburg, VA</div>
+                    <div class="item-subtitle"><strong>Lynchburg City Schools</strong> · Lynchburg, Virginia</div>
                     <p>Taught Algebra I, Algebra II, Math 8, and remedial mathematics while leading departmental efforts to improve student learning and performance.</p>
-                </div>
-                <div class="experience-item">
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
                         <span class="item-title">Intro Programming Instructor</span>
                         <span class="item-date">2016 – 2022</span>
                     </div>
-                    <div class="item-subtitle">Udemy</div>
-                </div>
-                <div class="experience-item">
+                    <div class="item-subtitle"><strong>Udemy</strong></div>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
                         <span class="item-title">Math/CS Teacher</span>
                         <span class="item-date">2014 – 2017</span>
                     </div>
-                    <div class="item-subtitle">Courtland High School · Spotsylvania, VA</div>
+                    <div class="item-subtitle"><strong>Courtland High School</strong> · Spotsylvania, Virginia</div>
                     <p>Taught Algebra I, Geometry, C++, AP Computer Science Principles, and Applied Math using blended and data-informed instructional practices.</p>
-                </div>
-                <div class="experience-item">
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
                         <span class="item-title">Earlier Teaching Positions</span>
                         <span class="item-date">2011 – 2014</span>
                     </div>
-                    <div class="item-subtitle">Various Schools</div>
-                    <p>Math Teacher at Mountain View High (Stafford, VA), Classical School Teacher at Nova Classical Academy (St. Paul, MN), Middle School Teacher at Andersen United School (Minneapolis, MN), Math Teacher at City West Academy (Eden Prairie, MN), and Middle &amp; High School Teacher at Lynchburg City Schools (Lynchburg, VA).</p>
-                </div>
-                <div class="experience-item">
+                    <div class="item-subtitle"><strong>Various Schools</strong></div>
+                    <p>Served in mathematics and general teaching roles at Mountain View High School, Nova Classical Academy, Andersen United School, City West Academy, and Lynchburg City Schools.</p>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
                         <span class="item-title">Software Engineer / Developer</span>
                         <span class="item-date">Various</span>
                     </div>
-                    <div class="item-subtitle">Various Companies</div>
-                </div>
+                    <div class="item-subtitle"><strong>Various Companies</strong></div>
+                </article>
             </div>
         </section>
 
-        <section id="publications" class="cv-band cv-band--scholarship">
-            <div class="cv-band__header">
-                <p class="section-kicker">Scholarship</p>
-                <h2>Publications</h2>
+        <section id="publications" class="cv-section">
+            <div class="cv-section__header">
+                <p class="section-kicker">Publications</p>
+                <h2>Selected Publications</h2>
             </div>
-            <div class="publications-item">
-                <p>Volk, A. H. (2021, Sep 1). <em>A Practitioner's Review of Visible Learning for Mathematics Classrooms.</em> MathBits. <a href="http://www.mctmmathbits.org/?p=3510" target="_blank" rel="noopener noreferrer">http://www.mctmmathbits.org/?p=3510</a></p>
+            <div class="cv-entries cv-entries--scholarship">
+                <article class="cv-entry cv-entry--citation">
+                    <p>Volk, A. H. (2021, September 1). <em>A Practitioner’s Review of Visible Learning for Mathematics Classrooms.</em> MathBits. <a href="http://www.mctmmathbits.org/?p=3510" target="_blank" rel="noopener noreferrer">http://www.mctmmathbits.org/?p=3510</a></p>
+                </article>
+                <article class="cv-entry cv-entry--citation">
+                    <p>Volk, A. H. (2019). <em>Euclidea: The game of geometric constructions.</em> Virginia Mathematics Teacher, 46(1), 56–57.</p>
+                </article>
+                <article class="cv-entry cv-entry--citation">
+                    <p>Volk, A. H. (2019). <em>Flatland by Edwin Abbott Abbott.</em> Virginia Mathematics Teacher, 45(2), 36.</p>
+                </article>
             </div>
-            <div class="publications-item">
-                <p>Volk, A. H. (2019). <em>Euclidea: The game of geometric constructions.</em> Virginia Mathematics Teacher, 46(1), 56–57.</p>
-            </div>
-            <div class="publications-item">
-                <p>Volk, A. H. (2019). <em>Flatland by Edwin Abbott Abbott.</em> Virginia Mathematics Teacher, 45(2), 36.</p>
-            </div>
-
-            <section id="research" class="cv-panel cv-panel--research">
-                <h3>Research Interests</h3>
-                <div class="research-grid">
-                    <div class="experience-item">
-                        <div class="item-header">
-                            <span class="item-title">Teaching for Growth and Mastery</span>
-                        </div>
-                        <p>Research topics within this broader category include growth mindset, grit, U-PACE, and learning retention.</p>
-                    </div>
-                    <div class="experience-item">
-                        <div class="item-header">
-                            <span class="item-title">Assessing Consistently and Grading Sparingly</span>
-                        </div>
-                        <p>Assessment practices in the classroom and in business environments remain a meaningful area of inquiry regarding motivation and durable learning change.</p>
-                    </div>
-                    <div class="experience-item">
-                        <div class="item-header">
-                            <span class="item-title">Humanity and Curiosity in Mathematics</span>
-                        </div>
-                        <p>Research connecting mathematics to the narratives and people behind its development in ways that demystify the subject.</p>
-                    </div>
-                    <div class="experience-item">
-                        <div class="item-header">
-                            <span class="item-title">Mathematics and Education</span>
-                        </div>
-                        <p>Effective teaching methods and learning outcomes in mathematics education.</p>
-                    </div>
-                    <div class="experience-item">
-                        <div class="item-header">
-                            <span class="item-title">Digital Humanities</span>
-                        </div>
-                        <p>Exploring the intersection of technology, computational methods, and humanities disciplines.</p>
-                    </div>
-                    <div class="experience-item">
-                        <div class="item-header">
-                            <span class="item-title">Mathematics History</span>
-                        </div>
-                        <p>Studying the historical development of mathematical concepts and the people behind them.</p>
-                    </div>
-                </div>
-            </section>
         </section>
 
-        <section id="presentations" class="cv-band cv-band--scholarship-alt">
-            <div class="cv-band__header">
-                <p class="section-kicker">Scholarship</p>
+        <section id="presentations" class="cv-section">
+            <div class="cv-section__header">
+                <p class="section-kicker">Presentations</p>
                 <h2>Conference Presentations</h2>
             </div>
-            <div class="cv-timeline">
-                <div class="presentation-item">
+            <div class="cv-entries">
+                <article class="cv-entry">
                     <div class="item-header">
-                        <span class="item-title">NCTM 2024 Virtual Conference</span>
+                        <span class="item-title">Cultivating Reflective Practice in Math Education: A Dual Perspective</span>
                         <span class="item-date">April 2024</span>
                     </div>
-                    <div class="item-subtitle">Cultivating Reflective Practice in Math Education: A Dual Perspective</div>
-                    <p>Volk &amp; McGowan</p>
-                </div>
-                <div class="presentation-item">
+                    <div class="item-subtitle"><strong>NCTM 2024 Virtual Conference</strong></div>
+                    <p>Volk &amp; McGowan.</p>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
-                        <span class="item-title">Virginia Council of Teachers of Mathematics Annual Conference</span>
+                        <span class="item-title">Exploring the Capabilities of OpenAI to Write Mathematical Proofs: Implications for Mathematics Educators</span>
                         <span class="item-date">March 2023</span>
                     </div>
-                    <div class="item-subtitle">Exploring the Capabilities of OpenAI to Write Mathematical Proofs: Implications for Mathematics Educators</div>
-                    <p>Volk</p>
-                </div>
-                <div class="presentation-item">
+                    <div class="item-subtitle"><strong>Virginia Council of Teachers of Mathematics Annual Conference</strong></div>
+                    <p>Volk.</p>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
-                        <span class="item-title">Indiana College English Association: 86th Annual Conference</span>
+                        <span class="item-title">Vocabulary and Dr. Seuss: A Study in Zipf's Law Search Frequency</span>
                         <span class="item-date">October 2021</span>
                     </div>
-                    <div class="item-subtitle">Vocabulary and Dr. Seuss: A Study in Zipf's Law Search Frequency</div>
-                    <p>Underwood and Volk</p>
-                </div>
-                <div class="presentation-item">
+                    <div class="item-subtitle"><strong>Indiana College English Association: 86th Annual Conference</strong></div>
+                    <p>Underwood and Volk.</p>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
-                        <span class="item-title">XXVII Congreso Internacional de Literatura Hispánica</span>
+                        <span class="item-title">La cuantificación del estilo: los prefijos positivos y negativos en <em>La Celestina</em></span>
                         <span class="item-date">June 2021</span>
                     </div>
-                    <div class="item-subtitle">La cuantificación del estilo: los prefijos positivos y negativos en <em>La Celestina</em></div>
-                    <p>Milacci and Volk</p>
-                </div>
-                <div class="presentation-item">
+                    <div class="item-subtitle"><strong>XXVII Congreso Internacional de Literatura Hispánica</strong></div>
+                    <p>Milacci and Volk.</p>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
-                        <span class="item-title">Mathematical Association of America MD-DC-VA Section Meeting</span>
+                        <span class="item-title">Zipf's Law of Baseball Career Leaderboards</span>
                         <span class="item-date">November 2020</span>
                     </div>
-                    <div class="item-subtitle">Zipf's Law of Baseball Career Leaderboards</div>
-                    <p>Volk</p>
-                </div>
-                <div class="presentation-item">
+                    <div class="item-subtitle"><strong>Mathematical Association of America MD-DC-VA Section Meeting</strong></div>
+                    <p>Volk.</p>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
                         <span class="item-title">Earlier Presentations</span>
                         <span class="item-date">2014 – 2019</span>
                     </div>
-                    <ul class="compact-list">
-                        <li>Techstravaganza 2019: Embedding Formative Assessment in Instruction</li>
-                        <li>LCS PD Day 2018: Using Nearpod for Formative Assessment</li>
-                        <li>Techstravaganza 2018: Using Video for Engaging Instruction</li>
-                        <li>Spotsylvania Teacher's Conference 2016: Blended Learning</li>
-                        <li>Spotsylvania Teacher's Conference 2015: Data Driven Classroom</li>
+                    <ul class="compact-list compact-list--tight">
+                        <li>Techstravaganza 2019: Embedding Formative Assessment in Instruction.</li>
+                        <li>LCS PD Day 2018: Using Nearpod for Formative Assessment.</li>
+                        <li>Techstravaganza 2018: Using Video for Engaging Instruction.</li>
+                        <li>Spotsylvania Teacher's Conference 2016: Blended Learning.</li>
+                        <li>Spotsylvania Teacher's Conference 2015: Data Driven Classroom.</li>
                         <li>Interactive Achievement User Conferences 2015: What to do with the data?</li>
-                        <li>Pioneer Central Schools Inservice 2015: Growth Centered Classroom</li>
-                        <li>Rappahannock Region Association of Teachers of Mathematics Conference 2014: Teaching Students to Solve Word Problems (Volk/Martin)</li>
+                        <li>Pioneer Central Schools Inservice 2015: Growth Centered Classroom.</li>
+                        <li>Rappahannock Region Association of Teachers of Mathematics Conference 2014: Teaching Students to Solve Word Problems (Volk/Martin).</li>
                     </ul>
-                </div>
+                </article>
             </div>
         </section>
 
-        <section id="community" class="cv-band cv-band--service">
-            <div class="cv-band__header">
-                <p class="section-kicker">Service</p>
-                <h2>Community &amp; Church Service</h2>
+        <section id="teaching" class="cv-section">
+            <div class="cv-section__header">
+                <p class="section-kicker">Teaching</p>
+                <h2>Teaching Profile</h2>
             </div>
-            <div class="cv-timeline">
-                <div class="experience-item">
+            <div class="cv-entries">
+                <article class="cv-entry">
                     <div class="item-header">
-                        <span class="item-title">Small Group Leader</span>
-                        <span class="item-date">January 2018 – Present</span>
+                        <span class="item-title">Teaching Philosophy</span>
                     </div>
-                    <div class="item-subtitle">Crosspoint Church · Lynchburg, VA</div>
-                    <p>Host a Bible study and small group in the home on a weekly or biweekly basis.</p>
-                </div>
-                <div class="experience-item">
+                    <p>Learning is about change and growth. Teaching therefore aims not merely at the transfer of information, but at cultivating durable intellectual development, reflective habits, and confidence in students as learners.</p>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
-                        <span class="item-title">Kid's Ministry Volunteer</span>
-                        <span class="item-date">January 2018 – Present</span>
+                        <span class="item-title">Courses Taught</span>
                     </div>
-                    <div class="item-subtitle">Crosspoint Church · Lynchburg, VA</div>
-                    <p>Serve 2–4 times per month as a host, helper, or teacher in children’s ministry.</p>
-                </div>
+                    <div class="cv-split-list">
+                        <div>
+                            <p class="item-subtitle"><strong>Liberty University</strong></p>
+                            <ul class="compact-list compact-list--tight">
+                                <li>PHYS 103: Elements of Physics Lab</li>
+                                <li>PHYS 201L/231L: Physics Lab</li>
+                                <li>PHYS 202L/232L: Physics Lab</li>
+                                <li>MATH 100: Fundamentals of Mathematics</li>
+                                <li>MATH 105: Algebra for Non-STEM Majors</li>
+                                <li>MATH 110: Intermediate Algebra</li>
+                                <li>MATH 114: Quantitative Reasoning</li>
+                                <li>MATH 121: College Algebra</li>
+                                <li>ENGI 220: Engineering Economy</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <p class="item-subtitle"><strong>Franklin University</strong></p>
+                            <ul class="compact-list compact-list--tight">
+                                <li>MATH 280: Intro to Probability/Stats</li>
+                            </ul>
+                        </div>
+                    </div>
+                </article>
+                <article class="cv-entry">
+                    <div class="item-header">
+                        <span class="item-title">Research and Teaching Interests</span>
+                    </div>
+                    <ul class="compact-list compact-list--tight">
+                        <li>Teaching for growth and mastery.</li>
+                        <li>Assessment practices and grading for durable learning.</li>
+                        <li>Humanity and curiosity in mathematics.</li>
+                        <li>Mathematics education and learning outcomes.</li>
+                        <li>Digital humanities and interdisciplinary inquiry.</li>
+                        <li>History of mathematics.</li>
+                    </ul>
+                </article>
+                <article class="cv-entry">
+                    <div class="item-header">
+                        <span class="item-title">Educational Outreach</span>
+                        <span class="item-date">Current</span>
+                    </div>
+                    <div class="item-subtitle"><strong>Learn Abundantly YouTube Channel</strong></div>
+                    <p>Creates mathematics videos and supplemental learning resources that extend classroom teaching through accessible explanations and problem-solving support.</p>
+                    <p class="item-note"><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">https://www.youtube.com/learnabundantly</a></p>
+                </article>
             </div>
         </section>
 
-        <section id="mentoring" class="cv-band cv-band--service-alt">
-            <div class="cv-band__header">
-                <p class="section-kicker">Service</p>
-                <h2>Student Advising &amp; Mentoring</h2>
+        <section id="service" class="cv-section">
+            <div class="cv-section__header">
+                <p class="section-kicker">Service &amp; Mentoring</p>
+                <h2>Professional, Community, and Student Support</h2>
             </div>
-            <div class="cv-timeline">
-                <div class="experience-item">
+            <div class="cv-entries">
+                <article class="cv-entry">
                     <div class="item-header">
                         <span class="item-title">Honor Thesis Committee Chair</span>
                         <span class="item-date">October 2023 – Present</span>
                     </div>
-                    <p>Served as chair to support a student's honors thesis project through direction, feedback, and sustained advising.</p>
-                </div>
-                <div class="experience-item">
+                    <p>Supports a student's honors thesis project through direction, feedback, and sustained advising.</p>
+                </article>
+                <article class="cv-entry">
                     <div class="item-header">
                         <span class="item-title">Honor Thesis Committee Reader</span>
                         <span class="item-date">January 2024 – Present</span>
                     </div>
-                    <p>Served as reader for a student's honors thesis project, providing review and formative feedback.</p>
-                </div>
+                    <p>Provides review and formative feedback for a student's honors thesis project.</p>
+                </article>
+                <article class="cv-entry">
+                    <div class="item-header">
+                        <span class="item-title">Small Group Leader</span>
+                        <span class="item-date">January 2018 – Present</span>
+                    </div>
+                    <div class="item-subtitle"><strong>Crosspoint Church</strong> · Lynchburg, Virginia</div>
+                    <p>Hosts a Bible study and small group in the home on a weekly or biweekly basis.</p>
+                </article>
+                <article class="cv-entry">
+                    <div class="item-header">
+                        <span class="item-title">Kid's Ministry Volunteer</span>
+                        <span class="item-date">January 2018 – Present</span>
+                    </div>
+                    <div class="item-subtitle"><strong>Crosspoint Church</strong> · Lynchburg, Virginia</div>
+                    <p>Serves regularly as a host, helper, or teacher in children's ministry.</p>
+                </article>
             </div>
         </section>
 
-        <section id="youtube" class="cv-band cv-band--service-media">
-            <div class="cv-band__header">
-                <p class="section-kicker">Educational Outreach</p>
-                <h2>Educational Media &amp; Content Creation</h2>
-            </div>
-            <div class="experience-item">
-                <div class="item-header">
-                    <span class="item-title">Learn Abundantly YouTube Channel</span>
-                    <span class="item-date">Current</span>
-                </div>
-                <div class="item-subtitle">Creator, Instructor, and Educational Content Developer</div>
-                <p>
-                    Founded and manage an educational YouTube channel dedicated to mathematics instruction and
-                    problem-solving strategies. The channel serves as a supplemental learning resource for students
-                    at various levels, aligning with a teaching philosophy centered on accessible and engaging mathematics.
-                </p>
-                <div class="course-groups">
-                    <article class="course-group-card">
-                        <h4>Featured Content</h4>
-                        <ul class="compact-list">
-                            <li><strong>“Algebra: Graph Piecewise Functions in Desmos”</strong> — Interactive tutorial demonstrating practical graphing technology in algebra education.</li>
-                            <li><strong>“How to Solve Combination Word Problems FAST!”</strong> — Strategic approach to combinatorial mathematics with real-world applications.</li>
-                            <li><strong>“28 Math Questions Everyone Should Know!”</strong> — Review of essential mathematical concepts designed to build foundational skills.</li>
-                        </ul>
-                    </article>
-                    <article class="course-group-card">
-                        <h4>Impact &amp; Reach</h4>
-                        <p>The channel extends classroom teaching by offering students additional resources for review and practice while reinforcing interests in mathematical accessibility and practical application.</p>
-                        <p><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">https://www.youtube.com/learnabundantly</a></p>
-                    </article>
-                </div>
-            </div>
-        </section>
-
-        <section id="honors" class="cv-band cv-band--honors">
-            <div class="cv-band__header">
-                <p class="section-kicker">Recognition</p>
-                <h2>Honors &amp; Awards</h2>
+        <section id="honors" class="cv-section cv-section--honors">
+            <div class="cv-section__header">
+                <p class="section-kicker">Honors</p>
+                <h2>Selected Honors &amp; Awards</h2>
             </div>
             <ul class="compact-list award-list">
-                <li>LMS Impact Educator of the Year Award, Lynchburg City Schools, 2020</li>
+                <li><strong>LMS Impact Educator of the Year Award</strong>, Lynchburg City Schools, 2020</li>
                 <li>MathCounts Team 3rd Place Regional Finish as Coach, 2020</li>
-                <li>VCTM William C. Lowry Math Educator of the Year Award, 2019</li>
+                <li><strong>VCTM William C. Lowry Math Educator of the Year Award</strong>, 2019</li>
                 <li>Above and Beyond Call of Duty Award, 2015</li>
                 <li>Teacher of Promise Institute, 2011</li>
                 <li>SDP Distinguished Service Award, 2011</li>
@@ -608,22 +492,8 @@
 
             const menuToggle = document.querySelector('.cv-section-nav .menu-toggle');
             const navMenu = document.getElementById('nav-menu');
-            const navTriggers = Array.from(document.querySelectorAll('.cv-nav-trigger'));
-
-            function isMobileNav() {
-                return window.getComputedStyle(menuToggle).display !== 'none';
-            }
-
-            function closeDropdowns(exceptTrigger = null) {
-                navTriggers.forEach((trigger) => {
-                    const controlledMenu = document.getElementById(trigger.getAttribute('aria-controls'));
-                    const shouldStayOpen = exceptTrigger === trigger;
-                    trigger.setAttribute('aria-expanded', shouldStayOpen ? 'true' : 'false');
-                    if (controlledMenu) {
-                        controlledMenu.classList.toggle('dropdown-open', shouldStayOpen && isMobileNav());
-                    }
-                    trigger.parentElement?.removeAttribute('data-open');
-                });
+            function closeDropdowns() {
+                return;
             }
 
             menuToggle.addEventListener('click', () => {
@@ -632,32 +502,6 @@
                 if (!isOpen) {
                     closeDropdowns();
                 }
-            });
-
-            navTriggers.forEach((trigger) => {
-                trigger.addEventListener('click', () => {
-                    const menu = document.getElementById(trigger.getAttribute('aria-controls'));
-                    const willOpen = trigger.getAttribute('aria-expanded') !== 'true';
-
-                    closeDropdowns(willOpen ? trigger : null);
-
-                    if (!menu) {
-                        return;
-                    }
-
-                    trigger.setAttribute('aria-expanded', String(willOpen));
-                    trigger.parentElement?.setAttribute('data-open', String(willOpen));
-                    if (isMobileNav()) {
-                        menu.classList.toggle('dropdown-open', willOpen);
-                    }
-                });
-
-                trigger.addEventListener('keydown', (event) => {
-                    if (event.key === 'Escape') {
-                        closeDropdowns();
-                        trigger.focus();
-                    }
-                });
             });
 
             document.addEventListener('click', (event) => {
@@ -678,10 +522,8 @@
 
             window.addEventListener('resize', () => {
                 closeDropdowns();
-                if (!isMobileNav()) {
-                    navMenu.classList.remove('open');
-                    menuToggle.setAttribute('aria-expanded', 'false');
-                }
+                navMenu.classList.remove('open');
+                menuToggle.setAttribute('aria-expanded', 'false');
             });
         </script>
     </footer>

--- a/styles.css
+++ b/styles.css
@@ -3362,11 +3362,53 @@ body.math130-course-page {
   text-decoration-color: rgba(255, 255, 255, 0.35);
 }
 
-.cv-band {
-  margin-bottom: var(--spacing-10);
+.cv-intro {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(16rem, 0.95fr);
+  gap: clamp(1.75rem, 4vw, 3rem);
+  align-items: start;
+  margin-bottom: var(--section-space);
+  padding-bottom: var(--spacing-10);
+  border-bottom: 1px solid color-mix(in srgb, var(--outline-variant) 78%, transparent);
 }
 
-.cv-band__header {
+.cv-intro__main h2,
+.cv-section__header h2 {
+  margin-bottom: 0.8rem;
+}
+
+.cv-intro__main p,
+.cv-entry p,
+.cv-entry li,
+.cv-section > p {
+  max-width: 72ch;
+}
+
+.cv-facts-rail {
+  display: grid;
+  gap: var(--spacing-6);
+  padding-top: 0.2rem;
+}
+
+.cv-fact-group {
+  padding-left: var(--spacing-5);
+  border-left: 2px solid color-mix(in srgb, var(--outline-variant) 70%, transparent);
+}
+
+.cv-fact-group h3 {
+  margin-bottom: 0.65rem;
+  font-size: 1rem;
+}
+
+.cv-fact-group--featured {
+  border-left-color: color-mix(in srgb, var(--secondary) 48%, var(--surface-tint));
+}
+
+.cv-section {
+  margin-bottom: var(--section-space);
+}
+
+.cv-section__header {
   margin-bottom: var(--spacing-6);
 }
 
@@ -3380,73 +3422,44 @@ body.math130-course-page {
   color: var(--tertiary);
 }
 
-.cv-band--summary {
-  background: linear-gradient(180deg, rgba(220, 230, 224, 0.42), rgba(255, 255, 255, 0.92));
-}
-
-.cv-band--academic {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(235, 238, 234, 0.9));
-}
-
-.cv-band--narrative,
-.cv-band--experience,
-.cv-band--scholarship,
-.cv-band--service,
-.cv-band--honors {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(242, 244, 241, 0.94));
-}
-
-.cv-band--narrative-alt,
-.cv-band--scholarship-alt,
-.cv-band--service-alt,
-.cv-band--service-media {
-  background: linear-gradient(180deg, rgba(236, 240, 237, 0.9), rgba(255, 255, 255, 0.88));
-}
-
-.summary-grid,
-.cv-record-grid,
-.course-groups,
-.research-grid {
+.cv-entries {
   display: grid;
   gap: var(--spacing-6);
 }
 
-.summary-grid,
-.cv-record-grid {
-  grid-template-columns: minmax(0, 1.7fr) minmax(18rem, 1fr);
+.cv-entry {
+  padding-bottom: var(--spacing-6);
+  border-bottom: 1px solid color-mix(in srgb, var(--outline-variant) 72%, transparent);
 }
 
-.cv-panel,
-.cv-mini-panel,
-.course-group-card,
-.highlight-panel {
-  background: rgba(255, 255, 255, 0.68);
-  border-radius: var(--radius-lg);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 85%, transparent);
+.cv-entry:last-child {
+  padding-bottom: 0;
+  border-bottom: none;
 }
 
-.cv-panel {
-  padding: clamp(1.4rem, 2.8vw, 2rem);
+.cv-entry--current .item-title::after {
+  content: 'Current';
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.75rem;
+  padding: 0.16rem 0.55rem;
+  border-radius: 999px;
+  font-family: var(--type-meta-family);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--secondary);
+  background: color-mix(in srgb, var(--secondary) 12%, white 88%);
+  vertical-align: middle;
 }
 
-.cv-panel--stacked {
-  display: grid;
-  gap: var(--spacing-5);
-  align-content: start;
-  background: transparent;
-  box-shadow: none;
-  padding: 0;
+.cv-entry--citation {
+  padding-bottom: var(--spacing-4);
 }
 
-.cv-mini-panel,
-.course-group-card,
-.highlight-panel {
-  padding: 1.35rem 1.4rem;
-}
-
-.course-groups,
-.research-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+.cv-entry--citation p {
+  margin: 0;
 }
 
 .compact-list,
@@ -3463,43 +3476,30 @@ body.math130-course-page {
 }
 
 .compact-list li + li,
-.award-list li + li,
-.highlights-list li + li {
+.award-list li + li {
   margin-top: 0.6rem;
 }
 
+.compact-list--tight li + li {
+  margin-top: 0.45rem;
+}
+
 .compact-list li::before,
-.award-list li::before,
-.highlights-list li::before {
+.award-list li::before {
   content: "";
   position: absolute;
   top: 0.7rem;
   left: 0;
-  width: 0.4rem;
-  height: 0.4rem;
+  width: 0.38rem;
+  height: 0.38rem;
   border-radius: 999px;
   background: color-mix(in srgb, var(--secondary) 70%, var(--surface-tint));
 }
 
-.highlights-list li {
-  position: relative;
-  padding-left: 1.1rem;
-}
-
-.cv-timeline .experience-item,
-.cv-timeline .presentation-item,
-.cv-panel--timeline .education-item,
-.cv-panel--research .experience-item {
-  margin-bottom: 0;
-  padding: 1rem 0 1rem 1.5rem;
-  border-left: 1px solid color-mix(in srgb, var(--outline-variant) 75%, transparent);
-}
-
-.cv-timeline .experience-item + .experience-item,
-.cv-timeline .presentation-item + .presentation-item,
-.cv-panel--timeline .education-item + .education-item,
-.cv-panel--research .experience-item + .experience-item {
-  margin-top: 0.25rem;
+.cv-split-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--spacing-8);
 }
 
 .item-header {
@@ -3542,7 +3542,6 @@ body.math130-course-page {
   font-size: 0.93rem;
 }
 
-.cv-section-nav #nav-menu > li > .cv-nav-trigger,
 .cv-section-nav #nav-menu > li > .cv-nav-link {
   display: block;
   padding: 0.8rem 1rem;
@@ -3556,28 +3555,11 @@ body.math130-course-page {
   text-decoration: none;
 }
 
-.cv-section-nav #nav-menu > li > .cv-nav-trigger::after {
-  content: "▾";
-  margin-left: 0.45rem;
-  font-size: 0.8em;
-}
-
-.cv-section-nav #nav-menu > li > .cv-nav-trigger:hover,
-.cv-section-nav #nav-menu > li > .cv-nav-trigger:focus-visible,
 .cv-section-nav #nav-menu > li > .cv-nav-link:hover,
-.cv-section-nav #nav-menu > li > .cv-nav-link:focus-visible,
-.cv-section-nav #nav-menu .dropdown-menu a:hover,
-.cv-section-nav #nav-menu .dropdown-menu a:focus-visible {
+.cv-section-nav #nav-menu > li > .cv-nav-link:focus-visible {
   background: rgba(13, 80, 213, 0.1);
   color: var(--secondary);
   outline: none;
-}
-
-.cv-section-nav .cv-nav-group[data-open="true"] .dropdown-menu,
-.cv-section-nav .cv-nav-group:hover .dropdown-menu,
-.cv-section-nav .cv-nav-group:focus-within .dropdown-menu {
-  opacity: 1;
-  visibility: visible;
 }
 
 .download-container {
@@ -3605,10 +3587,8 @@ body.math130-course-page {
 
 @media (max-width: 900px) {
   .cv-hero__grid,
-  .summary-grid,
-  .cv-record-grid,
-  .course-groups,
-  .research-grid {
+  .cv-intro,
+  .cv-split-list {
     grid-template-columns: 1fr;
   }
 
@@ -3633,14 +3613,9 @@ body.math130-course-page {
     text-align: left;
   }
 
-  .cv-section-nav #nav-menu > li > .cv-nav-trigger,
   .cv-section-nav #nav-menu > li > .cv-nav-link {
     width: 100%;
     text-align: left;
-  }
-
-  .cv-section-nav .dropdown-menu {
-    margin-top: 0.2rem;
   }
 
   .download-container {


### PR DESCRIPTION
### Motivation
- Make the CV read as a professional document first and a designed web page second by simplifying structure and reducing panel/card clutter. 
- Preserve the existing hero (`cv-hero`) with photo, name, role, and contact information while improving scanning and hierarchy below it. 
- Replace dense, sibling boxed panels with a concise intro plus a compact facts rail to surface licensure, memberships, and featured distinctions. 
- Reorder content into a clear, linear CV flow (Education → Experience → Publications → Presentations → Teaching → Service/Mentoring → Honors). 

### Description
- Rewrote `CV.html` to replace the previous dropdown/grouped navigation with a flat section list and to introduce a two-part intro: `cv-intro` containing `cv-intro__main` (summary) and `cv-facts-rail` (facts and highlights). 
- Rebuilt the long-form content into sequential `section` blocks (`#education`, `#experience`, `#publications`, `#presentations`, `#teaching`, `#service`, `#honors`) and normalized entry markup to `article.cv-entry` with `item-header`, `item-title`, `item-date`, and `item-subtitle`. 
- Removed or consolidated panel/card patterns (`summary-grid`, `highlight-panel`, `cv-panel`, `cv-mini-panel`, `course-group-card`, and repeated `experience-item` containers) and introduced simplified editorial classes and modulary CSS (`.cv-intro`, `.cv-facts-rail`, `.cv-section`, `.cv-entries`, `.cv-entry`, `.cv-entry--current`, `.cv-entry--citation`, `.cv-split-list`). 
- Cleaned up the CV-specific JavaScript by removing dropdown group logic and obsolete helpers, and trimmed responsive CSS to support the new document-first layout; changes live in `CV.html` and `styles.css`. 

### Testing
- Ran an HTML parse check with the Python `html.parser` snippet (`P().feed(Path('CV.html').read_text())`) and the parse completed successfully. 
- Scanned for leftover legacy selectors with `rg` (searches for `isMobileNav`, `cv-nav-trigger`, `summary-grid`, `cv-panel`, `course-group-card`) and found no remaining critical panel/dropdown patterns. 
- Performed a manual diff review of the updated `CV.html` and `styles.css` to verify the structural and styling changes were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11bfc709c833191c5507caaedf0cf)