### PR TITLE
Update blue accent, hover treatments, and dark-header heading colors

### DIFF
--- a/WebDesign.md
+++ b/WebDesign.md
@@ -34,7 +34,7 @@ Treat the interface as a physical stack of fine parchment. Use the surface tiers
 Flat color is the enemy of prestige.
 
 - **The Library Glow:** Use subtle radial gradients on hero backgrounds, transitioning from `primary` (#001d17) to `primary-container` (#00342b) to mimic the way light hits a leather-bound book.
-- **Vibrant Accents:** Use the `secondary` blue (#0d50d5) sparingly for high-action CTAs or data highlights to inject "energetic professionalism" into the scholarly emerald base.
+- **Vibrant Accents:** Use the `secondary` blue (#1A56DB) sparingly for high-action CTAs, links, or data highlights to inject "energetic professionalism" into the scholarly emerald base.
 
 ---
 
@@ -155,12 +155,13 @@ If a border is legally or functionally required for accessibility, use the `outl
 ### Buttons: The Signature Action
 
 - **Primary:** `primary-container` (#00342b) background with `on-primary` (#ffffff) text. Use `rounding-md` (0.75rem). Add a subtle inner-glow gradient (top-to-bottom) for a "pressed silk" feel.
-- **Secondary:** Use the vibrant `secondary` blue (#0d50d5) for conversion-focused actions.
+- **Secondary:** Use the vibrant `secondary` blue (#1A56DB) for conversion-focused actions.
 - **Tertiary:** No background. `primary` text with an underline that only appears on hover.
 
 ### Cards & Lists
 
 - **Cards Are Selective, Not Default:** Cards are an emphasis tool, not the baseline layout primitive. Use them for featured content, interaction affordances, compact previews, or places where a distinct surface materially helps comprehension.
+- **Hover Behavior:** Panels, sections, and marketing cards should not change background fills on hover; use shadow and subtle outline emphasis only so the surface hierarchy stays stable.
 - **No Dividers:** Forbid the use of 1px lines between list items in editorial and marketing layouts. Use `spacing-4` (1.4rem) gaps or alternating subtle background shifts (`surface-container-low` vs `surface-container`).
 - **Instructional Exception:** In course and manual contexts, prioritize comprehension over purity; visible markers, numbering, or very subtle separators may be used when they improve step tracking.
 - **Hierarchy Before Uniformity:** When content has a clear primary/secondary relationship, express it through composition, scale, spacing, and placement before reaching for equal card grids.
@@ -242,6 +243,7 @@ Layout should reflect those answers. Components exist to reinforce hierarchy, no
 To keep implementation aligned with the current codebase, prefer the tokens and primitives already established in `styles.css`.
 
 - **Scholarly emerald base / authority text:** `--primary`, `--primary-container`, `--on-surface`.
+- **Header gradient legibility:** Inside `.page-shell-header` and `.course-header`, heading text should inherit `--light-text` so display headings remain readable over dark gradients.
 - **Energetic professional accent:** `--secondary` for actions, links, focus, and highlights.
 - **Sun-drenched parchment surfaces / dark reading surfaces:** `--surface`, `--surface-container-low`, `--surface-container-lowest`, `--surface-container-highest`, with dark-mode overrides under `:root[data-theme="dark"]`.
 - **Editorial typography split:** `--font-display` / `--type-display-family` for titles; `--font-body` / `--type-body-family` for reading text.

--- a/styles.css
+++ b/styles.css
@@ -22,7 +22,7 @@
   --parchment-muted: #ebeeea;
   --parchment-deep: #e1e3e0;
 
-  --accent-action: #0d50d5;
+  --accent-action: #1A56DB;
   --outline-variant: #c0c8c4;
   --surface-tint: #3a665c;
 
@@ -148,7 +148,7 @@
   linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(242, 244, 241, 0.72));
   --gradient-publication-surface-hover: linear-gradient(
     90deg,
-    rgba(13, 80, 213, 0.14),
+    rgba(26, 86, 219, 0.14),
     rgba(58, 102, 92, 0.06) 28%,
     transparent 74%
   ),
@@ -339,6 +339,16 @@ header h1 {
 .page-shell-header--profile .contact-info,
 .page-shell-header--profile .contact-item,
 .page-shell-header--profile .contact-item i {
+  color: var(--light-text);
+}
+
+/* Headings inside dark-gradient headers inherit light text rather than the
+   global h1–h6 dark-emerald default, which would be invisible on the gradient. */
+.page-shell-header h1,
+.page-shell-header h2,
+.page-shell-header h3,
+.course-header h1,
+.course-header h2 {
   color: var(--light-text);
 }
 
@@ -558,10 +568,8 @@ section h2 {
 .marketing-card:hover,
 .feature-section:hover,
 .promo-band:hover {
-  background:
-    var(--gradient-editorial-hover-tier),
-    var(--gradient-editorial-hover-panel);
   box-shadow: 0 18px 36px rgba(0, 29, 23, 0.06);
+  outline-color: color-mix(in srgb, var(--secondary) 18%, var(--outline-variant));
 }
 
 /* Two-column layout */
@@ -675,7 +683,7 @@ section h2 {
   font-weight: var(--meta-weight);
   letter-spacing: var(--meta-tracking);
   text-transform: uppercase;
-  color: var(--tertiary);
+  color: var(--secondary);
 }
 
 .home-hero {
@@ -968,10 +976,8 @@ section h2 {
 }
 
 .marketing-card:hover {
-  transform: translateY(-3px);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--surface-container-low) 88%, transparent), transparent),
-    linear-gradient(180deg, color-mix(in srgb, var(--surface-container-lowest) 96%, transparent), color-mix(in srgb, var(--surface-container-low) 92%, transparent));
+  box-shadow: 0 18px 36px rgba(0, 29, 23, 0.06);
+  outline-color: color-mix(in srgb, var(--secondary) 18%, var(--outline-variant));
 }
 
 .marketing-card h2 {
@@ -3431,7 +3437,7 @@ body.math130-course-page {
   font-weight: var(--meta-weight);
   letter-spacing: var(--meta-tracking);
   text-transform: uppercase;
-  color: var(--tertiary);
+  color: var(--secondary);
 }
 
 .cv-entries {


### PR DESCRIPTION
### Motivation
- Standardize the site accent to a slightly different blue (`#1A56DB`) and apply it consistently through tokens that drive headings, buttons, and link accents.
- Remove hover background-fill shifts on panels/cards so hover emphasis relies on shadow and subtle outline only, preserving stable surface hierarchy.
- Fix a bug where headings inside dark-gradient headers could inherit the global dark heading color and become unreadable.

### Description
- Updated the CSS token `--accent-action` to `#1A56DB` and adjusted derived usages (including a publication-hover gradient rgba value) so `--secondary` reflects the new blue.
- Removed hover background-fill transitions from `.editorial-panel`, `.marketing-card`, `.feature-section`, and `.promo-band`, and replaced them with `box-shadow` and `outline-color` hover emphasis.
- Switched `.home-kicker` and `.section-kicker` color from the burnt-earth token to `var(--secondary)` so kicker text uses the new blue.
- Added a rule forcing headings inside `.page-shell-header` and `.course-header` to `color: var(--light-text)` to ensure readability over dark gradients.
- Updated `WebDesign.md` to document the new blue value, the hover behavior policy for panels/cards, and the header legibility guideline.

### Testing
- Ran `git diff --check` to validate whitespace/diff issues, which completed with no errors.
- Ran `git status --short` to confirm the expected files (`styles.css`, `WebDesign.md`) were modified, which matched the change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c13774872483318fc1dc84e2585a7d)