### PR TITLE
Remove default list styling from math130 summary list

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3175,6 +3175,7 @@ body.math130-course-page {
   display: grid;
   gap: 0.8rem;
   padding-left: 0;
+  list-style: none;
 }
 
 .math130-summary-list li {


### PR DESCRIPTION
## Summary
This change removes the default bullet point styling from the math130 course page summary list by adding `list-style: none;` to the `.math130-summary-list` CSS rule.

## Key Changes
- Added `list-style: none;` property to `.math130-summary-list` class to hide default list markers

## Implementation Details
This is a minor CSS-only change that prevents the browser's default bullet points or numbering from appearing on the summary list items. This allows for custom styling of the list items without the default list markers, providing better visual control over the list presentation on the math130 course page.

https://claude.ai/code/session_01BDVjZZtrELr9QhjXawEX59