### PR TITLE
Remove emojis from Math 130 course page

### DIFF
--- a/courses/math130.html
+++ b/courses/math130.html
@@ -91,7 +91,7 @@
 
       <div class="tabs review-tabs review-tabs-4 math130-unit-grid card-container">
         <article class="tab-btn review-tab-btn is-priority math130-unit-card">
-          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true">📐</div>
+          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true"></div>
           <div class="review-tab-copy math130-unit-card__copy">
             <span class="review-tab-label">Unit 1 · Test 1</span>
             <span class="review-tab-meta">Foundations, algebra fluency, and setup skills for later units.</span>
@@ -105,7 +105,7 @@
         </article>
 
         <article class="tab-btn review-tab-btn math130-unit-card">
-          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true">📈</div>
+          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true"></div>
           <div class="review-tab-copy math130-unit-card__copy">
             <span class="review-tab-label">Unit 2 · Test 2</span>
             <span class="review-tab-meta">Functions, equations, graphing, and technical modeling tools.</span>
@@ -119,7 +119,7 @@
         </article>
 
         <article class="tab-btn review-tab-btn math130-unit-card">
-          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true">⚙️</div>
+          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true"></div>
           <div class="review-tab-copy math130-unit-card__copy">
             <span class="review-tab-label">Unit 3 · Test 3</span>
             <span class="review-tab-meta">Trigonometry, vectors, and targeted mid-course review support.</span>
@@ -133,7 +133,7 @@
         </article>
 
         <article class="tab-btn review-tab-btn math130-unit-card">
-          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true">📝</div>
+          <div class="review-tab-icon math130-unit-card__icon" aria-hidden="true"></div>
           <div class="review-tab-copy math130-unit-card__copy">
             <span class="review-tab-label">Unit 4 · Final Exam</span>
             <span class="review-tab-meta">Cumulative review and final-week preparation across the course.</span>
@@ -154,7 +154,7 @@
   <div class="container">
     <p>&copy; 2025 - All Rights Reserved</p>
     <div class="social-links">
-      <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">📺</a>
+      <a href="https://www.youtube.com/learnabundantly" aria-label="YouTube">YouTube</a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
### Motivation
- Remove decorative emoji glyphs from the Math 130 course dashboard to improve accessibility and ensure consistent, text-based labels in `courses/math130.html`.

### Description
- Cleared the emoji characters from the four unit card icon containers and replaced the emoji-only YouTube footer link with the plain text `YouTube` in `courses/math130.html`; no other layout or content changes were made and no extra skills were required to make this edit.

### Testing
- Verified the change by running a Unicode/emoji scan with a small `python` check, inspected the HTML diff with `git diff -- courses/math130.html`, and reviewed the file excerpt with `nl -ba courses/math130.html | sed -n '90,165p'`, all showing the emojis removed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c177852c548331ba4909784fa5b3a9)