### PR TITLE
Align Math 130 review page with editorial design system

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -18,42 +18,6 @@
 <style>
         /* Page-specific styles only; shared Math 130 review tokens/components live in styles.css. */
 
-        body.review-page.light,
-        body.light .math-review-page,
-        .math-review-page.is-light {
-            --review-bg: var(--surface);
-            --review-surface: var(--surface-container-lowest);
-            --review-surface-2: var(--surface-container-low);
-            --review-border: rgba(192, 200, 196, 0.18);
-            --review-accent: var(--secondary);
-            --review-accent-soft: rgba(26, 86, 219, 0.08);
-            --review-accent-glow: rgba(26, 86, 219, 0.14);
-            --review-muted: var(--on-surface-variant);
-            --review-text: var(--on-surface);
-            --review-shadow: 0 22px 48px rgba(0, 29, 23, 0.08);
-            --review-grid: rgba(58, 102, 92, 0.035);
-            --review-accent-hover: rgba(26, 86, 219, 0.2);
-            --review-green-border: rgba(15, 118, 110, 0.22);
-            --review-red-border: rgba(185, 28, 28, 0.18);
-            --review-check-bg: rgba(15, 118, 110, 0.06);
-            --review-check-border: rgba(15, 118, 110, 0.22);
-            --review-got-border: rgba(15, 118, 110, 0.3);
-            --review-miss-border: rgba(185, 28, 28, 0.28);
-            --review-green-step: rgba(15, 118, 110, 0.16);
-            --review-h1-from: var(--primary);
-            --review-h1-to: var(--primary-container);
-            --review-body-muted: color-mix(in srgb, var(--on-surface-variant) 86%, var(--primary) 14%);
-            --review-semantic-body: var(--on-surface);
-            --review-success: #0f766e;
-            --review-success-bg: rgba(15, 118, 110, 0.08);
-            --review-warning: #b45309;
-            --review-warning-bg: rgba(180, 83, 9, 0.08);
-            --review-error: #b91c1c;
-            --review-error-bg: rgba(185, 28, 28, 0.08);
-            --review-info: var(--secondary);
-            --review-info-bg: rgba(26, 86, 219, 0.08);
-        }
-
         .math-review-page {
             background:
                 radial-gradient(circle at top left, rgba(58, 102, 92, 0.12), transparent 28%),
@@ -62,29 +26,28 @@
         }
         body.review-page:not(.light) .math-review-page {
             background:
-                radial-gradient(circle at top left, rgba(108, 99, 255, 0.06), transparent 28%),
+                radial-gradient(circle at top left, rgba(126, 168, 255, 0.08), transparent 28%),
                 var(--surface);
         }
-        body.review-page::before { opacity: 0.28; }
         .review-shell { max-width: 1180px; padding-top: clamp(2.5rem, 5vw, 4rem); }
-        .review-header {
+        .review-header.review-header--hero {
             margin-bottom: 2.5rem;
             padding: clamp(2.35rem, 5vw, 4rem);
             background: var(--gradient-library-glow);
             border-radius: 1.5rem;
             color: var(--on-primary);
             overflow: hidden;
-            box-shadow: 0 28px 60px rgba(0, 29, 23, 0.16);
+            box-shadow: 0 22px 48px rgba(0, 29, 23, 0.10);
             text-align: left;
         }
-        .review-header::before {
+        .review-header.review-header--hero::before {
             content: "";
             position: absolute;
             inset: 0;
             background: linear-gradient(135deg, rgba(58, 102, 92, 0.16), rgba(13, 80, 213, 0.14));
             pointer-events: none;
         }
-        .review-header::after {
+        .review-header.review-header--hero::after {
             display: block;
             inset: auto auto 0 0;
             width: min(18rem, 42%);
@@ -92,20 +55,20 @@
             background: linear-gradient(90deg, rgba(255,255,255,0.92), color-mix(in srgb, var(--secondary) 78%, transparent));
             opacity: 0.92;
         }
-        .review-header > * { position: relative; z-index: 1; }
-        .review-header .breadcrumb,
-        .review-header h1,
-        .review-header .header-meta,
-        .review-header .review-subtitle,
-        .review-header .header-chip { color: var(--on-primary); }
-        .review-header .breadcrumb {
+        .review-header.review-header--hero > * { position: relative; z-index: 1; }
+        .review-header.review-header--hero .breadcrumb,
+        .review-header.review-header--hero h1,
+        .review-header.review-header--hero .header-meta,
+        .review-header.review-header--hero .review-subtitle,
+        .review-header.review-header--hero .header-chip { color: var(--on-primary); }
+        .review-header.review-header--hero .breadcrumb {
             background: rgba(255, 255, 255, 0.1);
             box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.14);
         }
-        .review-header .breadcrumb a,
-        .review-header .breadcrumb-current,
-        .review-header .breadcrumb-sep { color: rgba(255,255,255,0.82); }
-        .review-header h1 {
+        .review-header.review-header--hero .breadcrumb a,
+        .review-header.review-header--hero .breadcrumb-current,
+        .review-header.review-header--hero .breadcrumb-sep { color: rgba(255,255,255,0.82); }
+        .review-header.review-header--hero h1 {
             color: var(--on-primary);
             font-size: clamp(2.8rem, 6vw, 4.4rem);
             margin-bottom: 1rem;
@@ -148,16 +111,21 @@
         }
         .tab-btn.review-tab-btn.active, .review-tabs .tab-btn.active {
             background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 10%, var(--surface-container-lowest)), color-mix(in srgb, var(--surface-container-low) 92%, white));
-            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 24%, transparent), 0 14px 30px rgba(0, 29, 23, 0.08);
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 24%, transparent);
         }
 
 
+        .review-section--open {
+            padding: 0.5rem 0 1rem;
+            margin-bottom: 2rem;
+        }
+
         @media (max-width: 980px) {
-            .review-header h1 { max-width: none; }
+            .review-header.review-header--hero h1 { max-width: none; }
         }
 
         @media (max-width: 640px) {
-            .review-header { padding: 1.5rem; }
+            .review-header.review-header--hero { padding: 1.5rem; }
         }
 
         /* Cards */
@@ -167,7 +135,7 @@
             border-radius: 1rem;
             padding: 2rem;
             margin-bottom: 1.5rem;
-            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 78%, transparent), 0 18px 40px rgba(0, 29, 23, 0.06);
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 78%, transparent);
             transition: transform 0.2s;
         }
 
@@ -211,7 +179,7 @@
         .formula-priority-note,
         .formula-legend {
             background: var(--surface2);
-            border: 1px solid var(--border);
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 68%, transparent);
             border-radius: 14px;
             padding: 1rem 1.1rem;
         }
@@ -236,7 +204,7 @@
             border-radius: 999px;
             font-size: 0.88rem;
             font-weight: 600;
-            border: 1px solid var(--border);
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 68%, transparent);
             background: var(--surface);
             color: var(--text-muted);
         }
@@ -248,9 +216,9 @@
             background: var(--border);
             flex-shrink: 0;
         }
-        .legend-chip.legend-memorize { border-color: var(--red); color: var(--red); background: var(--red-bg); }
+        .legend-chip.legend-memorize { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--red) 18%, transparent); color: var(--red); background: var(--red-bg); }
         .legend-chip.legend-memorize::before { background: var(--red); }
-        .legend-chip.legend-provided { border-color: var(--green); color: var(--green); background: var(--green-bg); }
+        .legend-chip.legend-provided { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--green) 18%, transparent); color: var(--green); background: var(--green-bg); }
         .legend-chip.legend-provided::before { background: var(--green); }
         .legend-chip.legend-useful::before { background: var(--text-muted); }
         .formula-section-note {
@@ -270,18 +238,14 @@
             background: var(--surface2);
             padding: 1.5rem 1.25rem;
             border-radius: 14px;
-            border: 1px solid var(--border);
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 68%, transparent);
             text-align: center;
             overflow: hidden;
-            box-shadow: 0 10px 24px rgba(0,0,0,0.08);
-            transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
-        }
-        body.review-page:not(.light) .formula-card {
-            box-shadow: 0 10px 24px rgba(0,0,0,0.28);
+            transition: transform 0.18s ease, background-color 0.18s ease, box-shadow 0.18s ease;
         }
         .formula-card:hover {
             transform: translateY(-2px);
-            box-shadow: 0 14px 28px rgba(0,0,0,0.12);
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
         }
         .formula-card::before {
             content: "";
@@ -293,13 +257,13 @@
             background: var(--border);
         }
         .formula-card.memorize-card {
-            border-color: var(--red);
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--red) 16%, transparent);
             background: linear-gradient(180deg, var(--surface2) 0%, var(--red-bg) 100%);
         }
         .formula-card.memorize-card::before { background: var(--red); }
         .formula-card.memorize-card .formula-title { color: var(--text); }
         .formula-card.provided-card {
-            border-color: var(--green);
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--green) 16%, transparent);
             background: linear-gradient(180deg, var(--surface2) 0%, var(--green-bg) 100%);
         }
         .formula-card.provided-card::before { background: var(--green); }
@@ -325,14 +289,14 @@
 
         /* Quiz Section */
         .quiz-selector { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 2rem; }
-        .quiz-btn { background: var(--surface2); border: 1px solid var(--border); color: var(--text); padding: 0.5rem 1rem; border-radius: 8px; cursor: pointer; transition: all 0.2s; font-size: 0.95rem; }
+        .quiz-btn { background: var(--surface2); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 66%, transparent); color: var(--text); padding: 0.5rem 1rem; border-radius: 8px; cursor: pointer; transition: all 0.2s; font-size: 0.95rem; }
         .quiz-btn:hover { border-color: var(--accent); }
         .quiz-btn.active { background: var(--accent); color: white; border-color: var(--accent); }
 
         .quiz-box { text-align: center; padding: 1rem 0; }
         .question-text { font-size: 1.3rem; margin-bottom: 1.5rem; line-height: 1.8; }
         
-        .svg-canvas { background: var(--surface2); border: 1px solid var(--border); border-radius: 12px; padding: 1rem; margin: 0 auto 1.5rem auto; display: block; max-width: 100%; height: auto; }
+        .svg-canvas { background: var(--surface2); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 66%, transparent); border-radius: 12px; padding: 1rem; margin: 0 auto 1.5rem auto; display: block; max-width: 100%; height: auto; }
         .svg-fallback { margin: -0.9rem auto 1.2rem auto; max-width: 640px; color: var(--text-muted); font-size: 0.92rem; text-align: left; }
 
         /* Multi-Inputs */
@@ -351,12 +315,12 @@
         .math-text { font-size: 1.5rem; font-family: var(--type-display-family); }
         .question-note { 
             max-width: 720px; margin: -0.5rem auto 1.25rem auto; padding: 0.9rem 1rem;
-            background: var(--surface2); border: 1px solid var(--border); border-radius: 12px;
+            background: var(--surface2); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 66%, transparent); border-radius: 12px;
             color: var(--text-muted); font-size: 0.98rem; line-height: 1.55; text-align: left;
         }
         .log-arg-template { 
             display: inline-flex; align-items: center; gap: 0.45rem; flex-wrap: wrap;
-            padding: 0.5rem 0.75rem; border-radius: 14px; background: var(--surface2); border: 1px solid var(--border);
+            padding: 0.5rem 0.75rem; border-radius: 14px; background: var(--surface2); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 66%, transparent);
         }
         .log-base-stack {
             display: inline-flex; flex-direction: column; align-items: center; justify-content: flex-end;
@@ -386,7 +350,7 @@
         .btn-primary { background: var(--accent); color: white; border: none; padding: 1rem 2rem; border-radius: 12px; font-size: 1.1rem; font-weight: 600; cursor: pointer; transition: all 0.2s; font-family: var(--type-body-family); }
         .btn-primary:hover { background: var(--accent-hover); transform: translateY(-2px); }
         .btn-primary:active { transform: translateY(0); }
-        .btn-secondary { background: transparent; color: var(--text); border: 1px solid var(--border); padding: 0.75rem 1.5rem; border-radius: 12px; font-size: 1rem; cursor: pointer; transition: all 0.2s; margin-left: 0.5rem;}
+        .btn-secondary { background: transparent; color: var(--text); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 66%, transparent); padding: 0.75rem 1.5rem; border-radius: 12px; font-size: 1rem; cursor: pointer; transition: all 0.2s; margin-left: 0.5rem;}
         .btn-secondary:hover { background: var(--surface2); }
 
         /* Mock quiz cards need their own hover treatment because they sit on the same surface tone as the container */
@@ -394,16 +358,14 @@
             margin-left: 0;
             width: 100%;
             background: var(--surface);
-            border-color: var(--border);
             min-height: 100%;
-            box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 62%, transparent);
         }
         #quiz-cta .btn-secondary:hover,
         #quiz-cta .btn-secondary:focus-visible {
             background: color-mix(in srgb, var(--accent) 10%, var(--surface));
-            border-color: color-mix(in srgb, var(--accent) 48%, var(--border));
             transform: translateY(-2px);
-            box-shadow: 0 10px 24px rgba(91, 82, 224, 0.10);
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
             outline: none;
         }
         #quiz-cta .btn-secondary div:last-child {
@@ -417,21 +379,23 @@
         /* Feedback */
         .feedback { margin-top: 1.5rem; padding: 1.25rem; border-radius: 12px; font-weight: 500; display: none; animation: fadeIn 0.3s ease; text-align: left; }
         @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
-        .feedback.correct { display: block; background: var(--green-bg); color: var(--green); border: 1px solid var(--green); text-align: center; }
-        .feedback.incorrect { display: block; background: var(--surface2); color: var(--text); border: 1px solid var(--red); border-left: 6px solid var(--red); }
+        .feedback.correct { display: block; background: var(--green-bg); color: var(--green); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--green) 22%, transparent); text-align: center; }
+        .feedback.incorrect { display: block; background: var(--surface2); color: var(--text); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--red) 22%, transparent); border-left: 6px solid var(--red); }
         .solution-step { margin-top: 1rem; padding-top: 1rem; border-top: 1px dashed var(--border); color: var(--text-muted); font-size: 1.05rem; }
 
         /* Progress Stats & History Table */
         .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
-        .stat-card { background: var(--surface2); padding: 1.5rem; border-radius: 12px; border: 1px solid var(--border); text-align: center; }
+        .stat-card { background: var(--surface2); padding: 1.5rem; border-radius: 12px; box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 66%, transparent); text-align: center; }
         .stat-val { font-size: 2.5rem; font-family: var(--type-meta-family); color: var(--accent); font-weight: 700; margin-bottom: 0.5rem; }
         .stat-label { color: var(--text-muted); font-size: 0.9rem; text-transform: uppercase; letter-spacing: 1px; }
 
-        .history-table { width: 100%; border-collapse: collapse; margin-top: 1rem; font-size: 0.95rem; }
-        .history-table th { color: var(--text-muted); text-transform: uppercase; font-size: 0.8rem; letter-spacing: 1px; padding: 1rem; border-bottom: 2px solid var(--border); text-align: left;}
-        .history-table td { padding: 1rem; border-bottom: 1px solid var(--border); }
-        .history-table tr:hover { background: var(--surface2); }
-        .best-row { background: var(--green-bg); }
+        .history-table { width: 100%; border-collapse: separate; border-spacing: 0 0.5rem; margin-top: 1rem; font-size: 0.95rem; }
+        .history-table th { color: var(--text-muted); text-transform: uppercase; font-size: 0.8rem; letter-spacing: 1px; padding: 0 1rem 0.4rem; text-align: left;}
+        .history-table td { padding: 1rem; background: color-mix(in srgb, var(--surface2) 76%, var(--surface)); }
+        .history-table tbody td:first-child { border-radius: 12px 0 0 12px; }
+        .history-table tbody td:last-child { border-radius: 0 12px 12px 0; }
+        .history-table tr:hover td { background: color-mix(in srgb, var(--surface2) 92%, var(--accent-soft)); }
+        .best-row td { background: color-mix(in srgb, var(--green-bg) 72%, var(--surface)); }
         
         .badge { padding: 0.3rem 0.8rem; border-radius: 20px; font-size: 0.8rem; font-weight: bold; }
         .badge-perfect { background: color-mix(in srgb, var(--green) 18%, var(--surface)); color: var(--text); border: 1px solid color-mix(in srgb, var(--green) 48%, var(--border)); }
@@ -453,7 +417,7 @@
 
         /* Section progress bars */
         .progress-summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
-        .progress-item { background: var(--surface2); border: 1px solid var(--border); border-radius: 12px; padding: 1rem; }
+        .progress-item { background: var(--surface2); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 66%, transparent); border-radius: 12px; padding: 1rem; }
         .progress-item-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
         .progress-item-label { font-weight: 600; font-size: 0.9rem; }
         .progress-item-count { font-family: var(--type-meta-family); font-size: 0.85rem; color: var(--text-muted); }
@@ -479,17 +443,7 @@
 
 
 
-/* Print Configuration */
-@media print {
-    .theme-toggle, .tabs, .status-supplemental-section, .quiz-selector, .btn-primary, .btn-secondary {
-        display: none !important;
-    }
-    body { background: white; color: black; }
-    .card { border: none; box-shadow: none; }
-}
-
-
-        .formula-card.wide { grid-column: 1 / -1; }
+.formula-card.wide { grid-column: 1 / -1; }
 
         @media (max-width: 1024px) {
             .container { padding: 1.5rem; }
@@ -759,11 +713,11 @@
             font-weight: 700;
             letter-spacing: 0.04em;
             text-transform: uppercase;
-            border: 1px solid var(--border);
+            box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 60%, transparent);
             background: var(--surface);
             color: var(--text-muted);
         }
-        .slide-tag.pdf { border-color: var(--green); color: var(--green); background: var(--green-bg); }
+        .slide-tag.pdf { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--green) 18%, transparent); color: var(--green); background: var(--green-bg); }
         .slide-tag.pptx { border-color: var(--border); color: var(--text-muted); }
         .slide-card h3 {
             font-family: var(--type-display-family);
@@ -942,7 +896,7 @@
 </nav>
 
 <div class="container review-shell">
-<header class="review-header">
+<header class="review-header review-header--hero">
 <div class="header-copy review-title-group">
 <nav class="breadcrumb" aria-label="Breadcrumb">
 <a href="index.html">Home</a>
@@ -1003,7 +957,7 @@
 </div>
 <!-- SCHEDULE TAB -->
 <div class="tab-content" id="tab-schedule">
-<div class="card review-card">
+<section class="review-section review-section--open">
 <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; margin-bottom: 1.5rem;">
 <h2 style="margin-bottom: 0;">Course Schedule</h2>
 <div id="exam-countdown" style="background: var(--red-bg); border: 1px solid var(--red); color: var(--red); padding: 0.5rem 1rem; border-radius: 12px; font-weight: 600; font-family: var(--type-meta-family); font-size: 0.95rem;"></div>
@@ -1113,8 +1067,8 @@
 </tbody>
 </table>
 </div>
-</div>
-<div class="card review-card">
+</section>
+<section class="review-section review-section--open">
 <h2>ALEKS Modules</h2>
 <div style="overflow-x: auto;">
 <table class="history-table">
@@ -1148,11 +1102,11 @@
 </tbody>
 </table>
 </div>
-</div>
+</section>
 </div>
 <!-- FORMULAS TAB -->
 <div class="tab-content" id="tab-formulas">
-<div class="card review-card">
+<section class="review-section review-section--open">
 <h2>Essential Formulas for Test 2</h2>
 <p style="color: var(--text-muted); margin-bottom: 1rem; font-weight: 500;">
                 Covers formulas relevant to Sections 4.2, 4.3, and the Test 2 geometry topics.
@@ -1340,7 +1294,7 @@
 </div>
 </div>
 </div>
-</div>
+</section>
 </div>
 <!-- PRACTICE TAB -->
 <div class="tab-content" id="tab-practice">
@@ -1464,7 +1418,7 @@
 </div>
 <!-- VIDEOS TAB -->
 <div class="tab-content" id="tab-videos">
-<div class="card review-card">
+<section class="review-section review-section--open">
 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; flex-wrap: wrap; gap: 0.5rem;">
 <h2>Study Videos</h2>
 <div id="video-progress" style="color: var(--text-muted); font-size: 0.95rem; font-weight: 500;"></div>
@@ -1532,7 +1486,7 @@
 </a>
 </div>
 </div>
-</div>
+</section>
 </div>
 
 <!-- LECTURE SLIDES TAB -->

--- a/styles.css
+++ b/styles.css
@@ -2583,18 +2583,18 @@ main.error-main {
 
 /* Math 130 review layer */
 :root {
-  --review-bg: #0f1117;
-  --review-surface: #181a24;
-  --review-surface-2: #1f2233;
-  --review-border: #2a2d42;
-  --review-accent: #6c63ff;
-  --review-accent-soft: rgba(108, 99, 255, 0.12);
-  --review-accent-glow: rgba(108, 99, 255, 0.25);
-  --review-muted: #9ca0b8;
-  --review-text: #e2e4ef;
-  --review-shadow: 0 12px 36px rgba(0, 0, 0, 0.22);
-  --review-grid: rgba(108, 99, 255, 0.03);
-  --review-accent-hover: rgba(108, 99, 255, 0.3);
+  --review-bg: var(--surface-dim);
+  --review-surface: var(--surface-container-low);
+  --review-surface-2: var(--surface-container-lowest);
+  --review-border: var(--surface-container-highest);
+  --review-accent: var(--secondary);
+  --review-accent-soft: rgba(126, 168, 255, 0.12);
+  --review-accent-glow: rgba(126, 168, 255, 0.25);
+  --review-muted: var(--on-surface-variant);
+  --review-text: var(--on-surface);
+  --review-shadow: 0 12px 36px rgba(0, 0, 0, 0.18);
+  --review-grid: rgba(126, 168, 255, 0.03);
+  --review-accent-hover: rgba(126, 168, 255, 0.3);
   --review-green-border: rgba(52, 211, 153, 0.2);
   --review-red-border: rgba(248, 113, 113, 0.2);
   --review-check-bg: rgba(52, 211, 153, 0.04);
@@ -2602,18 +2602,18 @@ main.error-main {
   --review-got-border: rgba(52, 211, 153, 0.4);
   --review-miss-border: rgba(248, 113, 113, 0.4);
   --review-green-step: rgba(52, 211, 153, 0.25);
-  --review-h1-from: #e2e4ef;
-  --review-h1-to: #9d98ff;
-  --review-body-muted: #9aa3bd;
-  --review-semantic-body: #d7dcef;
+  --review-h1-from: var(--on-surface);
+  --review-h1-to: var(--secondary);
+  --review-body-muted: color-mix(in srgb, var(--on-surface-variant) 88%, var(--on-surface) 12%);
+  --review-semantic-body: var(--on-surface);
   --review-success: #34d399;
   --review-success-bg: rgba(52, 211, 153, 0.1);
   --review-warning: #f59e0b;
   --review-warning-bg: rgba(245, 158, 11, 0.1);
   --review-error: #f87171;
   --review-error-bg: rgba(248, 113, 113, 0.1);
-  --review-info: #60a5fa;
-  --review-info-bg: rgba(96, 165, 250, 0.1);
+  --review-info: var(--secondary);
+  --review-info-bg: rgba(126, 168, 255, 0.1);
   --review-radius: 16px;
   --review-shell-width: min(1100px, calc(100vw - 2rem));
 }
@@ -2663,18 +2663,18 @@ body.review-page,
 body.review-page.light,
 body.light .math-review-page,
 .math-review-page.is-light {
-  --review-bg: #f8fafc;
-  --review-surface: #ffffff;
-  --review-surface-2: #f1f5f9;
-  --review-border: #e2e8f0;
-  --review-accent: #5b52e0;
-  --review-accent-soft: rgba(91, 82, 224, 0.08);
-  --review-accent-glow: rgba(91, 82, 224, 0.12);
-  --review-muted: #586879;
-  --review-text: #0f172a;
-  --review-shadow: 0 8px 32px rgba(15, 23, 42, 0.06);
-  --review-grid: rgba(91, 82, 224, 0.04);
-  --review-accent-hover: rgba(91, 82, 224, 0.25);
+  --review-bg: var(--surface);
+  --review-surface: var(--surface-container-lowest);
+  --review-surface-2: var(--surface-container-low);
+  --review-border: var(--ghost-outline);
+  --review-accent: var(--secondary);
+  --review-accent-soft: rgba(26, 86, 219, 0.08);
+  --review-accent-glow: rgba(26, 86, 219, 0.14);
+  --review-muted: var(--on-surface-variant);
+  --review-text: var(--on-surface);
+  --review-shadow: 0 8px 32px rgba(0, 29, 23, 0.06);
+  --review-grid: rgba(58, 102, 92, 0.02);
+  --review-accent-hover: rgba(26, 86, 219, 0.2);
   --review-green-border: rgba(5, 150, 105, 0.2);
   --review-red-border: rgba(220, 38, 38, 0.18);
   --review-check-bg: rgba(5, 150, 105, 0.05);
@@ -2682,30 +2682,20 @@ body.light .math-review-page,
   --review-got-border: rgba(5, 150, 105, 0.4);
   --review-miss-border: rgba(220, 38, 38, 0.35);
   --review-green-step: rgba(5, 150, 105, 0.2);
-  --review-h1-from: #1a1d2b;
-  --review-h1-to: #5046e5;
-  --review-body-muted: #3e4a5c;
-  --review-semantic-body: #1e293b;
+  --review-h1-from: var(--primary);
+  --review-h1-to: var(--secondary);
+  --review-body-muted: color-mix(in srgb, var(--on-surface-variant) 86%, var(--primary) 14%);
+  --review-semantic-body: var(--on-surface);
   --review-success: #059669;
   --review-success-bg: rgba(5, 150, 105, 0.08);
   --review-warning: #d97706;
   --review-warning-bg: rgba(217, 119, 6, 0.08);
   --review-error: #dc2626;
   --review-error-bg: rgba(220, 38, 38, 0.08);
-  --review-info: #2563eb;
-  --review-info-bg: rgba(37, 99, 235, 0.08);
+  --review-info: var(--secondary);
+  --review-info-bg: rgba(26, 86, 219, 0.08);
 }
 
-body.review-page::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  background-image: linear-gradient(var(--grid-line) 1px, transparent 1px), linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
-  background-size: 40px 40px;
-  opacity: 0.45;
-  pointer-events: none;
-  z-index: 0;
-}
 
 .math-review-page {
   position: relative;
@@ -2726,14 +2716,6 @@ body.review-page::before {
   z-index: 1;
 }
 
-.math-review-page > header,
-.math-review-page .review-header {
-  background: transparent;
-  color: inherit;
-  text-align: left;
-  padding: 0;
-  box-shadow: none;
-}
 
 .review-shell {
   width: var(--review-shell-width);
@@ -2926,14 +2908,14 @@ body.review-page::before {
   width: 100%;
   padding: 1rem;
   background: var(--surface2);
-  border: 1px solid var(--border);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 72%, transparent);
   border-radius: 12px;
   transition: all 0.2s;
 }
 
 .review-formula-box, .formula-box {
   background: var(--surface2);
-  border: 1px solid var(--border);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 68%, transparent);
   border-radius: 8px;
   padding: 0.85rem 1rem;
   margin: 0.6rem 0;
@@ -2962,7 +2944,7 @@ body.review-page::before {
   margin: 0.75rem 0;
   padding: 0.85rem 1rem;
   background: var(--surface2);
-  border: 1px solid var(--border);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 68%, transparent);
   border-radius: 10px;
   color: var(--text);
   text-decoration: none;
@@ -2972,9 +2954,9 @@ body.review-page::before {
 .review-video-link:visited, .video-link:visited { color: var(--text); }
 .review-video-link:visited span, .video-link:visited span { color: var(--text); }
 .review-video-link i[data-lucide], .video-link i[data-lucide] { color: var(--green, var(--accent)) !important; flex-shrink: 0; opacity: 0.85; }
-.review-video-link:hover, .video-link:hover { border-color: var(--green, var(--accent)); }
+.review-video-link:hover, .video-link:hover { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--green, var(--accent)) 38%, transparent); }
 .review-video-link:hover i[data-lucide], .video-link:hover i[data-lucide] { opacity: 1; }
-.review-video-link.watched, .video-link.watched { border-color: var(--green, var(--accent)); background: var(--green-bg); }
+.review-video-link.watched, .video-link.watched { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--green, var(--accent)) 32%, transparent); background: var(--green-bg); }
 .review-video-link.watched i[data-lucide], .video-link.watched i[data-lucide] { color: var(--green, var(--accent)) !important; opacity: 0.5; }
 .review-video-link.watched span, .video-link.watched span { opacity: 0.5; text-decoration: line-through; }
 .review-video-link::after, .video-link::after { content: '↗'; font-size: 0.8rem; color: var(--text); opacity: 0.35; margin-left: auto; padding-left: 0.5rem; flex-shrink: 0; }
@@ -2983,19 +2965,18 @@ body.review-page::before {
   padding: 1rem 1.1rem;
   margin: 1rem 0;
   border-radius: 14px;
-  border: 1px solid var(--border);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ghost-outline) 68%, transparent);
   background: linear-gradient(135deg, color-mix(in srgb, var(--surface2) 84%, transparent), var(--surface));
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
 }
-.review-callout--exam { text-align:center; border-width: 2px; border-color: color-mix(in srgb, var(--accent) 52%, var(--border)); background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 16%, var(--surface)), color-mix(in srgb, var(--surface2) 88%, var(--surface))); }
+.review-callout--exam { text-align:center; box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 28%, transparent); background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 16%, var(--surface)), color-mix(in srgb, var(--surface2) 88%, var(--surface))); }
 .review-callout--tip, .tip-box,
 .review-callout--warning, .warning-box,
 .review-callout--info,
 .review-callout--success { color: var(--semantic-body); }
-.review-callout--tip, .tip-box { background: color-mix(in srgb, var(--amber) 10%, var(--surface)); border-color: color-mix(in srgb, var(--amber) 35%, var(--border)); }
-.review-callout--warning, .warning-box { background: color-mix(in srgb, var(--red) 9%, var(--surface)); border-color: color-mix(in srgb, var(--red) 35%, var(--border)); }
-.review-callout--info { background: color-mix(in srgb, var(--blue) 9%, var(--surface)); border-color: color-mix(in srgb, var(--blue) 35%, var(--border)); }
-.review-callout--success { background: color-mix(in srgb, var(--green) 10%, var(--surface)); border-color: color-mix(in srgb, var(--green) 35%, var(--border)); }
+.review-callout--tip, .tip-box { background: color-mix(in srgb, var(--amber) 10%, var(--surface)); border-left: 4px solid color-mix(in srgb, var(--amber) 72%, transparent); }
+.review-callout--warning, .warning-box { background: color-mix(in srgb, var(--red) 9%, var(--surface)); border-left: 4px solid color-mix(in srgb, var(--red) 72%, transparent); }
+.review-callout--info { background: color-mix(in srgb, var(--blue) 9%, var(--surface)); border-left: 4px solid color-mix(in srgb, var(--blue) 72%, transparent); }
+.review-callout--success { background: color-mix(in srgb, var(--green) 10%, var(--surface)); border-left: 4px solid color-mix(in srgb, var(--green) 72%, transparent); }
 .review-callout--tip i, .tip-box i, .review-callout--tip strong, .tip-box strong { color: var(--amber); }
 .review-callout--warning i, .warning-box i, .review-callout--warning strong, .warning-box strong { color: var(--red); }
 .review-callout--info i, .review-callout--info strong { color: var(--blue); }
@@ -3017,7 +2998,7 @@ body.review-page::before {
 .section-lead--results h2 { text-align: center; }
 
 .review-callout--highlight {
-  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 24%, transparent);
   background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 10%, var(--surface)), var(--surface));
 }
 .review-callout__title { font-family: var(--type-display-family); font-size: 1.25rem; margin-bottom: 0.75rem; }


### PR DESCRIPTION
### Motivation
- Bring the Math 130 review page into visual and structural alignment with the site-wide emerald/parchment editorial design system by mapping page-specific tokens to the shared token set so the review page reads like the rest of the site.  
- Remove the high-contrast grid overlay and unrelated blue-purple accents that caused the review page to appear as a different visual system.  
- Reduce visual density produced by hard 1px borders and heavy drop shadows so the page follows the design system's "No-Line" and tonal-layering guidance.  
- Reduce unnecessary card nesting around major sections so content relies on surface tiers and spacing rather than boxed containers where appropriate.  

### Description
- Remapped the review token layer in `styles.css` (:root `--review-*`) to use shared tokens (`var(--secondary)`, `var(--surface)`, `var(--on-surface)`, etc.) and adjusted related RGBA derivatives for both dark and light variants.  
- Removed the full-viewport grid overlay (`body.review-page::before`) and removed the conflicting flat-header reset so the Library Glow hero is preserved and header styles are scoped to `.review-header--hero`.  
- Replaced many `border: 1px solid var(--border)` usages and heavy external `box-shadow` rules with ghost-outline inset treatments (`inset 0 0 0 1px color-mix(...)`) and softer tonal/background shifts for checklist rows, formula cards, video links, quiz controls, stat cards, progress items, and history rows.  
- De-boxed Schedule, Formulas, and Videos tabs by removing outer `.card.review-card` wrappers and converting those areas to `section.review-section.review-section--open` so separation is provided by spacing and surface tier rather than an extra card; consolidated print rules into the shared stylesheet and removed redundant page-level overrides from `130Test2.html`.  

### Testing
- Ran `git diff --check` to verify whitespace / index issues and found no problems (check passed).  
- Parsed the updated HTML with Python's `html.parser` to ensure the document is syntactically valid (the parser feed completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a83c22188331917de2c8ec06d0cc)