### PR TITLE
Refine homepage copy for clarity and concision

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,49 +52,49 @@
 <header class="page-shell-header home-shell-header">
   <div class="container">
     <div class="page-shell-header__eyebrow">Home</div>
-    <h1>Prof. Volk's digital curator space for learning, tools, and thoughtful scholarship.</h1>
-    <p class="subtitle">An editorial gateway to courses, tools, and academic work in mathematics, physics, and engineering.</p>
+    <h1>Course materials, tools, and academic resources for mathematics, physics, and engineering.</h1>
+    <p class="subtitle">Use this site to find class pages, study support, and professional information in one place.</p>
   </div>
 </header>
 
   <main class="container page-shell-main home-main">
     <section class="home-stage home-hero feature-section" aria-labelledby="home-hero-title">
       <div class="hero-copy-column">
-        <p class="home-kicker">Digital Curator</p>
-        <h2 id="home-hero-title">A curated learning site for mathematics, physics, and engineering.</h2>
-        <p class="hero-lead">Built for students, colleagues, and independent learners. Start in Learn to enter through the course material first.</p>
+        <p class="home-kicker">Start here</p>
+        <h2 id="home-hero-title">Find course pages, study tools, and teaching resources.</h2>
+        <p class="hero-lead">Most visitors should begin with Learn for course content and guided review, then use the tools and profile pages as needed.</p>
         <div class="hero-cta-cluster" aria-label="Primary actions">
-          <a href="learn.html" class="button">Start in Learn</a>
-          <a href="projects.html" class="button button-secondary">See the tools</a>
+          <a href="learn.html" class="button">Browse courses</a>
+          <a href="projects.html" class="button button-secondary">Open tools</a>
         </div>
         <p class="hero-tertiary-wrap"><a href="CV.html" class="hero-tertiary-link">View CV and teaching profile</a></p>
       </div>
 
       <article class="highlighted-destination-card">
         <p class="home-kicker">Recommended start</p>
-        <h3>Start with the course pathway.</h3>
-        <p>Learn is the front door because it gathers the core course pages, study sequences, and guided explanations in one place.</p>
+        <h3>Begin with Learn.</h3>
+        <p>Learn brings together the main course pages, review material, and step-by-step explanations in one place.</p>
         <ul class="supporting-link-list">
-          <li>Begin with organized course hubs</li>
-          <li>Continue into review and reference pages</li>
-          <li>Branch into tools or background once you are oriented</li>
+          <li>Go directly to course home pages</li>
+          <li>Move into review and reference material</li>
+          <li>Use tools after you have the course context</li>
         </ul>
-        <a href="learn.html" class="button">Enter Learn</a>
+        <a href="learn.html" class="button">Go to Learn</a>
       </article>
     </section>
 
     <section class="home-stage home-start-here" aria-labelledby="featured-paths-title">
       <div class="band-intro home-start-here__intro">
-        <p class="home-kicker">Main paths</p>
-        <h2 id="featured-paths-title">Three paths, one clear priority.</h2>
-        <p>Learn is the primary destination for most visitors. Projects &amp; tools exists for applied support, and the CV exists for professional context.</p>
+        <p class="home-kicker">Main sections</p>
+        <h2 id="featured-paths-title">Three sections with a clear starting point.</h2>
+        <p>Learn is the best place to start for most visitors. Tools adds practical support, and the CV provides background and professional information.</p>
       </div>
       <div class="supporting-card-grid home-start-grid">
         <article class="supporting-card supporting-card--feature">
           <div class="card-icon" aria-hidden="true">📚</div>
           <p class="home-kicker">Primary path</p>
           <h3>Learn</h3>
-          <p>Choose this path for the main body of teaching material: courses, study guides, and structured review.</p>
+          <p>Use Learn for course pages, study guides, and structured review.</p>
           <a href="learn.html">Browse Learn</a>
         </article>
         <div class="home-start-sidebar">
@@ -102,7 +102,7 @@
             <div class="card-icon" aria-hidden="true">🔧</div>
             <p class="home-kicker">Support path</p>
             <h3>Projects &amp; tools</h3>
-            <p>Choose this path for calculators, interactive tools, and project work that support what you study in Learn.</p>
+            <p>Use Tools for calculators, interactive resources, and project work that support your coursework.</p>
             <a href="projects.html">Explore tools and projects</a>
           </article>
           <p class="start-here-secondary-link"><span>Background path</span> <a href="CV.html">Read the CV and profile</a></p>
@@ -113,20 +113,20 @@
     <section class="home-stage home-support-strip" aria-labelledby="beyond-site-title">
       <div class="home-support-strip__media">
         <p class="home-kicker">Beyond the site</p>
-        <h2 id="beyond-site-title">Continue beyond the site through video, community, and contact.</h2>
-        <p>Visit the YouTube channel for lesson-based follow-up, then use the community and contact links below when you want to stay connected off-site.</p>
+        <h2 id="beyond-site-title">Keep in touch through video, community, and email.</h2>
+        <p>Use the YouTube channel for additional lesson support, and use the links below to stay connected outside the site.</p>
         <a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">Visit the channel</a>
       </div>
       <div class="home-support-strip__mission">
-        <p class="home-kicker">Follow-up</p>
-        <p>These external links belong in the final supporting layer of the homepage: useful after the main navigation choice, never in place of it.</p>
+        <p class="home-kicker">Quick follow-up</p>
+        <p>These links are here when you want extra support or a direct way to get in touch.</p>
       </div>
     </section>
 
     <section class="home-stage home-community-links" aria-labelledby="community-links-title">
       <div>
         <p class="home-kicker">Community &amp; contact</p>
-        <h2 id="community-links-title">Stay connected off-site.</h2>
+        <h2 id="community-links-title">Stay connected.</h2>
       </div>
       <div class="community-link-row">
         <a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Liberty University Math Club</a>


### PR DESCRIPTION
### Motivation
- Replace mockup-style, editorial language with practical, concise site copy that reads like a finished academic resource.
- Make the site structure and entry point explicit by clarifying that `Learn` is the primary starting place for most visitors.
- Simplify call-to-action labels and supporting text so navigation choices are clearer and more actionable.

### Description
- Rewrote the header `h1` and subtitle to state the site's purpose as course materials, tools, and academic resources.
- Tightened the hero section by changing the kicker, `h2`, and lead paragraph and simplifying the primary CTAs to `Browse courses` and `Open tools`.
- Updated the recommended-start card and supporting bullet list to clearly direct users to `Learn` and shortened the CTA to `Go to Learn`.
- Adjusted wording in the main sections, tools description, off-site support, and community/contact copy for concise, practical phrasing across `index.html`.

### Testing
- Validated the modified `index.html` with Python's `html.parser` to ensure the document parses without errors, which passed.
- Inspected the generated diff to confirm the changes are limited to copy updates in `index.html`, which matched expectations and passed.
- Prepared PR metadata describing the change and included the HTML parse check as an automated verification step, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a968c77c83318713f0e0dc7d81e4)