### PR TITLE
Move DMS conversions into Quiz 7 practice generator

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -1325,11 +1325,11 @@
 </button>
 <button class="btn-secondary review-option-button" onclick="startMockQuiz(7)">
 <div class="review-option-title">Quiz 7 — Triangles, Lines &amp; Areas (8 Questions)</div>
-<div class="review-option-copy">Similar Triangles, Parallel Lines, Triangle/Polygon Areas, DMS Conversions</div>
+<div class="review-option-copy">Similar Triangles, Parallel Lines, Triangle/Polygon Areas, Degrees ↔ DMS Conversions</div>
 </button>
 <button class="btn-secondary review-option-button" onclick="startMockQuiz(8)">
 <div class="review-option-title">Quiz 8 — Circles</div>
-<div class="review-option-copy">DMS, Radians, Arcs, Sectors, Speed, Circle Theorems</div>
+<div class="review-option-copy">Radians, Arcs, Sectors, Speed, Circle Theorems</div>
 </button>
 </div>
 </div>
@@ -2154,7 +2154,7 @@
             }
         },
         {
-            id: 'dms', section: 'Circles',
+            id: 'dms', section: 'Triangles, Lines & Areas',
             label: 'Convert DMS',
             generate: () => {
                 const deg = (Math.random() * 80 + 10).toFixed(4);
@@ -2180,7 +2180,7 @@
             }
         },
         {
-            id: 'dms_to_dec', section: 'Circles',
+            id: 'dms_to_dec', section: 'Triangles, Lines & Areas',
             label: 'DMS → Decimal Degrees',
             generate: () => {
                 const d = Math.floor(Math.random() * 80) + 10;


### PR DESCRIPTION
### Motivation
- Prevent DMS conversion generators from being drawn by the Circles quiz while keeping them available to the fixed Quiz 7 blueprint. 
- Keep the quiz option labels consistent with the underlying generator membership so the UI accurately reflects available question types.

### Description
- Updated the quiz option copy in `130Test2.html` so Quiz 7 advertises "Degrees ↔ DMS Conversions" and Quiz 8 no longer lists DMS. 
- Reassigned the two generators `dms` and `dms_to_dec` in `130Test2.html` from section `'Circles'` to `'Triangles, Lines & Areas'`, so Quiz 8's section-based sampling will not include them. 
- No generator logic or question formats were changed beyond the section membership and UI text adjustments.

### Testing
- Ran a repository search (`rg`) to locate relevant quiz labels and generator definitions and confirmed the expected locations were updated; the search completed successfully. 
- Executed a small Python verification script that asserts the `dms` and `dms_to_dec` generators are now assigned to `Triangles, Lines & Areas` and that the option copy for Quiz 8 no longer mentions DMS, and the script passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b24c10dc8331a4e5b33b074cb1eb)