### PR TITLE
Add hash-based router for lab summary sections

### DIFF
--- a/courses/Lab_Report_Summary.html
+++ b/courses/Lab_Report_Summary.html
@@ -293,6 +293,17 @@
     border-top: 1px solid var(--border);
   }
 
+
+  .lab-section.is-hidden {
+    display: none;
+  }
+
+  nav.toc a.is-active {
+    color: var(--text);
+    text-decoration: underline;
+    text-underline-offset: 0.16em;
+  }
+
   @media (max-width: 600px) {
     .page-header h1 { font-size: 1.6rem; }
     nav.toc ol { flex-direction: column; gap: 0.35rem; }
@@ -624,6 +635,51 @@
 <footer>
   Carolina Distance Learning — Physics Lab Report Reference
 </footer>
+
+
+<script>
+  (function () {
+    const sections = Array.from(document.querySelectorAll('.lab-section'));
+    const links = Array.from(document.querySelectorAll('nav.toc a[href^="#"]'));
+
+    if (!sections.length) return;
+
+    const validIds = new Set(sections.map((section) => section.id));
+
+    function getTargetId() {
+      const hash = window.location.hash.replace('#', '');
+      if (hash && validIds.has(hash)) return hash;
+      return sections[0].id;
+    }
+
+    function render() {
+      const targetId = getTargetId();
+
+      sections.forEach((section) => {
+        const isActive = section.id === targetId;
+        section.classList.toggle('is-hidden', !isActive);
+        section.setAttribute('aria-hidden', String(!isActive));
+      });
+
+      links.forEach((link) => {
+        const isActive = link.getAttribute('href') === `#${targetId}`;
+        link.classList.toggle('is-active', isActive);
+        if (isActive) {
+          link.setAttribute('aria-current', 'page');
+        } else {
+          link.removeAttribute('aria-current');
+        }
+      });
+
+      if (window.location.hash.replace('#', '') !== targetId) {
+        window.location.replace(`#${targetId}`);
+      }
+    }
+
+    window.addEventListener('hashchange', render);
+    render();
+  })();
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Keep `courses/Lab_Report_Summary.html` as a single-page file but make navigation behave like a simple SPA so only one `.lab-section` is visible at a time. 
- Improve usability and accessibility by reflecting the active section in the URL and the table-of-contents state.

### Description
- Add a small CSS utility `.lab-section.is-hidden` to hide inactive sections and a `nav.toc a.is-active` rule to visually indicate the active TOC link. 
- Insert an inline hash router script that validates `window.location.hash` against available section IDs, shows the matching `.lab-section`, sets `aria-hidden` on hidden sections, and updates `aria-current` on the active TOC link. 
- Router listens for `hashchange`, defaults to the first section when the hash is missing or invalid, and avoids splitting the original HTML into multiple files by keeping everything in `courses/Lab_Report_Summary.html`.

### Testing
- Attempted HTML validation with `xmllint --html --noout courses/Lab_Report_Summary.html`, but the `xmllint` tool is not available in the environment so validation could not be completed. 
- No unit tests exist for this static page; the change is limited to CSS and a lightweight client-side script that degrades gracefully when JavaScript is disabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c493f534cc8331bc1bcfa359a2a619)