### PR TITLE
Add Overview/Home button and make landing items clickable in Lab_Report_Summary

### DIFF
--- a/courses/Lab_Report_Summary.html
+++ b/courses/Lab_Report_Summary.html
@@ -384,6 +384,21 @@
     cursor: not-allowed;
   }
 
+  .nav-buttons {
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+  }
+
+  .step-nav button.home-btn {
+    background: var(--surface);
+    color: var(--accent);
+  }
+
+  .step-nav button.home-btn:hover {
+    background: var(--accent-light);
+  }
+
   .step-indicator {
     font-size: 0.85rem;
     color: var(--text-muted);
@@ -395,6 +410,19 @@
     .page-header h1 { font-size: 1.6rem; }
     nav.toc ol { flex-direction: column; gap: 0.35rem; }
     .lab-body { padding: 1.25rem; }
+    .step-nav-inner { flex-wrap: wrap; }
+    .nav-buttons { width: 100%; justify-content: space-between; }
+  }
+
+  .assignment-order ol li a {
+    color: var(--accent);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .assignment-order ol li a:hover {
+    text-decoration: underline;
+    text-underline-offset: 0.16em;
   }
 
   @media print {
@@ -412,9 +440,14 @@
 
 <nav class="step-nav" aria-label="Assignment navigation">
   <div class="step-nav-inner">
-    <button type="button" id="prevBtn">← Back</button>
+    <div class="nav-buttons">
+      <button type="button" id="prevBtn">← Back</button>
+      <button type="button" id="homeBtn" class="home-btn">Overview ⌂</button>
+    </div>
     <div class="step-indicator" id="stepIndicator">Step 1 of 12</div>
-    <button type="button" id="nextBtn">Forward →</button>
+    <div class="nav-buttons">
+      <button type="button" id="nextBtn">Forward →</button>
+    </div>
   </div>
 </nav>
 
@@ -426,17 +459,17 @@
     <p>Landing page: start here, then use Forward and Back to move one assignment at a time.</p>
   </header>
   <ol>
-    <li><strong>Course Requirements Checklist</strong><span>Course Overview Module</span></li>
-    <li><strong>Quiz: Introduction to Graphing and Lab Safety</strong><span>Module 1: Week 1 - Introduction to Graphing and Lab Safety</span></li>
-    <li><strong>Lab Report: Kinematics</strong><span>Module 2: Week 2 - Kinematics</span></li>
-    <li><strong>Short Answer Response: Kinematics</strong><span>Module 2: Week 2 - Kinematics</span></li>
-    <li><strong>Lab Report: Projectile Motion</strong><span>Module 3: Week 3 - Projectile Motion</span></li>
-    <li><strong>Short Answer Response: Newton's Laws</strong><span>Module 4: Week 4 - Newton's Second Law</span></li>
-    <li><strong>Quiz: Newton's Second Law</strong><span>Module 4: Week 4 - Newton's Second Law</span></li>
-    <li><strong>Lab Report: Sound and Resonance</strong><span>Module 5: Week 5 - Sound and Resonance</span></li>
-    <li><strong>Lab Report: Series and Parallel Circuits</strong><span>Module 6: Week 6 - Series and Parallel Circuits</span></li>
-    <li><strong>Lab Report: Magnetism</strong><span>Module 7: Week 7 - Magnetism</span></li>
-    <li><strong>Quiz: Refraction of Light</strong><span>Module 8: Week 8 - Refraction of Light</span></li>
+    <li><a href="#course-requirements"><strong>Course Requirements Checklist</strong></a><span>Course Overview Module</span></li>
+    <li><a href="#intro-quiz"><strong>Quiz: Introduction to Graphing and Lab Safety</strong></a><span>Module 1: Week 1 - Introduction to Graphing and Lab Safety</span></li>
+    <li><a href="#kinematics"><strong>Lab Report: Kinematics</strong></a><span>Module 2: Week 2 - Kinematics</span></li>
+    <li><a href="#kinematics-short-answer"><strong>Short Answer Response: Kinematics</strong></a><span>Module 2: Week 2 - Kinematics</span></li>
+    <li><a href="#projectile"><strong>Lab Report: Projectile Motion</strong></a><span>Module 3: Week 3 - Projectile Motion</span></li>
+    <li><a href="#newton-short-answer"><strong>Short Answer Response: Newton's Laws</strong></a><span>Module 4: Week 4 - Newton's Second Law</span></li>
+    <li><a href="#newton-quiz"><strong>Quiz: Newton's Second Law</strong></a><span>Module 4: Week 4 - Newton's Second Law</span></li>
+    <li><a href="#sound"><strong>Lab Report: Sound and Resonance</strong></a><span>Module 5: Week 5 - Sound and Resonance</span></li>
+    <li><a href="#circuits"><strong>Lab Report: Series and Parallel Circuits</strong></a><span>Module 6: Week 6 - Series and Parallel Circuits</span></li>
+    <li><a href="#magnetism"><strong>Lab Report: Magnetism</strong></a><span>Module 7: Week 7 - Magnetism</span></li>
+    <li><a href="#refraction-quiz"><strong>Quiz: Refraction of Light</strong></a><span>Module 8: Week 8 - Refraction of Light</span></li>
   </ol>
 </section>
 
@@ -872,6 +905,7 @@
     const stepIndicator = document.getElementById('stepIndicator');
     const prevBtn = document.getElementById('prevBtn');
     const nextBtn = document.getElementById('nextBtn');
+    const homeBtn = document.getElementById('homeBtn');
 
     if (!sections.length) return;
 
@@ -909,6 +943,9 @@
 
     prevBtn.addEventListener('click', () => goTo(-1));
     nextBtn.addEventListener('click', () => goTo(1));
+    homeBtn.addEventListener('click', () => {
+      window.location.hash = '#overview';
+    });
     window.addEventListener('hashchange', render);
     render();
   })();


### PR DESCRIPTION
### Motivation
- Improve navigation so users can jump directly from the landing overview to any assignment section and return to the overview from any step.

### Description
- Added a new `Overview`/home button in the step navigation and associated styling (`.nav-buttons`, `.home-btn`) to support returning to the landing page from any step.
- Converted each item on the Assignment Overview list into an anchor linking to its section hash (for example `href="#kinematics"`) so the landing page entries are clickable.
- Adjusted responsive CSS to accommodate the new buttons on small screens and added hover styling for overview links.
- Wired the new `homeBtn` into the existing hash-based navigation script so clicking the button sets the hash to `#overview` and reuses the existing render logic.

### Testing
- Verified presence of new elements and anchors by searching the updated HTML and confirming `id="homeBtn"` and section `href` entries were present (success).
- Performed a lightweight HTML parse using Python's `html.parser` to ensure the file is syntactically consumable (success).
- Attempted `xmllint --html --noout` but the `xmllint` utility is not available in the environment (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4ba990ae48331909fdf379f44613c)