### PR TITLE
Simplify PHYS 103 assignment guide navigation and clean up rubrics/content

### DIFF
--- a/courses/103LUOAssignmentGuide.html
+++ b/courses/103LUOAssignmentGuide.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Physics 103 Liberty University Online Assignment Guide by Prof. Andrew H. Volk</title>
+<title>PHYS 103 Assignment Guide</title>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700&family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,700;1,9..144,400&display=swap" rel="stylesheet">
 <style>
   :root {
@@ -384,46 +384,6 @@
     cursor: not-allowed;
   }
 
-  .nav-controls {
-    display: flex;
-    gap: 0.65rem;
-    align-items: center;
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-
-  .jump-control {
-    display: inline-flex;
-    gap: 0.35rem;
-    align-items: center;
-    color: var(--text-muted);
-    font-size: 0.82rem;
-  }
-
-  .jump-control select {
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    background: var(--surface);
-    color: var(--text);
-    padding: 0.35rem 0.45rem;
-    max-width: 245px;
-    font-size: 0.82rem;
-  }
-
-  .show-all-toggle {
-    border: 1px solid var(--accent);
-    background: var(--surface);
-    color: var(--accent);
-    border-radius: 8px;
-    padding: 0.38rem 0.72rem;
-    font-weight: 600;
-    cursor: pointer;
-  }
-
-  body.show-all-mode .show-all-toggle {
-    background: var(--accent-light);
-  }
-
   .nav-buttons {
     display: flex;
     gap: 0.6rem;
@@ -458,9 +418,6 @@
     .lab-body { padding: 1.25rem; }
     .step-nav-inner { flex-wrap: wrap; }
     .nav-buttons { width: 100%; justify-content: space-between; }
-    .nav-controls { width: 100%; justify-content: space-between; }
-    .jump-control { width: 100%; justify-content: space-between; }
-    .jump-control select { flex: 1; max-width: none; }
   }
 
   .assignment-order ol li a {
@@ -490,7 +447,7 @@
 <body>
 
 <header class="page-header">
-  <h1>Physics 103 Liberty University Online Assignment Guide by Prof. Andrew H. Volk</h1>
+  <h1>PHYS 103 Assignment Guide</h1>
   <p>Assignment overview, pacing navigation, submissions, and supply checklists</p>
 </header>
 
@@ -501,37 +458,11 @@
       <button type="button" id="homeBtn" class="home-btn">Overview ⌂</button>
       <button type="button" id="nextBtn">Forward →</button>
     </div>
-    <div class="step-indicator" id="stepIndicator">Step 1 of 12</div>
-    <div class="nav-controls">
-      <label for="jumpSelect" class="jump-control">Jump to assignment
-        <select id="jumpSelect" aria-label="Jump to assignment"></select>
-      </label>
-      <button type="button" id="showAllBtn" class="show-all-toggle" aria-pressed="false">Show All Sections</button>
-    </div>
+    <div class="step-indicator" id="stepIndicator">Step 1 of 11</div>
   </div>
 </nav>
 
 <main>
-
-<section class="assignment-order page-step" id="overview">
-  <header>
-    <h2>Assignment Overview</h2>
-    <p>Landing page: start here, then use Forward and Back to move one assignment at a time.</p>
-  </header>
-  <ol>
-    <li><a href="#course-requirements"><strong>Course Requirements Checklist</strong></a><span>Course Overview Module</span></li>
-    <li><a href="#intro-quiz"><strong>Quiz: Introduction to Graphing and Lab Safety</strong></a><span>Module 1: Week 1 - Introduction to Graphing and Lab Safety (Open Book / Open Notes)</span></li>
-    <li><a href="#kinematics"><strong>Lab Report: Kinematics</strong></a><span>Module 2: Week 2 - Kinematics</span></li>
-    <li><a href="#kinematics-short-answer"><strong>Short Answer Response: Kinematics</strong></a><span>Module 2: Week 2 - Kinematics</span></li>
-    <li><a href="#projectile"><strong>Lab Report: Projectile Motion</strong></a><span>Module 3: Week 3 - Projectile Motion</span></li>
-    <li><a href="#newton-short-answer"><strong>Short Answer Response: Newton's Laws</strong></a><span>Module 4: Week 4 - Newton's Second Law</span></li>
-    <li><a href="#newton-quiz"><strong>Quiz: Newton's Second Law</strong></a><span>Module 4: Week 4 - Newton's Second Law (Open Book / Open Notes)</span></li>
-    <li><a href="#sound"><strong>Lab Report: Sound and Resonance</strong></a><span>Module 5: Week 5 - Sound and Resonance</span></li>
-    <li><a href="#circuits"><strong>Lab Report: Series and Parallel Circuits</strong></a><span>Module 6: Week 6 - Series and Parallel Circuits</span></li>
-    <li><a href="#magnetism"><strong>Lab Report: Magnetism</strong></a><span>Module 7: Week 7 - Magnetism</span></li>
-    <li><a href="#refraction-quiz"><strong>Quiz: Refraction of Light</strong></a><span>Module 8: Week 8 - Refraction of Light (Open Book / Open Notes)</span></li>
-  </ol>
-</section>
 
 <section class="lab-section page-step" id="course-requirements">
   <div class="lab-header">
@@ -640,12 +571,12 @@
       <h3>Lab Report: Kinematics Grading Rubric</h3>
       <div class="submit-note">Download: Lab Report: Kinematics Grading Rubric</div>
       <ul>
-        <li><strong>Activity 1: Final Graph (14 pts)</strong> — Advanced (14 to &gt;12.0 pts): Dependent and Independent variables are clearly identified, header and axis are labeled properly, and meaningful data is presented. Proficient (12 to &gt;9.0 pts): Variables may be unidentified, header/axis may have 1 mistake, and data may have an error. Developing (9 to &gt;0.0 pts): Variables are unclear, header/axis may have more than 1 mistake, and data may have multiple errors. Not Present (0 pts).</li>
-        <li><strong>Activity 2: Data Table 1 (14 pts)</strong> — Advanced (14 to &gt;12.0 pts): All observations are conceptually related to row headings and scientifically accurate. Proficient (12 to &gt;9.0 pts): Some entries are not conceptually related; up to 2 data entries are scientifically inaccurate. Developing (9 to &gt;0.0 pts): Some entries are not conceptually related; more than 2 data entries are scientifically inaccurate. Not Present (0 pts).</li>
-        <li><strong>Photos of Graphs and Setups (14 pts)</strong> — Advanced (14 to &gt;12.0 pts): Photos are accurate and clear. Proficient (12 to &gt;9.0 pts): Photos are accurate but may have up to 2 errors and are not very clear. Developing (9 to &gt;0.0 pts): Photos may have more than 2 errors and are not clear. Not Present (0 pts).</li>
-        <li><strong>Activity 3: Data Table 3 (14 pts)</strong> — Advanced (14 to &gt;12.0 pts): All observations are conceptually related to row headings and scientifically accurate. Proficient (12 to &gt;9.0 pts): Some entries are not conceptually related to row headings; up to 2 data entries are scientifically inaccurate. Developing (9 to &gt;0.0 pts): Some entries are not conceptually related; more than 2 data entries are scientifically inaccurate. Not Present (0 pts).</li>
-        <li><strong>Activity 3: Graph of Displacement vs Time Squared (14 pts)</strong> — Advanced (14 to &gt;12.0 pts): Dependent and Independent variables are clearly identified, header and axis are labeled properly, and meaningful data is presented. Proficient (12 to &gt;9.0 pts): Variables may be unidentified, header/axis may have 1 mistake, and data may have an error. Developing (9 to &gt;0.0 pts): Variables are unclear, header/axis may have more than 1 mistake, and data may have multiple errors. Not Present (0 pts).</li>
-        <li><strong>Mechanics (30 pts)</strong> — Advanced (30 to &gt;12.0 pts): Grammar, spelling, and punctuation are correct, entries are clearly visible, and name is included on tables and graphs. Proficient (12 to &gt;9.0 pts): Several grammatical or spelling errors are present, entries are difficult to read, and name is not on tables or graphs. Developing (9 to &gt;0.0 pts): Multiple grammatical and spelling errors are present, entries/data are not legible, and name is not on tables or graphs. Not Present (0 pts).</li>
+        <li><strong>Activity 1: Final Graph (14 pts)</strong> — Advanced: Dependent and Independent variables are clearly identified, header and axis are labeled properly, and meaningful data is presented.</li>
+        <li><strong>Activity 2: Data Table 1 (14 pts)</strong> — Advanced: All observations are conceptually related to row headings and scientifically accurate.</li>
+        <li><strong>Photos of Graphs and Setups (14 pts)</strong> — Advanced: Photos are accurate and clear.</li>
+        <li><strong>Activity 3: Data Table 3 (14 pts)</strong> — Advanced: All observations are conceptually related to row headings and scientifically accurate.</li>
+        <li><strong>Activity 3: Graph of Displacement vs Time Squared (14 pts)</strong> — Advanced: Dependent and Independent variables are clearly identified, header and axis are labeled properly, and meaningful data is presented.</li>
+        <li><strong>Mechanics (30 pts)</strong> — Advanced: Grammar, spelling, and punctuation are correct, entries are clearly visible, and name is included on tables and graphs.</li>
       </ul>
       <div class="tip-box"><strong>Total Points:</strong> 100</div>
     </div>
@@ -671,13 +602,13 @@
     <div class="activity">
       <h3>Grading Rubric</h3>
       <ul>
-        <li><strong>Answer 1 — Explanation (20 pts):</strong> Advanced (20 to &gt;15.0 pts): The student fully answers the question. Proficient (15 to &gt;10.0 pts): The student partially answers the question. Developing (10 to &gt;0.0 pts): The student insufficiently answers the question. Not Present (0 pts).</li>
-        <li><strong>Answer 2 — Explanation (20 pts):</strong> Advanced (20 to &gt;15.0 pts): The student fully answers the question. Proficient (15 to &gt;10.0 pts): The student partially answers the question. Developing (10 to &gt;0.0 pts): The student insufficiently answers the question. Not Present (0 pts).</li>
-        <li><strong>Answer 3 — Explanation (20 pts):</strong> Advanced (20 to &gt;15.0 pts): The student fully answers the question. Proficient (15 to &gt;10.0 pts): The student partially answers the question. Developing (10 to &gt;0.0 pts): The student insufficiently answers the question. Not Present (0 pts).</li>
-        <li><strong>Answer 4 — Explanation (20 pts):</strong> Advanced (20 to &gt;15.0 pts): The student fully answers the question. Proficient (15 to &gt;10.0 pts): The student partially answers the question. Developing (10 to &gt;0.0 pts): The student insufficiently answers the question. Not Present (0 pts).</li>
-        <li><strong>Answer 5 — Explanation (20 pts):</strong> Advanced (20 to &gt;15.0 pts): The student fully answers the question. Proficient (15 to &gt;10.0 pts): The student partially answers the question. Developing (10 to &gt;0.0 pts): The student insufficiently answers the question. Not Present (0 pts).</li>
+        <li><strong>Answer 1 — Explanation (20 pts):</strong> Advanced: The student fully answers the question.</li>
+        <li><strong>Answer 2 — Explanation (20 pts):</strong> Advanced: The student fully answers the question.</li>
+        <li><strong>Answer 3 — Explanation (20 pts):</strong> Advanced: The student fully answers the question.</li>
+        <li><strong>Answer 4 — Explanation (20 pts):</strong> Advanced: The student fully answers the question.</li>
+        <li><strong>Answer 5 — Explanation (20 pts):</strong> Advanced: The student fully answers the question.</li>
       </ul>
-      <div class="tip-box"><strong>Total Points:</strong> 10</div>
+      <div class="tip-box"><strong>Total Points:</strong> 100</div>
     </div>
   </div>
 </section>
@@ -975,7 +906,6 @@
 <script>
   (function () {
     const sectionIds = [
-      'overview',
       'course-requirements',
       'intro-quiz',
       'kinematics',
@@ -993,23 +923,15 @@
     const prevBtn = document.getElementById('prevBtn');
     const nextBtn = document.getElementById('nextBtn');
     const homeBtn = document.getElementById('homeBtn');
-    const showAllBtn = document.getElementById('showAllBtn');
-    const jumpSelect = document.getElementById('jumpSelect');
 
     if (!sections.length) return;
 
     const validIds = new Set(sections.map((section) => section.id));
-    let showAll = false;
 
     function getTargetIndex() {
       const hash = window.location.hash.replace('#', '');
       if (hash && validIds.has(hash)) return sectionIds.indexOf(hash);
       return 0;
-    }
-
-    function syncSelect(index) {
-      if (!jumpSelect) return;
-      jumpSelect.value = sectionIds[index];
     }
 
     function render() {
@@ -1018,22 +940,13 @@
 
       sections.forEach((section) => {
         const isActive = section.id === targetId;
-        const shouldShow = showAll || isActive;
-        section.classList.toggle('is-hidden', !shouldShow);
-        section.setAttribute('aria-hidden', String(!shouldShow));
+        section.classList.toggle('is-hidden', !isActive);
+        section.setAttribute('aria-hidden', String(!isActive));
       });
 
-      document.body.classList.toggle('show-all-mode', showAll);
-      showAllBtn.setAttribute('aria-pressed', String(showAll));
-      showAllBtn.textContent = showAll ? 'Single Section Mode' : 'Show All Sections';
-
-      stepIndicator.textContent = showAll
-        ? `Expanded review mode · ${sections.length} sections visible`
-        : `Step ${targetIndex + 1} of ${sections.length}`;
-
-      prevBtn.disabled = showAll || targetIndex === 0;
-      nextBtn.disabled = showAll || targetIndex === sections.length - 1;
-      syncSelect(targetIndex);
+      stepIndicator.textContent = `Step ${targetIndex + 1} of ${sections.length}`;
+      prevBtn.disabled = targetIndex === 0;
+      nextBtn.disabled = targetIndex === sections.length - 1;
 
       if (window.location.hash.replace('#', '') !== targetId) {
         window.location.replace(`#${targetId}`);
@@ -1046,33 +959,13 @@
       window.location.hash = `#${sectionIds[next]}`;
     }
 
-    sections.forEach((section) => {
-      const label = section.querySelector('h2')?.textContent?.trim() || section.id;
-      const option = document.createElement('option');
-      option.value = section.id;
-      option.textContent = label;
-      jumpSelect.appendChild(option);
-    });
-
     prevBtn.addEventListener('click', () => goTo(-1));
     nextBtn.addEventListener('click', () => goTo(1));
     homeBtn.addEventListener('click', () => {
-      showAll = false;
-      window.location.hash = '#overview';
-    });
-
-    jumpSelect.addEventListener('change', (event) => {
-      showAll = false;
-      window.location.hash = `#${event.target.value}`;
-    });
-
-    showAllBtn.addEventListener('click', () => {
-      showAll = !showAll;
-      render();
+      window.location.hash = `#${sectionIds[0]}`;
     });
 
     document.addEventListener('keydown', (event) => {
-      if (showAll) return;
       if (event.key === 'ArrowLeft') {
         event.preventDefault();
         goTo(-1);
@@ -1081,7 +974,7 @@
         goTo(1);
       } else if (event.key === 'Home') {
         event.preventDefault();
-        window.location.hash = '#overview';
+        window.location.hash = `#${sectionIds[0]}`;
       } else if (event.key === 'End') {
         event.preventDefault();
         window.location.hash = `#${sectionIds[sections.length - 1]}`;


### PR DESCRIPTION
### Motivation
- Streamline the linear navigation experience by removing the multi-section "overview" landing and the "Show All / Jump" controls to simplify step-based browsing.
- Reduce UI complexity in the responsive layout and JavaScript by removing unused controls and show-all mode logic.
- Clean up rubric copy and correct total-points metadata for clarity and consistency.

### Description
- Update the document title and header to `PHYS 103 Assignment Guide` and remove the standalone `overview` section from the page flow.
- Remove CSS rules for `.nav-controls`, `.jump-control`, and `.show-all-toggle` and related responsive adjustments to eliminate the removed controls' styles.
- Simplify the navigation JavaScript by removing `showAll`, `showAllBtn`, `jumpSelect`, and `syncSelect` logic, update `sectionIds` (now 11 sections), and adjust `prev/next/home` behaviors and keyboard handling to target the first section in `sectionIds` instead of `#overview`.
- Simplify grading rubric copy by stripping tiered score ranges and standardizing items to single-line "Advanced" descriptions, and fix the `Total Points` for the kinematics short-answer section from `10` to `100`.
- Update the step indicator calculation to `Step X of Y` and ensure sections are shown/hidden based solely on the active section.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4c86dfaa0833187c81ef9c23fcf3d)