### PR TITLE
Add Kinematics short-answer support link to LUO assignment guide

### DIFF
--- a/courses/103LUOAssignmentGuide.html
+++ b/courses/103LUOAssignmentGuide.html
@@ -587,6 +587,7 @@
         <li>Use the Canvas assignment page for the exact 5 prompts and submission details.</li>
       </ul>
       <div class="tip-box"><strong>Work format option:</strong> You may answer all 5 questions on paper and submit clear photos of your work. This is often easier when showing math steps.</div>
+      <div class="tip-box"><strong>Helpful resource:</strong> If you want extra help understanding the equations and concepts, review <a href="/projects/PHYS103LUO/KinematicsShortAnswer.html" target="_blank" rel="noopener noreferrer">Kinematics Short Answer Support Page</a>.</div>
       <div class="tip-box quiz-note"><strong>LUO Submission Policy:</strong> The first submission of this assignment will be used for grading. If you need an exception to this policy, please contact your faculty member.</div>
       <div class="submit-note">Submit: Your completed 5-question short-answer response in the Module 2 assignment (typed responses or clear photos of handwritten work are both acceptable), due by 11:59 p.m. (ET) on Monday of Module 2: Week 2.</div>
     </div>


### PR DESCRIPTION
### Motivation
- Provide students an easy-to-find resource for extra help with the kinematics equations and concepts referenced in the Module 2 short-answer assignment.

### Description
- Inserted a new `div` with class `tip-box` linking to `/projects/PHYS103LUO/KinematicsShortAnswer.html` inside the Module 2 "Short Answer Response: Kinematics" section of `courses/103LUOAssignmentGuide.html`.
- No other content or layout changes were made to the file.

### Testing
- Confirmed the new link and callout text are present using `rg -n "Helpful resource|Kinematics Short Answer Support Page|KinematicsShortAnswer.html" courses/103LUOAssignmentGuide.html`, which returned the updated lines.
- Verified the insertion and surrounding context using `nl -ba courses/103LUOAssignmentGuide.html | sed -n '582,596p'`, which displayed the new `tip-box` line.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55b3fe1888331a23fa51606f63449)