### PR TITLE
Remove video placeholder and generalize checklist language on PHYS103LUO kinematics page

### DIFF
--- a/projects/PHYS103LUO/KinematicsShortAnswer.html
+++ b/projects/PHYS103LUO/KinematicsShortAnswer.html
@@ -674,23 +674,12 @@
                 </ol>
             </div>
 
-            <div class="video-placeholder">
-                <h3>🎥 Recommended Video Topics</h3>
-                <p>Search for these topics on educational platforms:</p>
-                <ul style="text-align: left; display: inline-block;">
-                    <li>"Kinematic equations explained"</li>
-                    <li>"Free fall physics problems"</li>
-                    <li>"Vertical projectile motion"</li>
-                    <li>"1D kinematics problem solving"</li>
-                </ul>
-            </div>
-
             <div class="warning-box">
                 <h3>📋 Assignment Submission Checklist</h3>
                 <p>Before submitting, ensure you have:</p>
                 <ul>
-                    <li>☐ Written the kinematic equation for distance: d = v₀t + ½at²</li>
-                    <li>☐ Written the vertical position equation: Y(t) = v₀t - ½gt²</li>
+                    <li>☐ Written the correct kinematic equation for distance</li>
+                    <li>☐ Written the correct vertical position equation</li>
                     <li>☐ Clearly stated your assignment due date (Month and Day)</li>
                     <li>☐ Calculated the building height (6 × Day) with units</li>
                     <li>☐ Shown all steps for calculating fall time</li>


### PR DESCRIPTION
### Motivation

- Remove an unused video placeholder section to declutter the Additional Learning Resources area.
- Make the assignment checklist less prescriptive by removing explicit equation text so students are prompted to write the correct expressions themselves.

### Description

- Deleted the `<div class="video-placeholder">` block containing recommended video topic links from `projects/PHYS103LUO/KinematicsShortAnswer.html`.
- Replaced two checklist items that previously contained explicit kinematic equations with more generic items: `Written the correct kinematic equation for distance` and `Written the correct vertical position equation`.
- Minor file tidying to ensure newline at end of file remains consistent.

### Testing

- Ran HTML validation with `tidy` which reported no errors and completed successfully.
- Ran `htmlhint` against the modified file and it returned no new warnings or failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55b82358483319594ed47010cd153)