### PR TITLE
Standardize KaTeX CSS URL across test HTML files

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -8,7 +8,7 @@
 <title>Math 130 – Test 1 Study Guide</title>
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.js"></script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
 <style>
   /* Page-specific styles only; shared Math 130 review tokens/components live in styles.css. */
 


### PR DESCRIPTION
### Motivation
- Ensure all test HTML pages use a single canonical KaTeX stylesheet URL (jsDelivr) at version `0.16.9` so asset references are consistent across the site.

### Description
- Replaced the CDNJS KaTeX CSS reference in `130Test1.html` with the canonical jsDelivr URL `https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css`, aligning it with `130Test2.html`, `130Test3.html`, and `130Test4.html`.

### Testing
- Ran `rg -n "katex\.min\.css" *.html`, `rg -o "https?://[^\"']*katex\.min\.css" *.html | sort -u`, and `rg -n "katex\.min\.css|integrity=|crossorigin=" *.html` to verify a single unique stylesheet URL remains and that `integrity`/`crossorigin` attributes are consistently absent; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55d6a14988331935c06b9c2ace188)