### PR TITLE
Normalize HTML stylesheet paths to /styles.css

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
 <script src="theme.js"></script>
 <title>Math 130 – Test 1 Study Guide</title>
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/130Test2.html
+++ b/130Test2.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
 <script src="theme.js"></script>
 <title>Math 130 – Test 2 Review (Spring 2026)</title>
 

--- a/130Test3.html
+++ b/130Test3.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
 <script src="theme.js"></script>
     <title>Math 130 – Test 3 Review (Spring 2026)</title>
 

--- a/130Test4.html
+++ b/130Test4.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <title>Math 130 – Final Exam Review</title>
 
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="/styles.css">
 <script src="theme.js"></script>
 
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/404.html
+++ b/404.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found - Prof. Volk's Office</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <script src="theme.js"></script>
 </head>
 <body>

--- a/CV.html
+++ b/CV.html
@@ -7,7 +7,7 @@
     <meta name="author" content="Andrew H. Volk">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Andrew H. Volk - Professional CV</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="theme.js"></script>
 </head>

--- a/Taskflow.html
+++ b/Taskflow.html
@@ -63,7 +63,7 @@
   </style>
 
 
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <script src="theme.js" defer></script>
 </head>
 <body class="tool-page-body">

--- a/Unit3Practice.html
+++ b/Unit3Practice.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Math 130 Unit 3 Practice Questions</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <script src="theme.js"></script>
     <style>
         .practice-page {

--- a/bookings.html
+++ b/bookings.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Book a Meeting with Professor Volk</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="theme.js"></script>
 </head>
 <body>

--- a/chessboard.html
+++ b/chessboard.html
@@ -98,7 +98,7 @@
     </style>
 
 
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <script src="theme.js" defer></script>
 </head>
 <body class="tool-page-body">

--- a/courses/114-module1-summary.html
+++ b/courses/114-module1-summary.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Module 1 Summary: Critical Thinking and Introductory Math Concepts</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
   <style>
     .summary-page {

--- a/courses/basic-statistical-measures.html
+++ b/courses/basic-statistical-measures.html
@@ -421,7 +421,7 @@
       }
     }
   </style>
-    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
   <nav class="top-nav" aria-label="Primary">

--- a/courses/constant-acceleration-lab-manual.html
+++ b/courses/constant-acceleration-lab-manual.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Constant Acceleration Lab Manual | PHYS 103</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/data-sheet-for-electric-circuits.html
+++ b/courses/data-sheet-for-electric-circuits.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Data Sheet for Electric Circuits</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/density-lab-manual.html
+++ b/courses/density-lab-manual.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Density Lab Manual | PHYS 103</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/electrical-circuits-lab-data-sheet.html
+++ b/courses/electrical-circuits-lab-data-sheet.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Electrical Circuits Lab Data Sheet</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/electrical-circuits-lab-manual.html
+++ b/courses/electrical-circuits-lab-manual.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Electrical Circuits Lab Manual | PHYS 103</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
   <style>
 @media print {

--- a/courses/engi220.html
+++ b/courses/engi220.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ENGI 220 Course Resources | Engineering Economy</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/final-exam-review-guide.html
+++ b/courses/final-exam-review-guide.html
@@ -64,7 +64,7 @@
          }
     </style>
 
-    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <script src="../theme.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-800">

--- a/courses/hookes-law-lab-manual.html
+++ b/courses/hookes-law-lab-manual.html
@@ -3,7 +3,7 @@
 <head>
 <title>Hooke's Law Lab Manual</title>
 <script src="../theme.js"></script>
-<link rel="stylesheet" href="../styles.css">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body class="reading-page reading-page--lab">
 <main class="reading-flow">

--- a/courses/knowledgegrowth.html
+++ b/courses/knowledgegrowth.html
@@ -16,7 +16,7 @@
         }
     </style>
 
-    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <script src="../theme.js"></script>
 </head>
 <body class="bg-gray-100">

--- a/courses/latent-heat-of-fusion-lab-manual.html
+++ b/courses/latent-heat-of-fusion-lab-manual.html
@@ -3,7 +3,7 @@
 <head>
 <title>Latent Heat of Fusion Lab Manual</title>
 <script src="../theme.js"></script>
-<link rel="stylesheet" href="../styles.css">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body class="reading-page reading-page--lab">
 <main class="reading-flow">

--- a/courses/math100.html
+++ b/courses/math100.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MATH 100 Course Resources | Fundamentals of Mathematics</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/math105.html
+++ b/courses/math105.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MATH 105 Course Resources | Algebra for Non-STEM Majors</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/math110.html
+++ b/courses/math110.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MATH 110 Course Resources | Intermediate Algebra</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/math114-final-review.html
+++ b/courses/math114-final-review.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MATH 114 Final Review &amp; Exam</title>
-    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="/styles.css" />
     <script src="../theme.js"></script>
   </head>
   <body>

--- a/courses/math114-financial-math.html
+++ b/courses/math114-financial-math.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MATH 114 Financial Math</title>
-    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="/styles.css" />
     <script src="../theme.js"></script>
   </head>
   <body>

--- a/courses/math114-foundations.html
+++ b/courses/math114-foundations.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MATH 114 Orientation &amp; Foundations</title>
-    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="/styles.css" />
     <script src="../theme.js"></script>
   </head>
   <body>

--- a/courses/math114-statistics.html
+++ b/courses/math114-statistics.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MATH 114 Statistics</title>
-    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="/styles.css" />
     <script src="../theme.js"></script>
   </head>
   <body>

--- a/courses/math114-test1.html
+++ b/courses/math114-test1.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MATH 114 Test 1 Review</title>
-    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="/styles.css" />
     <script src="../theme.js"></script>
   </head>
   <body>

--- a/courses/math114-test2.html
+++ b/courses/math114-test2.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MATH 114 Test 2 Review</title>
-    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="/styles.css" />
     <script src="../theme.js"></script>
   </head>
   <body>

--- a/courses/math114-test3.html
+++ b/courses/math114-test3.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MATH 114 Test 3 Review</title>
-    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="/styles.css" />
     <script src="../theme.js"></script>
   </head>
   <body>

--- a/courses/math114.html
+++ b/courses/math114.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MATH 114: Quantitative Reasoning</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/math114Spring26Links.html
+++ b/courses/math114Spring26Links.html
@@ -136,7 +136,7 @@
     }
   </style>
 
-    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/math121.html
+++ b/courses/math121.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MATH 121 Course Resources | College Algebra</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/math130.html
+++ b/courses/math130.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body class="math130-course-page">

--- a/courses/measurement-lab-manual.html
+++ b/courses/measurement-lab-manual.html
@@ -3,7 +3,7 @@
 <head>
 <title>Measurement Lab Manual</title>
 <script src="../theme.js"></script>
-<link rel="stylesheet" href="../styles.css">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body class="reading-page reading-page--lab">
 <main class="reading-flow">

--- a/courses/phys103.html
+++ b/courses/phys103.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PHYS 103 Course Resources | Elements of Physics Lab</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/physics-labs.html
+++ b/courses/physics-labs.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Physics Labs Course Resources | Prof. Volk's Office</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/physlab1.html
+++ b/courses/physlab1.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PHYS 201L/231L Course Resources | Physics Lab 1</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/physlab2.html
+++ b/courses/physlab2.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PHYS 202L/232L Course Resources | Physics Lab 2</title>
-  <link rel="stylesheet" href="../styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>
 </head>
 <body>

--- a/courses/reflection-and-refraction-lab-manual.html
+++ b/courses/reflection-and-refraction-lab-manual.html
@@ -3,7 +3,7 @@
 <head>
 <title>Reflection and Refraction Lab Manual</title>
 <script src="../theme.js"></script>
-<link rel="stylesheet" href="../styles.css">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body class="reading-page reading-page--lab">
 <main class="reading-flow">

--- a/courses/simple-pendulum-lab-manual.html
+++ b/courses/simple-pendulum-lab-manual.html
@@ -3,7 +3,7 @@
 <head>
 <title>Simple Pendulum Lab Manual</title>
 <script src="../theme.js"></script>
-<link rel="stylesheet" href="../styles.css">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body class="reading-page reading-page--lab">
 <main class="reading-flow">

--- a/courses/sound-lab-manual.html
+++ b/courses/sound-lab-manual.html
@@ -3,7 +3,7 @@
 <head>
 <title>Sound Lab Manual</title>
 <script src="../theme.js"></script>
-<link rel="stylesheet" href="../styles.css">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body class="reading-page reading-page--lab">
 <main class="reading-flow">

--- a/courses/spectroscopy-lab-manual.html
+++ b/courses/spectroscopy-lab-manual.html
@@ -3,7 +3,7 @@
 <head>
 <title>Spectroscopy Lab Manual</title>
 <script src="../theme.js"></script>
-<link rel="stylesheet" href="../styles.css">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body class="reading-page reading-page--lab">
 <main class="reading-flow">

--- a/employeepay.html
+++ b/employeepay.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <script src="theme.js" defer></script>
     <title>Who Earns More? Fixed vs. Doubling Pay</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/growth.html
+++ b/growth.html
@@ -17,7 +17,7 @@
     </style>
 
 
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <script src="theme.js" defer></script>
 </head>
 <body class="tool-page-body">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prof. Volk's Office</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="theme.js"></script>
 </head>
 <body>

--- a/infographic.html
+++ b/infographic.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Church and Christianity in 2025</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <script src="theme.js"></script>
 </head>
 <body>

--- a/learn.html
+++ b/learn.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Learning Resources</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="theme.js"></script>
 </head>
 <body>

--- a/projects.html
+++ b/projects.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prof. Volk's Tools</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="/styles.css">
   <script src="theme.js"></script>
 </head>
 <body>

--- a/projects/ResearchMentorship/MathJournals.html
+++ b/projects/ResearchMentorship/MathJournals.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Interactive Undergraduate Math Journals Resource</title>
-    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="/styles.css">
     <script src="../../theme.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
### Motivation
- Ensure the site uses a single site-absolute stylesheet reference so pages resolve the main stylesheet correctly regardless of directory depth. 
- Remove fragile depth-based variants (`styles.css`, `../styles.css`, `../../styles.css`) that complicate maintenance and cause inconsistent resolution. 
- Preserve external/CDN stylesheet links (fonts, KaTeX, icons) unchanged so third-party resources continue to load normally.

### Description
- Replaced depth-dependent local stylesheet references in HTML files with `href="/styles.css"` across site pages (changed in 52 files covering root pages, `courses/`, and nested `projects/`).
- The replacement was performed via a script using a regex to normalize `href="(?:../){0,2}styles.css"` to `href="/styles.css"` while leaving other link tags intact. 
- Did not modify CDN/preconnect/font links or other script references; only the local stylesheet `href` values were normalized.

### Testing
- Searched for remaining depth-based references with `rg -n 'href="\.\./styles\.css"|href="\.\.\/\.\./styles\.css"' --glob '*.html'` and confirmed no matches were found. 
- Verified the change set with `rg -n 'href="(\.\./)+styles\.css"|href="styles\.css"' --glob '*.html'` and confirmed only the normalized `href="/styles.css"` instances remain. 
- Spot-checked representative pages `index.html`, `courses/math114.html`, and `projects/ResearchMentorship/MathJournals.html` and confirmed each now references `href="/styles.css"` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55de943bc833193fe4c31b6835fda)