### PR TITLE
Add CSS loading policy, page-specific CDN comments, and lint CI

### DIFF
--- a/.github/workflows/css-link-lint.yml
+++ b/.github/workflows/css-link-lint.yml
@@ -1,0 +1,22 @@
+name: CSS Link Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  css-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run CSS link lint
+        run: python scripts/check_css_links.py

--- a/130Test1.html
+++ b/130Test1.html
@@ -6,8 +6,10 @@
 <link rel="stylesheet" href="/styles.css">
 <script src="theme.js"></script>
 <title>Math 130 – Test 1 Study Guide</title>
+<!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.js"></script>
+<!-- Page-specific external CSS: KaTeX styles are required for math formula rendering. -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
 <style>
   /* Page-specific styles only; shared Math 130 review tokens/components live in styles.css. */

--- a/130Test2.html
+++ b/130Test2.html
@@ -9,6 +9,7 @@
 <title>Math 130 – Test 2 Review (Spring 2026)</title>
 
 <!-- Fonts -->
+<!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&amp;family=JetBrains+Mono:wght@400;500&amp;family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600;6..72,700&amp;display=swap" rel="stylesheet"/>
 <!-- KaTeX for Math Rendering -->
 <link href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" rel="stylesheet"/>

--- a/130Test3.html
+++ b/130Test3.html
@@ -9,6 +9,7 @@
     <title>Math 130 – Test 3 Review (Spring 2026)</title>
 
 <!-- Fonts -->
+<!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&amp;family=DM+Sans:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet"/>
 <!-- KaTeX for Math Rendering -->
 <link href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" rel="stylesheet"/>

--- a/130Test4.html
+++ b/130Test4.html
@@ -10,7 +10,9 @@
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<!-- Page-specific external CSS: KaTeX styles are required for math formula rendering. -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>

--- a/CV.html
+++ b/CV.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Andrew H. Volk - Professional CV</title>
     <link rel="stylesheet" href="/styles.css">
+    <!-- Page-specific external CSS: Font Awesome provides icon glyphs used on this page. -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="theme.js"></script>
 </head>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ This repository contains the source for a static academic website with course ma
 - When renaming files or moving legacy assets, update all `href`/`src` references in related pages and metadata files.
 - Keep shared JavaScript utilities at the repository root (for example, `theme.js`) and reference them from subdirectories with relative paths like `../theme.js` instead of duplicating script files.
 
+## CSS Loading and CDN Policy
+
+- Global stylesheet: use `/styles.css` as the canonical local stylesheet include.
+- Third-party CSS: load only on pages that require the dependency (for example, KaTeX rendering or icon fonts).
+- Approved CDN domains: `fonts.googleapis.com`, `cdn.jsdelivr.net`, and `cdnjs.cloudflare.com`.
+- Version pinning: pin third-party library versions in CDN URLs (for example, `katex@0.16.9`, `font-awesome/6.4.0`) and avoid unversioned CDN package URLs.
+
+### CSS Include Lint Check
+
+Run this lightweight lint to catch stylesheet include issues:
+
+```bash
+python scripts/check_css_links.py
+```
+
+This check reports:
+- non-canonical local stylesheet `href` values
+- duplicate CDN variants for the same library
+
 ## Recommended Validation
 
 Run this local check before pushing to catch broken local `href` links:

--- a/courses/103LUOAssignmentGuide.html
+++ b/courses/103LUOAssignmentGuide.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PHYS 103 Assignment Guide</title>
+<!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700&family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,700;1,9..144,400&display=swap" rel="stylesheet">
 <style>
   :root {

--- a/courses/math130.html
+++ b/courses/math130.html
@@ -6,6 +6,7 @@
   <title>MATH 130: Advanced Technical Mathematics</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
   <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/styles.css">
   <script src="../theme.js"></script>

--- a/courses/test4-formulas.html
+++ b/courses/test4-formulas.html
@@ -19,6 +19,7 @@
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <script>
         MathJax = {

--- a/projects/ResearchMentorship/MathJournals.html
+++ b/projects/ResearchMentorship/MathJournals.html
@@ -8,6 +8,7 @@
     <script src="../../theme.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body class="bg-gradient-to-br from-slate-50 to-indigo-100 font-sans text-slate-700 min-h-screen">

--- a/scripts/check_css_links.py
+++ b/scripts/check_css_links.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Lightweight lint for stylesheet href conventions.
+
+Checks:
+1) non-canonical local stylesheet hrefs (anything local that's not /styles.css)
+2) duplicate CDN variants for the same library
+"""
+from __future__ import annotations
+
+import glob
+import re
+from collections import defaultdict
+from html import unescape
+from urllib.parse import urlparse
+
+STYLESHEET_LINK_RE = re.compile(r"<link\b[^>]*\brel\s*=\s*['\"]stylesheet['\"][^>]*>", re.IGNORECASE)
+HREF_RE = re.compile(r"\bhref\s*=\s*['\"]([^'\"]+)['\"]", re.IGNORECASE)
+
+
+def iter_stylesheet_hrefs() -> list[tuple[str, str]]:
+    results: list[tuple[str, str]] = []
+    for file_path in sorted(glob.glob("**/*.html", recursive=True)):
+        with open(file_path, encoding="utf-8", errors="ignore") as fh:
+            text = fh.read()
+        for tag in STYLESHEET_LINK_RE.findall(text):
+            href_match = HREF_RE.search(tag)
+            if href_match:
+                results.append((file_path, unescape(href_match.group(1).strip())))
+    return results
+
+
+def is_local_href(href: str) -> bool:
+    return not re.match(r"^(https?:|//|mailto:|tel:|data:|javascript:|#)", href, flags=re.IGNORECASE)
+
+
+def normalize_jsdelivr(path: str) -> tuple[str | None, str | None]:
+    # /npm/katex@0.16.9/dist/katex.min.css
+    m = re.match(r"^/npm/([^@/]+)(?:@([^/]+))?", path)
+    if not m:
+        return None, None
+    return m.group(1), m.group(2) or "unversioned"
+
+
+def normalize_cdnjs(path: str) -> tuple[str | None, str | None]:
+    # /ajax/libs/font-awesome/6.4.0/css/all.min.css
+    m = re.match(r"^/ajax/libs/([^/]+)/([^/]+)", path)
+    if not m:
+        return None, None
+    return m.group(1), m.group(2)
+
+
+def classify_external_variant(href: str) -> tuple[str | None, str | None]:
+    parsed = urlparse(href)
+    host = parsed.netloc.lower()
+    path = parsed.path
+
+    if host == "cdn.jsdelivr.net":
+        lib, version = normalize_jsdelivr(path)
+        if lib:
+            return lib, f"{host}:{version}"
+    elif host == "cdnjs.cloudflare.com":
+        lib, version = normalize_cdnjs(path)
+        if lib:
+            return lib, f"{host}:{version}"
+    return None, None
+
+
+def main() -> int:
+    local_non_canonical: list[tuple[str, str]] = []
+    variants: dict[str, set[str]] = defaultdict(set)
+
+    for file_path, href in iter_stylesheet_hrefs():
+        href_no_hash = href.split("#", 1)[0].split("?", 1)[0]
+
+        if is_local_href(href):
+            if href_no_hash != "/styles.css":
+                local_non_canonical.append((file_path, href))
+            continue
+
+        lib, variant = classify_external_variant(href)
+        if lib and variant:
+            variants[lib].add(variant)
+
+    failed = False
+
+    if local_non_canonical:
+        failed = True
+        print("Non-canonical local stylesheet hrefs found (expected '/styles.css'):")
+        for file_path, href in local_non_canonical:
+            print(f"- {file_path}: {href}")
+    else:
+        print("No non-canonical local stylesheet hrefs found.")
+
+    duplicate_variants = {lib: values for lib, values in variants.items() if len(values) > 1}
+    if duplicate_variants:
+        failed = True
+        print("\nDuplicate CDN variants detected for the same library:")
+        for lib, values in sorted(duplicate_variants.items()):
+            print(f"- {lib}: {', '.join(sorted(values))}")
+    else:
+        print("No duplicate CDN variants detected for tracked stylesheet libraries.")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Establish a canonical local stylesheet and document CDN/versioning rules to avoid inconsistent styling and unpinned third-party dependencies.
- Make the rationale for page-scoped external CSS explicit in the HTML so future editors understand why a third-party stylesheet is loaded.
- Add an automated, lightweight check to catch non-canonical local hrefs and conflicting CDN variants early in CI.

### Description

- Added a `CSS Loading and CDN Policy` section to `README.md` that defines the canonical global stylesheet (`/styles.css`), page-scoped third-party CSS rules, approved CDN domains, and version-pinning guidance, plus instructions to run the lint (`python scripts/check_css_links.py`).
- Inserted page-specific HTML comments next to external stylesheet includes (Google Fonts, KaTeX, Font Awesome) across affected pages such as `130Test1.html`, `130Test2.html`, `130Test3.html`, `130Test4.html`, `CV.html`, `courses/103LUOAssignmentGuide.html`, `courses/math130.html`, `courses/test4-formulas.html`, and `projects/ResearchMentorship/MathJournals.html` explaining the dependency purpose.
- Added a lightweight lint script at `scripts/check_css_links.py` that scans HTML files and reports non-canonical local stylesheet `href` values and duplicate CDN variants for tracked libraries (jsDelivr and CDNJS patterns).
- Added a GitHub Actions workflow `.github/workflows/css-link-lint.yml` to run the lint on pushes to `main` and on pull requests.

### Testing

- Ran `python scripts/check_css_links.py` which initially reported duplicate Google Fonts variants, then the script classification was refined and the final run printed `No non-canonical local stylesheet hrefs found.` and `No duplicate CDN variants detected for tracked stylesheet libraries.` (exit code 0).
- Ran an automated check to ensure external stylesheet links have nearby comments which printed `All external stylesheet links have nearby comments.` (exit code 0).
- Verified the new workflow file is present and configured to run the lint step on `push` and `pull_request` events.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55f71ccf083319fccf0df0d4324a0)