### PR TITLE
Refocus color foundation work and adopt Phase 1 semantic/status tokens

### DIFF
--- a/ColorPhase0Execution.md
+++ b/ColorPhase0Execution.md
@@ -1,7 +1,7 @@
-# Color Migration Phase 0 — Repository-Specific Preflight
+# Color Migration Phase 0 — Scope Guardrails (Docs Baseline)
 
-## Purpose
-This document operationalizes Phase 0 from `ColorImplementationPlan.md` for this repository so implementation can start with clear scope boundaries, migration policy, and PR controls.
+## Intent
+This document is intentionally limited to **verifiable process guardrails** for future color migration work. It does **not** classify files into migration buckets and does **not** assign speculative risk labels.
 
 ## Baseline Snapshot (2026-03-26)
 - Files scanned in color inventory: **65**
@@ -11,174 +11,30 @@ This document operationalizes Phase 0 from `ColorImplementationPlan.md` for this
 
 Source of truth: `colors.md` (generated 2026-03-26 17:20 UTC).
 
----
-
-## 1) Phase-0 Policy Locks (Required Before Phase 1)
-
-These are the required decision gates from the implementation plan, pre-filled with recommended defaults.
+## Phase-0 Policy Locks (to be explicitly approved)
 
 | Decision | Proposed default | Status | Owner |
 |---|---|---|---|
 | Dark selector standard | `:root[data-theme="dark"]` during migration; normalize later if needed | Proposed | Site maintainer |
-| Compatibility alias lifecycle | Keep for one full release cycle after Bucket C migration completes | Proposed | Site maintainer |
+| Compatibility alias lifecycle | Keep for one full release cycle after legacy aliases are fully redirected | Proposed | Site maintainer |
 | Accessibility bar | WCAG AA minimum globally; AAA target for text-heavy educational content where practical | Proposed | Site maintainer |
 | PR size cap | Max 8 files for global-shell PRs; max 3 files for standalone PRs | Proposed | Site maintainer |
-| Visual QA sign-off | 1 implementation reviewer + 1 visual QA reviewer for each Bucket C PR | Proposed | Site maintainer |
-| Screenshot diff policy | Required for every Bucket C page migration | Proposed | Site maintainer |
+| Visual QA sign-off | 1 implementation reviewer + 1 visual QA reviewer for each standalone page migration PR | Proposed | Site maintainer |
+| Screenshot diff policy | Required for every standalone page migration PR | Proposed | Site maintainer |
 
----
+## Phase Boundary
+- **Phase 0 output**: approved policies, approved checks, and updated inventory snapshots.
+- **Not included in Phase 0**: page bucket classifications, migration sequencing by page, or permanent exception lists without implementation evidence.
 
-## 2) Repository Scope Classification (A/B/C)
-
-### Bucket A — Global system files
-- `styles.css`
-- `theme.js`
-
-### Bucket B — Shared shells and low-risk inheritors
-
-#### B1: Low-literal pages (likely global-token inheritors)
-- `Taskflow.html`
-- `Unit3Practice.html`
-- `courses/electrical-circuits-lab-data-sheet.html`
-- `courses/electrical-circuits-lab-manual.html`
-- `courses/engi220.html`
-- `courses/final-exam-review-guide.html`
-- `courses/lab6-krules.html`
-- `courses/math100.html`
-- `courses/math105.html`
-- `courses/math110.html`
-- `courses/math114-foundations.html`
-- `courses/math114.html`
-- `courses/math121.html`
-- `courses/phys103.html`
-- `courses/physics-labs.html`
-- `courses/physlab1.html`
-- `courses/physlab2.html`
-
-#### B2: No-local-literal pages (likely strong global-style dependence)
-- `404.html`
-- `CV.html`
-- `bookings.html`
-- `index.html`
-- `infographic.html`
-- `learn.html`
-- `projects.html`
-- `courses/constant-acceleration-lab-manual.html`
-- `courses/data-sheet-for-electric-circuits.html`
-- `courses/density-lab-manual.html`
-- `courses/hookes-law-lab-manual.html`
-- `courses/latent-heat-of-fusion-lab-manual.html`
-- `courses/math114-final-review.html`
-- `courses/math114-financial-math.html`
-- `courses/math114-statistics.html`
-- `courses/math114-test1.html`
-- `courses/math114-test2.html`
-- `courses/math114-test3.html`
-- `courses/math130.html`
-- `courses/measurement-lab-manual.html`
-- `courses/reflection-and-refraction-lab-manual.html`
-- `courses/simple-pendulum-lab-manual.html`
-- `courses/sound-lab-manual.html`
-- `courses/spectroscopy-lab-manual.html`
-
-### Bucket C — Standalone themed/high-variance pages
-
-#### C1: High-risk standalone pages (migrate one-at-a-time)
-- `courses/103LUOAssignmentGuide.html`
-- `courses/basic-statistical-measures.html`
-- `projects/PHYS103LUO/KinematicsShortAnswer.html`
-- `projects/QuestionSpinner/questionspinner.html`
-- `projects/NormalDistributionGame.html`
-- `130Test3.html`
-- `130Test2.html`
-- `chessboard.html`
-- `courses/test4-formulas.html`
-- `130Test1.html`
-- `projects/PrayerAppV1/index.html`
-- `courses/knowledgegrowth.html`
-- `growth.html`
-
-#### C2: Moderate standalone pages (after C1)
-- `courses/math114Spring26Links.html`
-- `courses/114-module1-summary.html`
-- `courses/test3-formulas.html`
-- `projects/ResearchMentorship/MathJournals.html`
-- `130Test4.html`
-- `employeepay.html`
-
----
-
-## 3) Token Contract Table (Phase-0 Starter)
-
-This registry is intentionally small for PR 1 and will expand as files are migrated.
-
-| Source (token/literal pattern) | Target semantic token | Scope | Rationale |
-|---|---|---|---|
-| body/base text channels (`--text-color`, local text vars) | `--text-body` | Global + B + C | Consolidate body copy semantics |
-| heading/strong emphasis channels | `--text-heading` | Global + B + C | Preserve hierarchy and contrast |
-| muted/supporting copy channels | `--text-muted` | Global + B + C | Distinguish secondary text |
-| primary action/link color channels | `--primary-base` | Global + B + C | Action/brand consistency |
-| primary hover/focus action channels | `--primary-hover` | Global + B + C | Interaction-state consistency |
-| card/main surfaces | `--bg-surface` | Global + B + C | Surface normalization |
-| subtle strips/sections | `--bg-subtle` | Global + B + C | Secondary surface normalization |
-| dividers/default borders | `--border-subtle` | Global + B + C | Border consistency |
-| status success colors | `--status-success`, `--status-success-bg`, `--status-success-border` | Review/alert UIs | Keep status semantics explicit |
-| status warning colors | `--status-warning`, `--status-warning-bg`, `--status-warning-border` | Review/alert UIs | Keep status semantics explicit |
-| status error colors | `--status-error`, `--status-error-bg`, `--status-error-border` | Review/alert UIs | Keep status semantics explicit |
-| status info colors | `--status-info`, `--status-info-bg`, `--status-info-border` | Review/alert UIs | Keep status semantics explicit |
-| overlay/backdrop alpha layers | `--overlay-light`, `--overlay-medium`, `--overlay-dark` | Global + standalone modals/overlays | Preserve intentional translucency via semantic channels |
-
----
-
-## 4) Exception Registry Seed (Intentional Literals)
-
-These color literals are expected to remain page-local unless later explicitly approved for semantic mapping.
-
-| File | Expected intentional literal usage | Rationale |
-|---|---|---|
-| `projects/NormalDistributionGame.html` | gameplay/feedback highlights | instructional/game semantics |
-| `projects/QuestionSpinner/questionspinner.html` | category wheel and playful gradients | product-specific branding and affordance |
-| `projects/PHYS103LUO/KinematicsShortAnswer.html` | educational status/diagram accents | instructional meaning and cognitive grouping |
-| `employeepay.html` | chart datasets (`rgb/rgba`) | data visualization clarity |
-| `growth.html`, `courses/knowledgegrowth.html` | infographic palette colors | data/infographic category encoding |
-
----
-
-## 5) PR Sequence and Change Budget
-
-1. **PR 1 (Foundation-only, Bucket A):**
-   - Add Tier 1 + Tier 2 + Tier 2b token architecture in `styles.css`.
-   - Add compatibility aliases and bridge aliases.
-   - No standalone page edits.
-2. **PR 2 (Global shell migration, Bucket A + selected B):**
-   - Migrate shared selectors in `styles.css`.
-   - Limit to obvious shared component color substitutions.
-3. **PR 3 (Legacy alias redirection):**
-   - Redirect legacy aliases to semantic tokens.
-   - Keep temporary compatibility window.
-4. **PR 4+ (Bucket C):**
-   - One high-risk standalone page per PR.
-   - Required screenshot diff and light/dark/print checks per page.
-5. **Final cleanup PR:**
-   - Remove dead aliases when reference count is zero and all Bucket C pages are signed off.
-
----
-
-## 6) Required Per-PR Checks
-
+## Required Per-PR Checks
 - Re-run inventory and attach before/after excerpt from `colors.md`.
 - Confirm no new generic alias collisions (`--text`, `--bg`, `--surface`, `--border`, `--accent`) outside approved mapping.
 - Confirm no unapproved new literal status colors.
 - Confirm print and forced-colors support still present where applicable.
-- For Bucket C PRs: include side-by-side screenshot diffs.
+- For visible UI changes: include light/dark screenshots.
 
----
-
-## 7) Ready-to-Start Criteria for Phase 1
-
+## Ready-to-Start Criteria for Phase 1
 Phase 1 can start when all conditions below are true:
-1. Policy lock table in Section 1 is approved.
-2. Bucket table in Section 2 is approved.
-3. Token contract starter in Section 3 is approved.
-4. Exception seed list in Section 4 is approved.
-
+1. Policy lock table is approved.
+2. Required checks are approved.
+3. Current inventory snapshot is acknowledged as baseline.

--- a/styles.css
+++ b/styles.css
@@ -206,11 +206,11 @@ body {
   line-height: var(--line-height-body);
   margin: 0;
   padding: 0;
-  color: var(--text-color);
+  color: var(--text-body);
   background:
     radial-gradient(circle at top, rgba(58, 102, 92, 0.08), transparent 28%),
     linear-gradient(180deg, rgba(220, 230, 224, 0.24), transparent 24%),
-    var(--background-color);
+    var(--bg-body);
   transition:
     background-color 0.3s ease,
     color 0.3s ease;
@@ -233,29 +233,29 @@ h4,
 h5,
 h6 {
   margin-top: 0;
-  color: var(--secondary-color);
+  color: var(--text-heading);
   line-height: 1.3;
   font-family: var(--type-display-family);
 }
 
 a {
-  color: var(--secondary);
+  color: var(--primary-base);
   text-decoration-line: underline;
   text-decoration-thickness: 0.08em;
   text-underline-offset: 0.16em;
-  text-decoration-color: color-mix(in srgb, var(--secondary) 72%, transparent);
+  text-decoration-color: color-mix(in srgb, var(--primary-base) 72%, transparent);
   transition: color 0.2s ease, text-decoration-color 0.2s ease, text-decoration-thickness 0.2s ease, background-size 0.2s ease;
 }
 
 a:hover,
 a:focus-visible {
-  color: var(--tertiary);
+  color: var(--primary-hover);
   text-decoration-color: currentColor;
   text-decoration-thickness: 0.12em;
 }
 
 :where(.page-shell-main, .course-page, .review-shell, .summary-sheet, .question-guide, .answer-content, .publications-item, .experience-item, .education-item, #research, #publications, #philosophy, #overview) :where(p, li, dd, figcaption, blockquote) a {
-  text-decoration-color: color-mix(in srgb, var(--secondary) 82%, transparent);
+  text-decoration-color: color-mix(in srgb, var(--primary-base) 82%, transparent);
   text-decoration-thickness: 0.09em;
   text-underline-offset: 0.18em;
 }
@@ -2708,14 +2708,14 @@ main.error-main {
   --review-h1-to: var(--secondary, #7ea8ff);
   --review-body-muted: var(--on-surface-variant, #bac4bf);
   --review-semantic-body: var(--on-surface, #f2f5f2);
-  --review-success: #34d399;
-  --review-success-bg: rgba(52, 211, 153, 0.1);
-  --review-warning: #f59e0b;
-  --review-warning-bg: rgba(245, 158, 11, 0.1);
-  --review-error: #f87171;
-  --review-error-bg: rgba(248, 113, 113, 0.1);
-  --review-info: var(--secondary, #7ea8ff);
-  --review-info-bg: rgba(126, 168, 255, 0.1);
+  --review-success: var(--status-success);
+  --review-success-bg: var(--status-success-bg);
+  --review-warning: var(--status-warning);
+  --review-warning-bg: var(--status-warning-bg);
+  --review-error: var(--status-error);
+  --review-error-bg: var(--status-error-bg);
+  --review-info: var(--status-info);
+  --review-info-bg: var(--status-info-bg);
   --review-radius: 16px;
   --review-shell-width: min(1100px, calc(100vw - 2rem));
 }
@@ -2788,14 +2788,14 @@ body.light .math-review-page,
   --review-h1-to: var(--primary-container, #00342b);
   --review-body-muted: color-mix(in srgb, var(--on-surface-variant) 86%, var(--primary) 14%);
   --review-semantic-body: var(--on-surface, #001d17);
-  --review-success: #059669;
-  --review-success-bg: rgba(5, 150, 105, 0.08);
-  --review-warning: #d97706;
-  --review-warning-bg: rgba(217, 119, 6, 0.08);
-  --review-error: #dc2626;
-  --review-error-bg: rgba(220, 38, 38, 0.08);
-  --review-info: var(--secondary, #1A56DB);
-  --review-info-bg: rgba(26, 86, 219, 0.08);
+  --review-success: var(--status-success);
+  --review-success-bg: var(--status-success-bg);
+  --review-warning: var(--status-warning);
+  --review-warning-bg: var(--status-warning-bg);
+  --review-error: var(--status-error);
+  --review-error-bg: var(--status-error-bg);
+  --review-info: var(--status-info);
+  --review-info-bg: var(--status-info-bg);
 }
 
 /* Review-page banner header — mirrors .page-shell-header from the CV page */
@@ -3227,14 +3227,14 @@ body.light .math-review-page,
 .review-callout--warning, .warning-box,
 .review-callout--info,
 .review-callout--success { color: var(--semantic-body); }
-.review-callout--tip, .tip-box { background: color-mix(in srgb, var(--amber) 10%, var(--surface)); border-left: 4px solid color-mix(in srgb, var(--amber) 72%, transparent); }
-.review-callout--warning, .warning-box { background: color-mix(in srgb, var(--red) 9%, var(--surface)); border-left: 4px solid color-mix(in srgb, var(--red) 72%, transparent); }
-.review-callout--info { background: color-mix(in srgb, var(--blue) 9%, var(--surface)); border-left: 4px solid color-mix(in srgb, var(--blue) 72%, transparent); }
-.review-callout--success { background: color-mix(in srgb, var(--green) 10%, var(--surface)); border-left: 4px solid color-mix(in srgb, var(--green) 72%, transparent); }
-.review-callout--tip i, .tip-box i, .review-callout--tip strong, .tip-box strong { color: var(--amber); }
-.review-callout--warning i, .warning-box i, .review-callout--warning strong, .warning-box strong { color: var(--red); }
-.review-callout--info i, .review-callout--info strong { color: var(--blue); }
-.review-callout--success i, .review-callout--success strong { color: var(--green); }
+.review-callout--tip, .tip-box { background: var(--status-warning-bg); border-left: 4px solid var(--status-warning-border); }
+.review-callout--warning, .warning-box { background: var(--status-error-bg); border-left: 4px solid var(--status-error-border); }
+.review-callout--info { background: var(--status-info-bg); border-left: 4px solid var(--status-info-border); }
+.review-callout--success { background: var(--status-success-bg); border-left: 4px solid var(--status-success-border); }
+.review-callout--tip i, .tip-box i, .review-callout--tip strong, .tip-box strong { color: var(--status-warning); }
+.review-callout--warning i, .warning-box i, .review-callout--warning strong, .warning-box strong { color: var(--status-error); }
+.review-callout--info i, .review-callout--info strong { color: var(--status-info); }
+.review-callout--success i, .review-callout--success strong { color: var(--status-success); }
 .review-summary-card, .section-summary-card { padding: 1rem 1.1rem; }
 .review-stack-gap { margin-top: 2rem; }
 .review-link-reset, .video-link.review-link-reset { text-decoration: none; }


### PR DESCRIPTION
### Motivation
- Narrow the previous Phase-0 draft into a verifiable docs baseline and deliver a concrete Phase 1 token foundation proof-of-use in the stylesheet. 
- Preserve the newly-introduced semantic/status token channels across light, dark, and forced-colors scopes and demonstrate a small, maintainable selector migration that consumes those tokens.

### Description
- Tightened `ColorPhase0Execution.md` to remove speculative page-bucket classifications and long-range sequencing, leaving only verifiable policy guardrails, approval gates, and per-PR checks. 
- Kept Tier 1/2/2b token definitions in `styles.css` and migrated concrete selectors to use semantic tokens by changing body/background/heading/link color references to `--text-body`, `--bg-body`, `--text-heading`, `--primary-base`, and `--primary-hover`. 
- Mapped review-layer variables to the semantic status tokens by making review `--review-*` variables reference `--status-*`, and updated `.review-callout--tip|warning|info|success` to use `--status-*-bg`, `--status-*-border`, and `--status-*` for icons/text. 
- Preserved dark-theme (`:root[data-theme="dark"]`) and forced-colors (`@media (forced-colors: active)`) status-token equivalents so status tokens are defined and available across modes.

### Testing
- Exact commands run and results (truthful): 
  - `rg --files -g 'AGENTS.md'` — returned repository root as executed; succeeded. 
  - `git log --oneline -n 10 && git show --name-only --oneline 7ddbfd0` — attempted but `7ddbfd0` was not present in the working tree so the `git show` portion failed with an unknown revision error. 
  - `rg --files | rg 'ColorPhase0Execution.md|styles.css' && sed -n '1,220p' ColorPhase0Execution.md && sed -n '1,260p' styles.css` — located files and printed excerpts; succeeded. 
  - `rg -n "inline|review|TODO|FIXME|Phase 0|speculative|Bucket" ColorPhase0Execution.md styles.css` — grep search completed and returned matches; succeeded. 
  - `git show --stat --oneline b1c1060 && git show --name-only --oneline b1c1060` — inspected the earlier related commit and confirmed files added by that change; succeeded. 
  - `rg -n "data-theme=\"dark\"|forced-colors|status-success|status-warning|status-error|status-info|review-success" styles.css` — confirmed presence of status tokens and dark/forced-colors/usage; succeeded. 
  - `git diff --check` — ran and passed (no whitespace/conflict markers reported). 
  - `rg -n -- "--status-(success|warning|error|info)" styles.css` — used to confirm status tokens exist and returned results; succeeded (note: an earlier attempt without `--` before the pattern caused `rg` to try to interpret the pattern as flags, which failed, and the corrected form succeeded). 
  - `rg -n "@media \(forced-colors: active\)|:root\[data-theme=\"dark\"\]" styles.css` — confirmed dark and forced-colors scopes exist; succeeded. 
  - `rg -n "review-callout--(tip|warning|info|success)" styles.css` — confirmed the migrated selectors now reference `--status-*` tokens; succeeded. 
  - `git add ColorPhase0Execution.md styles.css && git commit -m "Refocus color token PR and resolve review feedback"` — staged and committed the changes successfully (commit recorded on the working branch). 
  - PR creation via internal `make_pr` tool was invoked and reported the PR title/body (no external CI runs were executed as this repository has no package.json-based build). 
- Automated test summary: `git diff --check` passed and all the `rg` validations used to confirm token definitions and selector usage passed; no automated style/build scripts were run because none are present in the repo. 
- Rollback notes: to revert the change completely run `git revert <commit-hash>` (the recent local commit created was `ce0248a` in this session) or restore prior file versions from the previous commit for finer rollback (e.g., `git checkout <previous-commit> -- styles.css ColorPhase0Execution.md`). 
- Screenshot evidence: a visible UI change was introduced (review callout states now consume `--status-*` tokens), but no browser screenshot tool was available in this execution environment so no screenshots are attached and none are being fabricated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5b4cd2af48331b9410a66ba0a45a3)