### PR TITLE
docs: tighten phase-0 review intake and next-agent handoff rules

### DIFF
--- a/ColorPhase0Execution.md
+++ b/ColorPhase0Execution.md
@@ -174,7 +174,16 @@ These color literals are expected to remain page-local unless later explicitly a
 
 ---
 
-## 7) Ready-to-Start Criteria for Phase 1
+
+## 7) Review Intake Log (Phase 0)
+
+- Latest commit reviewed before edits: `cc21e9c` (merge of PR #175).
+- PR discussion and inline comment review is required each turn; when discussion tooling is unavailable, document that limitation in the turn summary and avoid expanding scope.
+- Current scope lock for this turn: **Phase 0 docs only**.
+
+---
+
+## 8) Ready-to-Start Criteria for Phase 1
 
 Phase 1 can start when all conditions below are true:
 1. Policy lock table in Section 1 is approved.

--- a/nextagent.md
+++ b/nextagent.md
@@ -1,8 +1,11 @@
 # Instructions for the Next Agent
 
-1. Read the latest commit and PR discussion before making edits.
-2. Resolve all inline review comments on the active diff before adding new scope.
-3. Keep scope single-objective (either Phase 0 docs only or Phase 1 token foundation only).
-4. Run only the minimal validation commands you actually execute; report them truthfully.
-5. Commit once with a clear message tied to the chosen objective.
-6. Create/update `nextagent.md` in your turn and include this step explicitly in your own instructions.
+Objective for this turn: **Phase 0 docs only** (no Phase 1 token implementation).
+
+1. Read the latest commit (`git log -1 --oneline`) before making edits.
+2. Read PR discussion and inline comments for the active PR when tooling is available; if unavailable in this environment, note that explicitly in your summary.
+3. Resolve all outstanding inline review comments on the active diff before adding any new scope.
+4. Keep scope single-objective (either Phase 0 docs only or Phase 1 token foundation only).
+5. Run only the minimal validation commands you actually execute; report them truthfully.
+6. Commit once with a clear message tied to the chosen objective.
+7. Create/update `nextagent.md` in your turn and include this step explicitly in your own instructions.


### PR DESCRIPTION
### Motivation
- Clarify Phase 0 handoff so the next agent reviews recent context and keeps scope strictly to docs-only work for the turn. 
- Provide explicit fallback behavior when PR discussion tooling is unavailable to avoid accidental scope expansion.

### Description
- Add a "Review Intake Log (Phase 0)" section to `ColorPhase0Execution.md` that records the requirement to review the latest commit, PR discussion expectations, and the scope lock for docs-only work. 
- Update `nextagent.md` to declare an objective for the turn (`Phase 0 docs only`) and to present ordered handoff instructions including explicit fallback guidance when PR discussion tooling is not available. 
- Preserve the single-objective guidance and require the next agent to update `nextagent.md` during its turn.

### Testing
- Ran `git diff --check` which returned no issues. 
- Attempted `gh pr view` to fetch PR discussion but the `gh` CLI is not installed in this environment, so automated PR comment retrieval failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5bd3a35288331ba84640932227d0c)