### PR TITLE
docs: refresh Phase 0 review intake and next-agent handoff

### DIFF
--- a/ColorPhase0Execution.md
+++ b/ColorPhase0Execution.md
@@ -174,11 +174,11 @@ These color literals are expected to remain page-local unless later explicitly a
 
 ---
 
-
 ## 7) Review Intake Log (Phase 0)
 
-- Latest commit reviewed before edits: `cc21e9c` (merge of PR #175).
-- PR discussion and inline comment review is required each turn; when discussion tooling is unavailable, document that limitation in the turn summary and avoid expanding scope.
+- Latest commit reviewed before edits: `d6dffbb` (merge of PR #176) via `git log -1 --oneline` on 2026-03-26.
+- PR discussion and inline comment review attempted via `gh pr status`; GitHub CLI is not available in this environment (`gh: command not found`).
+- Because PR discussion tooling is unavailable here, scope remains locked to documentation updates only and no implementation changes were added.
 - Current scope lock for this turn: **Phase 0 docs only**.
 
 ---

--- a/nextagent.md
+++ b/nextagent.md
@@ -8,4 +8,4 @@ Objective for this turn: **Phase 0 docs only** (no Phase 1 token implementation)
 4. Keep scope single-objective (either Phase 0 docs only or Phase 1 token foundation only).
 5. Run only the minimal validation commands you actually execute; report them truthfully.
 6. Commit once with a clear message tied to the chosen objective.
-7. Create/update `nextagent.md` in your turn and include this step explicitly in your own instructions.
+7. Create/update `nextagent.md` in your turn and include this step explicitly in your own instructions for the following agent.


### PR DESCRIPTION
### Motivation
- Record the actual latest reviewed commit and the environment limitation so Phase 0 remains strictly documentation-only and the handoff instruction is clearer for the next agent.

### Description
- Update `ColorPhase0Execution.md` to reference the reviewed commit `d6dffbb`, add a note that `gh pr status` is unavailable in this environment and that scope is locked to Phase 0 docs-only, and modify `nextagent.md` to require the next agent to repeat the handoff-update step, then commit the changes.

### Testing
- Ran `git log -1 --oneline` (succeeded), attempted `gh pr status` which failed due to `gh: command not found`, ran `git diff -- ColorPhase0Execution.md nextagent.md` (succeeded), and ran `git show --stat --oneline HEAD` after committing (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5bed400648331b314811d40605458)