### PR TITLE
docs: refresh Phase 0 intake log and next-agent checklist

### DIFF
--- a/ColorPhase0Execution.md
+++ b/ColorPhase0Execution.md
@@ -176,9 +176,9 @@ These color literals are expected to remain page-local unless later explicitly a
 
 ## 7) Review Intake Log (Phase 0)
 
-- Latest commit reviewed before edits: `d6dffbb` (merge of PR #176) via `git log -1 --oneline` on 2026-03-26.
+- Latest commit reviewed before edits: `5ff7133` (merge of PR #177) via `git log -1 --oneline` on 2026-03-26.
 - PR discussion and inline comment review attempted via `gh pr status`; GitHub CLI is not available in this environment (`gh: command not found`).
-- Because PR discussion tooling is unavailable here, scope remains locked to documentation updates only and no implementation changes were added.
+- Because PR discussion tooling is unavailable here, outstanding inline comments cannot be verified in this environment; scope remained locked to documentation updates only.
 - Current scope lock for this turn: **Phase 0 docs only**.
 
 ---

--- a/nextagent.md
+++ b/nextagent.md
@@ -6,6 +6,7 @@ Objective for this turn: **Phase 0 docs only** (no Phase 1 token implementation)
 2. Read PR discussion and inline comments for the active PR when tooling is available; if unavailable in this environment, note that explicitly in your summary.
 3. Resolve all outstanding inline review comments on the active diff before adding any new scope.
 4. Keep scope single-objective (either Phase 0 docs only or Phase 1 token foundation only).
-5. Run only the minimal validation commands you actually execute; report them truthfully.
-6. Commit once with a clear message tied to the chosen objective.
-7. Create/update `nextagent.md` in your turn and include this step explicitly in your own instructions for the following agent.
+5. If Phase 0 docs are touched, update `ColorPhase0Execution.md` Section 7 (Review Intake Log) with this turn's exact commit and PR-tooling status.
+6. Run only the minimal validation commands you actually execute; report them truthfully.
+7. Commit once with a clear message tied to the chosen objective.
+8. Create/update `nextagent.md` in your turn and include this step explicitly in your own instructions for the following agent.


### PR DESCRIPTION
### Motivation

- Ensure Phase 0 documentation and the agent handoff checklist remain synchronized and explicit before any token implementation work begins.
- Make the next-agent checklist require an explicit update to the Phase 0 intake log when Phase 0 docs are edited so future agents record PR-tooling availability status.

### Description

- Updated `ColorPhase0Execution.md` Section 7 to record the reviewed pre-edit state and to clarify that inline PR comments could not be verified in this environment due to unavailable PR tooling. 
- Updated `nextagent.md` to require that any agent who touches Phase 0 docs must update `ColorPhase0Execution.md` Section 7 with the turn's pre-edit state and PR-tooling status, and adjusted the checklist numbering for clarity. 
- Applied the `ColorPhase0Execution.md` change via a small scripted edit to ensure the intake log format stays consistent with the execution plan.

### Testing

- Ran `git log -1 --oneline` to determine the repository head before edits, and the command completed successfully. 
- Checked for tooling availability with `gh --version`, which reported the GitHub CLI is not present in this environment. 
- Verified working tree and exact documentation diffs with `git status --short` and `git diff -- ColorPhase0Execution.md nextagent.md`, both of which completed and showed only the intended documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5c3084d6c8331806ee8b56e6650ce)