### PR TITLE
Finalize Phase 0 policy locks and approval stamp

### DIFF
--- a/ColorPhase0Execution.md
+++ b/ColorPhase0Execution.md
@@ -4,6 +4,7 @@
 This document operationalizes Phase 0 from `ColorImplementationPlan.md` for this repository so implementation can start with clear scope boundaries, migration policy, and PR controls.
 
 ## Baseline Snapshot (2026-03-26)
+- **Policy approval stamp:** **Approved on 2026-03-27 (UTC)** for Section 1 Phase-0 policy locks.
 - Files scanned in color inventory: **65**
 - Unique literal colors: **332**
 - Unique referenced color tokens (`var(--*)`): **160**
@@ -17,14 +18,14 @@ Source of truth: `colors.md` (generated 2026-03-26 17:20 UTC).
 
 These are the required decision gates from the implementation plan, pre-filled with recommended defaults.
 
-| Decision | Proposed default | Status | Owner |
+| Decision | Final policy value | Status | Owner |
 |---|---|---|---|
-| Dark selector standard | `:root[data-theme="dark"]` during migration; normalize later if needed | Proposed | Site maintainer |
-| Compatibility alias lifecycle | Keep for one full release cycle after Bucket C migration completes | Proposed | Site maintainer |
-| Accessibility bar | WCAG AA minimum globally; AAA target for text-heavy educational content where practical | Proposed | Site maintainer |
-| PR size cap | Max 8 files for global-shell PRs; max 3 files for standalone PRs | Proposed | Site maintainer |
-| Visual QA sign-off | 1 implementation reviewer + 1 visual QA reviewer for each Bucket C PR | Proposed | Site maintainer |
-| Screenshot diff policy | Required for every Bucket C page migration | Proposed | Site maintainer |
+| Dark selector standard | `:root[data-theme="dark"]` is the migration standard; normalize later only by explicit follow-up decision | Approved | Andrew Volk |
+| Compatibility alias lifecycle | Compatibility aliases remain for one full release cycle after Bucket C migration completes | Approved | Andrew Volk |
+| Accessibility bar | WCAG AA is the minimum target globally; AAA is required where practical for text-heavy educational content | Approved | Andrew Volk |
+| PR size cap | Max 8 files for global-shell PRs; max 3 files for standalone page PRs | Approved | Andrew Volk |
+| Mandatory reviewer model | Every Bucket C PR requires 1 implementation reviewer + 1 visual QA reviewer before merge | Approved | Andrew Volk |
+| Screenshot policy | Screenshot diffs are mandatory for every Bucket C page migration (light/dark and relevant states) | Approved | Andrew Volk |
 
 ---
 
@@ -190,4 +191,3 @@ Phase 1 can start when all conditions below are true:
 2. Bucket table in Section 2 is approved.
 3. Token contract starter in Section 3 is approved.
 4. Exception seed list in Section 4 is approved.
-


### PR DESCRIPTION
### Motivation
- Lock Phase-0 policy decisions in the repository-specific preflight so Phase 1 migrations start from an explicit, auditable policy state.
- Record final values for dark-mode selector, alias lifecycle, accessibility targets, PR size caps, reviewer model, and screenshot requirements to remove ambiguity during page migrations.
- Add a dated approval stamp so future PRs can verify which policy version they are implementing.

### Description
- Updated `ColorPhase0Execution.md` Section 1 to replace tentative rows with final policy values and set each row `Status` to `Approved` and `Owner` to `Andrew Volk` for the decisions listed in the table.
- Confirmed final values in the table: dark selector migration standard is `:root[data-theme="dark"]`, compatibility aliases kept for one release cycle post-Bucket C, accessibility minimum is WCAG AA with AAA where practical, PR caps are 8 files (global) and 3 files (standalone), every Bucket C PR requires 1 implementation reviewer + 1 visual QA reviewer, and screenshot diffs are mandatory for Bucket C page migrations.
- Added a policy approval stamp near the Baseline Snapshot reading `Approved on 2026-03-27 (UTC)` to mark the locked policy version.
- This change is documentation-only and modifies only `ColorPhase0Execution.md`.

### Testing
- Verified the content diff with `git diff -- ColorPhase0Execution.md`, which showed the intended table and stamp changes and no other edits.
- Confirmed file contents with `nl -ba ColorPhase0Execution.md | sed -n '1,80p'` to inspect the updated header, approval stamp, and policy table lines.
- Committed the change successfully with `git commit` and created the PR message via the repository tooling, all of which completed without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c678dafb7483319a5c03715beca0de)