### PR TITLE
Add ColorMigrationTracker seeded from Phase 0 bucket inventory

### DIFF
--- a/ColorMigrationTracker.md
+++ b/ColorMigrationTracker.md
@@ -1,0 +1,101 @@
+# Color Migration Tracker
+
+Tracking document for Phase 1 execution based on Section 2 of `ColorPhase0Execution.md`.
+
+## Global guidance
+- Initial seeding rule: all entries start as `Not started`.
+- First target for migration execution: **Bucket A**.
+- **Reminder:** Bucket C high-risk files (C1) are **one-per-PR only**.
+
+## Status key
+- **Migration status:** `Not started` → `In progress` → `Complete`
+- **PR number:** use `TBD` until a PR is opened (e.g., `#123`).
+- **Visual QA status:** track each mode as `Not started`, `Pass`, or `N/A` in `light/dark/print/forced-colors` format.
+- **Notes on intentional literals:** capture approved literal colors that remain by design.
+
+## Bucket A — Global system files (First target)
+
+| File | Bucket / sub-bucket | Migration status | PR number | Visual QA status (light/dark/print/forced-colors) | Notes on intentional literals |
+|---|---|---|---|---|---|
+| `styles.css` | A / Global system files | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `theme.js` | A / Global system files | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+
+## Bucket B1 — Low-literal pages
+
+| File | Bucket / sub-bucket | Migration status | PR number | Visual QA status (light/dark/print/forced-colors) | Notes on intentional literals |
+|---|---|---|---|---|---|
+| `Taskflow.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `Unit3Practice.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/electrical-circuits-lab-data-sheet.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/electrical-circuits-lab-manual.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/engi220.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/final-exam-review-guide.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/lab6-krules.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math100.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math105.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math110.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math114-foundations.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math114.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math121.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/phys103.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/physics-labs.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/physlab1.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/physlab2.html` | B / B1 Low-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+
+## Bucket B2 — No-local-literal pages
+
+| File | Bucket / sub-bucket | Migration status | PR number | Visual QA status (light/dark/print/forced-colors) | Notes on intentional literals |
+|---|---|---|---|---|---|
+| `404.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `CV.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `bookings.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `index.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `infographic.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `learn.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `projects.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/constant-acceleration-lab-manual.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/data-sheet-for-electric-circuits.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/density-lab-manual.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/hookes-law-lab-manual.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/latent-heat-of-fusion-lab-manual.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math114-final-review.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math114-financial-math.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math114-statistics.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math114-test1.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math114-test2.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math114-test3.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/math130.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/measurement-lab-manual.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/reflection-and-refraction-lab-manual.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/simple-pendulum-lab-manual.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/sound-lab-manual.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/spectroscopy-lab-manual.html` | B / B2 No-local-literal pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+
+## Bucket C1 — High-risk standalone pages (one-per-PR only)
+
+| File | Bucket / sub-bucket | Migration status | PR number | Visual QA status (light/dark/print/forced-colors) | Notes on intentional literals |
+|---|---|---|---|---|---|
+| `courses/103LUOAssignmentGuide.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/basic-statistical-measures.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `projects/PHYS103LUO/KinematicsShortAnswer.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | Intentional instructional accents expected |
+| `projects/QuestionSpinner/questionspinner.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | Intentional playful gradients expected |
+| `projects/NormalDistributionGame.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | Intentional gameplay highlights expected |
+| `130Test3.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `130Test2.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `chessboard.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/test4-formulas.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `130Test1.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `projects/PrayerAppV1/index.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/knowledgegrowth.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | Intentional infographic palette expected |
+| `growth.html` | C / C1 High-risk standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | Intentional infographic palette expected |
+
+## Bucket C2 — Moderate standalone pages
+
+| File | Bucket / sub-bucket | Migration status | PR number | Visual QA status (light/dark/print/forced-colors) | Notes on intentional literals |
+|---|---|---|---|---|---|
+| `courses/math114Spring26Links.html` | C / C2 Moderate standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/114-module1-summary.html` | C / C2 Moderate standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `courses/test3-formulas.html` | C / C2 Moderate standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `projects/ResearchMentorship/MathJournals.html` | C / C2 Moderate standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `130Test4.html` | C / C2 Moderate standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | None recorded |
+| `employeepay.html` | C / C2 Moderate standalone pages | Not started | TBD | Not started / Not started / Not started / Not started | Intentional chart dataset literals expected |


### PR DESCRIPTION
### Motivation
- Provide a repository-level tracker to drive Phase 1 color token migration using the bucket inventory defined in `ColorPhase0Execution.md`.
- Ensure every file from Section 2 is represented with a consistent set of columns for migration coordination and visual QA.
- Emphasize migration sequencing constraints so high-risk standalone pages are controlled during PRs.

### Description
- Add `ColorMigrationTracker.md` at the repo root containing a seeded table of all files listed in Section 2 (Buckets A, B1, B2, C1, and C2) with the requested columns: bucket/sub-bucket, migration status, PR number, visual QA status (light/dark/print/forced-colors), and notes on intentional literals.
- Seed every entry as `Not started` and set PR placeholders to `TBD`, and include a `Status key` that defines `Not started` → `In progress` → `Complete` and QA conventions.
- Mark `Bucket A` as the first target and add an explicit reminder that Bucket C1 high-risk files are migrated one-per-PR only.
- Structure content for easy updates during execution and for attaching per-PR validation artifacts (inventory excerpts and screenshots) per the Phase 0 policy.

### Testing
- Ran `wc -l ColorMigrationTracker.md` to confirm the new file content length, which succeeded.
- Ran `git status --short` to verify the tracker is present as an uncommitted/new file in the working tree, which succeeded.
- Printed the new file with line numbers (`nl -ba ColorMigrationTracker.md`) to verify the seeded entries and table formatting, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c67be7e0988331adc749ff71129202)