### PR TITLE
Update ColorMigrationTracker last reconciled metadata through PR #182

### DIFF
--- a/ColorMigrationTracker.md
+++ b/ColorMigrationTracker.md
@@ -6,7 +6,7 @@ Tracking document for Phase 1 execution based on Section 2 of `ColorPhase0Execut
 - Initial seeding rule: all entries start as `Not started`.
 - First target for migration execution: **Bucket A**.
 - **Reminder:** Bucket C high-risk files (C1) are **one-per-PR only**.
-- **Last reconciled:** `bb28136` on 2026-03-27 (UTC) to align tracker status with merged history through PR #181.
+- **Last reconciled:** `44b4ed0` on 2026-03-27 (UTC) to align tracker status with merged history through PR #182.
 
 ## Status key
 - **Migration status:** `Not started` → `In progress` → `Complete`


### PR DESCRIPTION
### Motivation
- Bring the tracker up to date with merged history through PR #182 by recording the explicit commit hash, UTC date, and scope so future reconciliations are auditable.

### Description
- Edit `ColorMigrationTracker.md` to replace the previous line with `- **Last reconciled:** `44b4ed0` on 2026-03-27 (UTC) to align tracker status with merged history through PR #182.` and commit the change with message `Update tracker reconciliation metadata through PR #182`.

### Testing
- Ran the automated update script (Python) which printed `updated`, verified the change with `git diff -- ColorMigrationTracker.md && git status --short`, and validated the referenced commit with `git show -s --format='%H%n%cd' --date=format-local:'%Y-%m-%d' 44b4ed0`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68deccfb88331868c5ee40025b1c6)