### PR TITLE
Update Phase 0 review baseline to latest merged PR

### DIFF
--- a/ColorPhase0Execution.md
+++ b/ColorPhase0Execution.md
@@ -177,7 +177,7 @@ These color literals are expected to remain page-local unless later explicitly a
 
 ## 7) Review Intake Log (Phase 0)
 
-- Latest commit reviewed before edits: `5ff7133` (merge of PR #177) via `git log -1 --oneline` on 2026-03-26.
+- Latest commit reviewed before edits: `a50037f` (merge of PR #183) via `git log -1 --oneline` on 2026-03-27.
 - PR discussion and inline comment review attempted via `gh pr status`; GitHub CLI is not available in this environment (`gh: command not found`).
 - Because PR discussion tooling is unavailable here, outstanding inline comments cannot be verified in this environment; scope remained locked to documentation updates only.
 - Current scope lock for this turn: **Phase 0 docs only**.


### PR DESCRIPTION
### Motivation
- Replace a stale review-baseline reference in Section 7 of `ColorPhase0Execution.md` so the document reflects the repository's current last-reviewed merge (`a50037f`, PR #183) while preserving the note about `gh` being unavailable.

### Description
- Updated the single baseline line in Section 7 to read: `a50037f` (merge of PR #183) via `git log -1 --oneline` on 2026-03-27, and left the `gh: command not found` tooling limitation note unchanged.

### Testing
- Verified the current HEAD merge commit with `git log -1 --oneline --no-decorate` and inspected the modified lines with `nl -ba ColorPhase0Execution.md | sed -n '176,186p'`, both commands succeeded; the change was staged and committed successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68e56d758833186503eeebbf14d0d)