### PR TITLE
docs: add Phase 1 readiness checkpoint to execution plan

### DIFF
--- a/ColorPhase0Execution.md
+++ b/ColorPhase0Execution.md
@@ -191,3 +191,8 @@ Phase 1 can start when all conditions below are true:
 2. Bucket table in Section 2 is approved.
 3. Token contract starter in Section 3 is approved.
 4. Exception seed list in Section 4 is approved.
+
+### Checkpoint (2026-03-27, UTC)
+> **Owner:** Andrew Volk  
+> **Ready-to-Start Criteria for Phase 1:** **Satisfied** (Sections 1–4 approved).  
+> **Execution active:** **PR 2/3 lane** (global shell migration + legacy alias redirection sequence).


### PR DESCRIPTION
### Motivation
- Make the Phase 0 -> Phase 1 handoff explicit and auditable by recording a concise checkpoint with date, owner, readiness status, and the active execution phase marker in the execution plan document.

### Description
- Inserted a `### Checkpoint (2026-03-27, UTC)` block into `ColorPhase0Execution.md` that records `Owner: Andrew Volk`, `Ready-to-Start Criteria for Phase 1: Satisfied (Sections 1–4 approved)`, and `Execution active: PR 2/3 lane` (global shell migration + legacy alias redirection sequence).

### Testing
- Applied the patch successfully and verified the inserted lines by inspecting the file with `nl -ba ColorPhase0Execution.md | sed -n '190,240p'`, which shows the new checkpoint block.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68ebbf1ec8331bd89b37a8ee0f52a)