### PR TITLE
Finalize legacy alias semantic routing and lifecycle guardrails

### DIFF
--- a/ColorPhase0Execution.md
+++ b/ColorPhase0Execution.md
@@ -129,6 +129,12 @@ This registry is intentionally small for PR 1 and will expand as files are migra
 | status info colors | `--status-info`, `--status-info-bg`, `--status-info-border` | Review/alert UIs | Keep status semantics explicit |
 | overlay/backdrop alpha layers | `--overlay-light`, `--overlay-medium`, `--overlay-dark` | Global + standalone modals/overlays | Preserve intentional translucency via semantic channels |
 
+### Alias lifecycle guardrails (compatibility window)
+
+- Compatibility aliases are **temporary** and remain available for **one full release cycle after Bucket C migration sign-off**.
+- During that window, aliases must map to Tier 2 semantic channels (for example `--text-body`, `--bg-surface`, `--primary-base`) rather than directly to literals.
+- No blind generic alias replacements are allowed. New or changed generic aliases (`--text`, `--bg`, `--surface`, `--border`, `--accent`) are only allowed in approved scoped bridge patterns (for example the Math 130 review layer bridge block).
+
 ---
 
 ## 4) Exception Registry Seed (Intentional Literals)

--- a/styles.css
+++ b/styles.css
@@ -74,7 +74,13 @@
   --status-info: #1A56DB;
   --status-info-bg: rgba(26, 86, 219, 0.08);
   --status-info-border: rgba(26, 86, 219, 0.32);
-  /* Legacy aliases routed through semantic tokens */
+  /*
+   * Legacy compatibility aliases (temporary):
+   * - Keep during migration window only (one full release cycle after Bucket C sign-off).
+   * - Every alias must resolve through Tier 2 semantic tokens (no direct Tier 1/literal wiring).
+   * - Do not introduce blind generic aliases (for example --text/--bg/--surface/--border/--accent)
+   *   outside approved scoped mapping patterns.
+   */
   --primary-color: var(--primary-base);
   --secondary-color: var(--text-heading);
   --accent-color: var(--primary-base);
@@ -85,8 +91,8 @@
   --card-background: var(--bg-surface);
   --featured-card-surface: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0)), linear-gradient(135deg, rgba(0, 29, 23, 0.96), rgba(0, 52, 43, 0.92));
   --featured-card-base: #002720;
-  --featured-card-text: var(--on-primary);
-  --featured-card-accent: color-mix(in srgb, var(--secondary) 78%, white 22%);
+  --featured-card-text: var(--primary-text);
+  --featured-card-accent: color-mix(in srgb, var(--primary-base) 78%, white 22%);
 
   --font-display: "Newsreader", "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
   --font-body: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
@@ -1826,8 +1832,8 @@ main.error-main {
   --card-background: var(--bg-surface);
   --featured-card-surface: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0)), linear-gradient(135deg, rgba(22, 29, 27, 0.95), rgba(33, 72, 62, 0.88));
   --featured-card-base: #16211d;
-  --featured-card-text: var(--on-surface);
-  --featured-card-accent: color-mix(in srgb, var(--secondary) 82%, var(--primary-container));
+  --featured-card-text: var(--primary-text);
+  --featured-card-accent: color-mix(in srgb, var(--primary-base) 82%, var(--primary-surface));
   --glass-surface: rgba(31, 39, 36, 0.85);
   --ghost-outline: rgba(94, 107, 102, 0.18);
   --ambient-outline: rgba(94, 107, 102, 0.36);
@@ -2730,6 +2736,7 @@ main.error-main {
 
 body.review-page,
 .math-review-page {
+  /* Approved scoped bridge aliases for legacy Math 130 review markup only. */
   --bg: var(--review-bg);
   --surface: var(--review-surface);
   --surface2: var(--review-surface-2);


### PR DESCRIPTION
### Motivation

- Ensure all remaining legacy compatibility aliases in `styles.css` route through Tier 2 semantic tokens so migration semantics are consistent and literals are not reintroduced. 
- Record alias lifecycle expectations and prevent unapproved broad/generic alias additions during the migration compatibility window. 
- Provide an explicit, scoped exception pattern for the Math 130 review layer so necessary bridge aliases can exist without enabling blind global replacements.

### Description

- Added a compatibility comment block in `:root` of `styles.css` documenting the temporary compatibility window and the rule that aliases must resolve via Tier 2 semantic tokens (no direct Tier 1/literal wiring). 
- Updated legacy featured-card aliases to resolve through semantic tokens by changing `--featured-card-text` to `var(--primary-text)` and `--featured-card-accent` to use `var(--primary-base)`/`var(--primary-surface)` in both default and dark theme blocks. 
- Annotated the Math 130 review block with a clear comment marking it as an approved scoped bridge pattern for legacy markup and kept its bridge aliases localized there. 
- Documented the alias lifecycle guardrails in `ColorPhase0Execution.md`, including the one-release compatibility window and prohibition on blind generic alias replacements outside approved scopes.

### Testing

- Ran `git diff --check` which succeeded with no whitespace/error issues. 
- Verified token/alias changes with targeted searches (`rg -n -e "--featured-card-text: var\(--primary-text\);" -e "--featured-card-accent: color-mix\(in srgb, var\(--primary-base\)" styles.css`) which returned the updated lines. 
- Verified documentation additions with `rg -n "Alias lifecycle guardrails|one full release cycle|No blind generic alias replacements" ColorPhase0Execution.md` which returned the new guardrail section. 
- Commit completed successfully; no visual/screenshot checks were performed due to environment limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69121a0108331b0da814102c500f6)