### PR TITLE
Add ColorMigrationQALog and require per-PR QA evidence in tracker/docs

### DIFF
--- a/ColorMigrationQALog.md
+++ b/ColorMigrationQALog.md
@@ -1,0 +1,95 @@
+# Color Migration QA Log
+
+This companion QA document is the **repeatable archive location** for required color-migration PR evidence.
+
+## Required evidence per color migration PR
+
+For every color migration PR, record and attach all four artifacts below:
+
+1. `colors.md` **before/after excerpt** (inventory delta evidence).
+2. **Generic alias collision check** result.
+3. **Unapproved literal status-color check** result.
+4. **Print + forced-colors presence verification** result.
+
+> Policy: A color migration PR is not QA-complete until all four artifacts are present in this log.
+
+## Command templates (repeatable)
+
+Run these from repo root and paste results in the matching PR section.
+
+### 1) Generic alias collision check
+```bash
+rg -n --no-heading --glob '*.css' --glob '*.html' -- "var\\(--(text|bg|surface|border|accent)\\)"
+```
+
+### 2) Unapproved literal status-color check
+```bash
+rg -n --no-heading --glob '*.css' --glob '*.html' -- "(success|warning|error|info)[^\\n]*?(#([0-9a-fA-F]{3,8})|rgba?\\()"
+```
+
+### 3) Print + forced-colors presence verification
+```bash
+rg -n --no-heading --glob '*.css' --glob '*.html' -- "@media\\s*print|@media\\s*\\(forced-colors:\\s*active\\)"
+```
+
+### 4) `colors.md` before/after excerpt capture
+```bash
+# Example pattern: capture summary block for attachment
+sed -n '1,120p' colors.md
+```
+
+## PR Evidence Entries
+
+Copy this template for each color migration PR.
+
+---
+
+### PR #<number> — <title>
+- Date (UTC): `<YYYY-MM-DD>`
+- Scope: `<files or bucket>`
+- Owner: `<name>`
+
+#### 1) `colors.md` before/after excerpt
+- Before (commit `<sha>`):
+```text
+<paste excerpt>
+```
+- After (commit `<sha>`):
+```text
+<paste excerpt>
+```
+
+#### 2) Generic alias collision check result
+Command:
+```bash
+rg -n --no-heading --glob '*.css' --glob '*.html' -- "var\\(--(text|bg|surface|border|accent)\\)"
+```
+Output:
+```text
+<paste output>
+```
+
+#### 3) Unapproved literal status-color check result
+Command:
+```bash
+rg -n --no-heading --glob '*.css' --glob '*.html' -- "(success|warning|error|info)[^\\n]*?(#([0-9a-fA-F]{3,8})|rgba?\\()"
+```
+Output:
+```text
+<paste output>
+```
+
+#### 4) Print + forced-colors presence verification
+Command:
+```bash
+rg -n --no-heading --glob '*.css' --glob '*.html' -- "@media\\s*print|@media\\s*\\(forced-colors:\\s*active\\)"
+```
+Output:
+```text
+<paste output>
+```
+
+#### Sign-off
+- [ ] Evidence complete and attached to PR
+- [ ] Reviewer verified outputs match PR diff
+- [ ] Tracker + PR checklist updated

--- a/ColorMigrationTracker.md
+++ b/ColorMigrationTracker.md
@@ -6,6 +6,7 @@ Tracking document for Phase 1 execution based on Section 2 of `ColorPhase0Execut
 - Initial seeding rule: all entries start as `Not started`.
 - First target for migration execution: **Bucket A**.
 - **Reminder:** Bucket C high-risk files (C1) are **one-per-PR only**.
+- **Per-PR evidence archive:** Record required migration QA artifacts in `ColorMigrationQALog.md` for every color migration PR.
 - **Last reconciled:** `44b4ed0` on 2026-03-27 (UTC) to align tracker status with merged history through PR #182.
 
 ## Status key

--- a/ColorPhase0Execution.md
+++ b/ColorPhase0Execution.md
@@ -178,6 +178,7 @@ These color literals are expected to remain page-local unless later explicitly a
 - Confirm no unapproved new literal status colors.
 - Confirm print and forced-colors support still present where applicable.
 - For Bucket C PRs: include side-by-side screenshot diffs.
+- Archive all required check outputs in `ColorMigrationQALog.md` (or linked PR checklist entry) for repeatable auditability.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Provide a repeatable, auditable place to attach the four required artifacts for every color-migration PR so QA evidence is standardized. 
- Prevent missing or inconsistent per-PR outputs (inventory deltas, alias-collision checks, status-literal checks, and print/forced-colors checks) during the color-token migration. 
- Ensure Phase-0 docs and the migration tracker explicitly enforce archival of those automated checks to make PR review and audits straightforward.

### Description
- Add `ColorMigrationQALog.md` with a per-PR evidence template and repeatable command snippets for the four required artifacts: `colors.md` before/after excerpt, generic alias collision check, unapproved literal status-color check, and print + forced-colors verification. 
- Update `ColorMigrationTracker.md` to require recording per-PR migration QA artifacts in `ColorMigrationQALog.md`. 
- Update `ColorPhase0Execution.md` to explicitly require archiving all per-PR check outputs in `ColorMigrationQALog.md` (or a linked PR checklist entry) for repeatable auditability.

### Testing
- Verified the new log and doc references exist using `rg -n "Per-PR evidence archive|ColorMigrationQALog|Archive all required check outputs" ColorMigrationTracker.md ColorPhase0Execution.md ColorMigrationQALog.md` and confirmed matches. 
- Printed and inspected the new `ColorMigrationQALog.md` and the updated sections of `ColorMigrationTracker.md` and `ColorPhase0Execution.md` using `nl -ba` + `sed` to confirm the template and wording were present. 
- Ran `git status --short` to validate working tree cleanliness after the changes; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c693cba4c08331a2e8724e8abd826b)