### PR TITLE
Remove stale Cloudflare email-decode script includes

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -421,7 +421,7 @@
   </div>
 </div>
 
-<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script>
+<script>
 // KaTeX
 function renderMath(){document.querySelectorAll('.k').forEach(el=>{if(el.dataset.rendered)return;try{katex.render(el.textContent,el,{throwOnError:false});el.dataset.rendered='true';}catch(e){}})}
 function renderLatexString(s){return s.replace(/\\?\\\((.+?)\\?\\\)/g,(_,t)=>{const sp=document.createElement('span');try{katex.render(t,sp,{throwOnError:false})}catch(e){sp.textContent=t}return sp.outerHTML})}

--- a/130Test2.html
+++ b/130Test2.html
@@ -1464,7 +1464,7 @@
 </div>
 </div>
 </div>
-<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script>
+<script>
     // --- ICON REFRESH (debounced to prevent redundant DOM walks) ---
     let _iconTimer = null;
     function refreshIcons() {

--- a/130Test3.html
+++ b/130Test3.html
@@ -1509,7 +1509,7 @@
 </div>
 </div>
 </div>
-<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script>
+<script>
     // --- ICON REFRESH (debounced to prevent redundant DOM walks) ---
     let _iconTimer = null;
     function refreshIcons() {

--- a/130Test4.html
+++ b/130Test4.html
@@ -786,7 +786,7 @@
     </section>
 
 </div>
-<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script>
+<script>
 // Nav handled by theme.js setupGlobalNav
 
 document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
### Motivation
- Cloudflare's injected email-obfuscation script reference (`/cdn-cgi/scripts/.../email-decode.min.js`) is not served on GitHub Pages and produced a recurring 404 console error on several pages.

### Description
- Remove the stale `<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script>` include from `130Test1.html`, `130Test2.html`, `130Test3.html`, and `130Test4.html` while leaving each page's existing inline `<script>` block intact.

### Testing
- Ran `rg -n "cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js|data-cfasync=\"false\""` across the modified files and confirmed there are no remaining matches (no 404-causing includes remain).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c93c519c83319649cb2b596c1279)