### PR TITLE
Fix disappearing Practice generators in 130Test1/130Test2

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -520,7 +520,7 @@ function initPracticeView(){
   practiceInit=true;
   const hist=loadHist().practice;
   const bestLine=hist.length?`<div style="margin-bottom:1rem"><span class="history-badge badge-green">Best: ${Math.min(...hist.map(h=>h.retries))} retries</span> <span style="color:var(--text-muted);font-size:0.82rem">across ${hist.length} session${hist.length>1?'s':''}</span></div>`:'';
-  document.getElementById('practice-container').innerHTML=`<div class="quiz-intro"><h2 style="font-family:var(--type-display-family);font-size:1.8rem;margin-bottom:0.5rem">Practice Mode</h2><p>${allProblems.length} problems in random order. Work each on paper, reveal the solution, then mark it. Missed problems recycle until you get them all right.</p>${bestLine}<button class="practice-start-btn" onclick="startPractice()">Start Practice</button></div>`;
+  document.getElementById('practice-container').innerHTML=`<div class="quiz-intro"><h2 style="font-family:var(--type-display-family);font-size:1.8rem;margin-bottom:0.5rem">Practice Mode</h2><p>${allProblems.length} problems in random order. Work each on paper, reveal the solution, then mark it. Missed problems recycle until you get them all right.</p>${bestLine}<button class="practice-start-btn" onclick="startPractice()" type="button">Start Practice</button></div>`;
 }
 
 function startPractice(){
@@ -529,9 +529,13 @@ function startPractice(){
 }
 
 function showPP(){
-  const c=document.getElementById('practice-container'),pi=practiceQueue[practiceIdx],p=allProblems[pi],rem=practiceQueue.length-practiceIdx;
+  const c=document.getElementById('practice-container');
+  if(!c)return;
+  const pi=practiceQueue[practiceIdx],p=allProblems[pi];
+  if(!p){initPracticeView();return;}
+  const rem=practiceQueue.length-practiceIdx;
   practiceSolShown=false;
-  c.innerHTML=`<div class="practice-dashboard"><div class="practice-stat"><div class="stat-num stat-green">${practiceCorrect}</div><div class="stat-label">Correct</div></div><div class="practice-stat"><div class="stat-num stat-red">${practiceMissed}</div><div class="stat-label">To Retry</div></div><div class="practice-stat"><div class="stat-num stat-blue">${rem}</div><div class="stat-label">Remaining</div></div></div><div class="problem-card"><div class="problem-label"><span>${p.label}${p._missed?'<span class="problem-tag-retry">RETRY</span>':''}</span><span class="problem-pts">${p.pts}</span></div><div class="problem-text">${p.text}</div><div class="practice-btn-row" id="pbtns"><button class="solution-toggle" onclick="revealPS()">Show Solution ▾</button></div><div class="solution" id="psol"><div class="solution-inner">${p.solution}</div></div></div>`;
+  c.innerHTML=`<div class="practice-dashboard"><div class="practice-stat"><div class="stat-num stat-green">${practiceCorrect}</div><div class="stat-label">Correct</div></div><div class="practice-stat"><div class="stat-num stat-red">${practiceMissed}</div><div class="stat-label">To Retry</div></div><div class="practice-stat"><div class="stat-num stat-blue">${rem}</div><div class="stat-label">Remaining</div></div></div><div class="problem-card"><div class="problem-label"><span>${p.label}${p._missed?'<span class="problem-tag-retry">RETRY</span>':''}</span><span class="problem-pts">${p.pts}</span></div><div class="problem-text">${p.text}</div><div class="practice-btn-row" id="pbtns"><button class="solution-toggle" onclick="revealPS()" type="button">Show Solution ▾</button></div><div class="solution" id="psol"><div class="solution-inner">${p.solution}</div></div></div>`;
   setTimeout(renderMath,50);
 }
 
@@ -558,7 +562,7 @@ function pMiss(){
 function showPC(){
   // Save session
   saveSession('practice',{correct:practiceCorrect,retries:practiceMissed,total:allProblems.length});
-  document.getElementById('practice-container').innerHTML=`<div class="practice-complete"><div class="big-check">🎉</div><h2>All Problems Cleared!</h2><div class="practice-stats-final"><div class="final-stat"><span class="num stat-green">${practiceCorrect}</span><span class="lbl">Correct</span></div><div class="final-stat"><span class="num stat-red">${practiceMissed}</span><span class="lbl">Retries</span></div><div class="final-stat"><span class="num stat-blue">${allProblems.length}</span><span class="lbl">Problems</span></div></div><p>${practiceMissed===0?'Perfect run — every problem on the first try!':'You cleared them all. Review the retried topics before test day.'}</p><button class="practice-start-btn" onclick="startPractice()">Practice Again</button></div>`;
+  document.getElementById('practice-container').innerHTML=`<div class="practice-complete"><div class="big-check">🎉</div><h2>All Problems Cleared!</h2><div class="practice-stats-final"><div class="final-stat"><span class="num stat-green">${practiceCorrect}</span><span class="lbl">Correct</span></div><div class="final-stat"><span class="num stat-red">${practiceMissed}</span><span class="lbl">Retries</span></div><div class="final-stat"><span class="num stat-blue">${allProblems.length}</span><span class="lbl">Problems</span></div></div><p>${practiceMissed===0?'Perfect run — every problem on the first try!':'You cleared them all. Review the retried topics before test day.'}</p><button class="practice-start-btn" onclick="startPractice()" type="button">Practice Again</button></div>`;
 }
 
 // ═══ QUIZ ═══

--- a/130Test2.html
+++ b/130Test2.html
@@ -1159,7 +1159,7 @@
 </div>
 </div>
 <!-- Exam Progress Bar (hidden until active) -->
-<div id="exam-progress-bar" class="u-hidden u-mb-lg">
+<div id="exam-progress-bar" class="u-mb-lg" style="display:none;">
 <div class="u-flex-between-center u-mb-xs">
 <span id="exam-mode-label" class="u-text-accent-strong">Mock Exam</span>
 <span id="exam-progress-label" class="u-meta-muted-sm">1 / 15</span>
@@ -1169,7 +1169,7 @@
 </div>
 </div>
 <!-- Exam Results (hidden until complete) -->
-<div class="card review-card u-hidden" id="exam-results">
+<div class="card review-card" id="exam-results" style="display:none;">
 <h2 class="u-text-center">📊 Exam Results</h2>
 <div id="exam-score-display" class="review-results-score"></div>
 <div id="exam-breakdown" class="u-mt-md"></div>
@@ -1178,7 +1178,7 @@
 </div>
 </div>
 <div class="quiz-selector" id="quiz-categories"></div>
-<div class="quiz-box quiz-box--active-shell u-hidden" id="quiz-active-area">
+<div class="quiz-box quiz-box--active-shell" id="quiz-active-area" style="display:none;">
 <div id="svg-display"></div>
 <div class="question-text" id="question-display"></div>
 <div class="question-note" id="question-note" class="u-hidden"></div>
@@ -1187,8 +1187,8 @@
 </div>
 <div class="u-flex-align-center-wrap u-gap-sm">
 <button class="btn-primary" id="btn-submit">Check Answer</button>
-<button class="btn-secondary u-hidden" id="btn-next">Next Question</button>
-<button id="btn-exit-exam" onclick="confirmExitExam()" class="btn-ghost-muted u-hidden u-ml-auto">✕ Exit</button>
+<button class="btn-secondary" id="btn-next" style="display:none;">Next Question</button>
+<button id="btn-exit-exam" onclick="confirmExitExam()" class="btn-ghost-muted u-ml-auto" style="display:none;">✕ Exit</button>
 </div>
 <div class="feedback" id="feedback-display"></div>
 </div>


### PR DESCRIPTION
### Motivation
- Practice/Exam controls could be shown/hidden by JS, but some elements in `130Test2.html` used the utility class `u-hidden` (which sets `display: none !important`) so later `style.display` toggles could not make them visible, causing the Practice generators to appear to disappear. 
- `showPP()` in `130Test1.html` assumed DOM and problem state were present and used buttons without explicit `type`, which can produce unexpected behavior in some contexts.

### Description
- Replaced `u-hidden` on JS-controlled elements in `130Test2.html` with inline `style="display:none;"` defaults for `#exam-progress-bar`, `#exam-results`, `#quiz-active-area`, `#btn-next`, and `#btn-exit-exam` so existing `style.display` show/hide logic works as intended.
- Hardened `showPP()` in `130Test1.html` by adding defensive checks for the container and current problem, and falling back to `initPracticeView()` when appropriate to avoid rendering blank UI.
- Added explicit `type="button"` to Start/Practice action buttons in `130Test1.html` to prevent default submit behavior from interfering with interactive flow.
- Minor button markup updates: made the in-problem "Show Solution" toggle and the final "Practice Again" button explicit `type="button"`.

### Testing
- Verified presence and replacement of targeted elements using `rg` and `sed` lookups and inspected the modified regions with `nl`/`sed` to confirm the inline `style="display:none;"` and `type="button"` insertions (commands executed and returned expected output). (succeeded)
- Confirmed script edits by viewing the `git diff` output for `130Test1.html` and `130Test2.html` (command executed and diff contains expected changes). (succeeded)
- Committed the changes and checked `git status --short` to ensure a clean workspace after commit. (succeeded)
- No automated browser tests were available in this environment; visual verification would be recommended in a browser to confirm the Practice / Exam panels become visible after pressing Start. (no automated browser test run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6cc49ac988331b7ed9703548a72d8)