### PR TITLE
Fix contrast for Recommended Start card and hero primary CTAs

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -805,18 +805,24 @@ section h2 {
   position: relative;
   padding: clamp(1.75rem, 3vw, 2.5rem);
   border-radius: var(--radius-lg);
-  background-color: color-mix(in srgb, var(--bg-base) 18%, var(--surface-transparent));
+  background-color: var(--bg-surface);
   background-image: linear-gradient(180deg, var(--surface-transparent), var(--surface-transparent));
-  color: var(--featured-card-text);
+  color: var(--text-main);
   backdrop-filter: blur(6px);
   transform: translateY(var(--spacing-8));
 }
 
-.highlighted-destination-card h3,
+.highlighted-destination-card h3 {
+  color: var(--text-main);
+}
+
 .highlighted-destination-card p,
-.highlighted-destination-card li,
-.highlighted-destination-card a {
-  color: var(--featured-card-text);
+.highlighted-destination-card li {
+  color: var(--text-muted);
+}
+
+.highlighted-destination-card a:not(.button) {
+  color: var(--text-main);
 }
 
 .highlighted-destination-card h3 {
@@ -824,9 +830,18 @@ section h2 {
   font-size: clamp(1.9rem, 3vw, 2.4rem);
 }
 
+.hero-cta-cluster > .button:not(.button-secondary),
+.highlighted-destination-card .button {
+  background: linear-gradient(180deg, var(--surface-transparent), var(--surface-transparent)), var(--primary-main);
+  color: var(--bg-surface);
+}
+
+.hero-cta-cluster > .button:not(.button-secondary):hover,
+.hero-cta-cluster > .button:not(.button-secondary):focus-visible,
 .highlighted-destination-card .button:hover,
 .highlighted-destination-card .button:focus-visible {
-  background: linear-gradient(180deg, var(--surface-transparent), var(--surface-transparent)), var(--featured-card-accent);
+  background: linear-gradient(180deg, var(--surface-transparent), var(--surface-transparent)), color-mix(in srgb, var(--primary-main) 85%, black);
+  color: var(--bg-surface);
 }
 
 .supporting-link-list {


### PR DESCRIPTION
### Motivation
- The recent tokenized color refactor exposed contrast regressions on the home hero: the light "Recommended start" card sat on a dark green hero and its copy was inheriting/using the wrong contrast tokens, and the primary CTAs used a pale `--primary-soft` background with white text making them unreadable.

### Description
- Change `.highlighted-destination-card` background to `var(--bg-surface)` and set the card-level text to `var(--text-main)` for headings and `var(--text-muted)` for paragraph/list copy, with non-button links using `var(--text-main)`.
- Scope and convert hero primary CTAs (`Browse courses` and `Go to Learn`) to high-contrast primary styling by targeting `.hero-cta-cluster > .button:not(.button-secondary)` and `.highlighted-destination-card .button`, setting background to `var(--primary-main)` and text to `var(--bg-surface)`.
- Update hover and focus states for these CTAs to a darker shade via `color-mix(in srgb, var(--primary-main) 85%, black)` and ensure hover text remains `var(--bg-surface)`.

### Testing
- Searched and inspected selectors with `rg` and `sed` to confirm targeted HTML elements and CSS locations, and these checks completed successfully.
- Verified the updated CSS snippet with `git diff -- styles.css` which showed the intended changes successfully.
- Committed the changes with `git commit -m "Fix home hero card and primary button contrast"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6cdf878f08331a7e93cf75e9c057c)