### PR TITLE
Add KaTeX CDN + local fallback, runtime warnings, and placeholder vendor assets

### DIFF
--- a/130Test1.html
+++ b/130Test1.html
@@ -8,9 +8,47 @@
 <title>Math 130 – Test 1 Study Guide</title>
 <!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.js"></script>
+<script id="katex-js-cdn" src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.js"></script>
 <!-- Page-specific external CSS: KaTeX styles are required for math formula rendering. -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
+<link id="katex-css-cdn" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
+<script>
+(function () {
+  const localKatexAssets = {
+    css: 'assets/vendor/katex/dist/katex.min.css',
+    js: 'assets/vendor/katex/dist/katex.min.js'
+  };
+
+  function loadLocalCss() {
+    if (document.getElementById('katex-css-local')) return;
+    const localCss = document.createElement('link');
+    localCss.id = 'katex-css-local';
+    localCss.rel = 'stylesheet';
+    localCss.href = localKatexAssets.css;
+    document.head.appendChild(localCss);
+  }
+
+  function loadLocalScript() {
+    if (document.getElementById('katex-js-local')) return;
+    const script = document.createElement('script');
+    script.id = 'katex-js-local';
+    script.defer = true;
+    script.src = localKatexAssets.js;
+    document.head.appendChild(script);
+  }
+
+  window.loadLocalKatexAssets = function () {
+    loadLocalCss();
+    loadLocalScript();
+  };
+
+  window.addEventListener('DOMContentLoaded', function () {
+    const cssCdn = document.getElementById('katex-css-cdn');
+    const jsCdn = document.getElementById('katex-js-cdn');
+    if (cssCdn) cssCdn.addEventListener('error', window.loadLocalKatexAssets);
+    if (jsCdn) jsCdn.addEventListener('error', window.loadLocalKatexAssets);
+  });
+})();
+</script>
 <style>
   /* Page-specific styles only; shared Math 130 review tokens/components live in styles.css. */
 
@@ -175,6 +213,17 @@
 
   .katex { font-size: 1.05em; }
   .formula-box .katex { font-size: 1.1em; }
+  .math-noscript, .math-runtime-warning {
+    margin: 0.8rem 0 1rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 10px;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
+  }
+  .math-noscript { color: var(--text-muted); border-left: 4px solid var(--text-muted); }
+  .math-runtime-warning { color: var(--danger-main); border-left: 4px solid var(--danger-main); }
   ::-webkit-scrollbar { width: 6px; }
   ::-webkit-scrollbar-track { background: var(--bg-base); }
   ::-webkit-scrollbar-thumb { background: var(--border-subtle); border-radius: 3px; }
@@ -367,6 +416,8 @@
 
   <!-- FORMULAS -->
   <div id="tab-formulas" class="tab-content">
+    <noscript><div class="math-noscript">JavaScript is required to render the math formulas on this page.</div></noscript>
+    <div id="math-runtime-warning" class="math-runtime-warning" aria-live="polite" hidden=""></div>
     <button class="print-btn" onclick="window.print()">🖨️ Print Formula Sheet</button>
 
     <div class="formula-section review-formula-section"><h3>📐 Core Algebra</h3><div class="formula-grid">
@@ -717,7 +768,11 @@ function doReset(){
   renderProgress();
 }
 
-initCL();renderMath();
+initCL();
+if(!window.katex){
+  if(window.loadLocalKatexAssets)window.loadLocalKatexAssets();
+  setTimeout(()=>{if(!window.katex)showMathRuntimeWarning('Math rendering is unavailable right now. CDN and local KaTeX fallback both failed to initialize.');renderMath();},250);
+}else{renderMath();}
 </script>
 </div>
 </body>

--- a/130Test2.html
+++ b/130Test2.html
@@ -11,10 +11,63 @@
 <!-- Fonts -->
 <!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&amp;family=JetBrains+Mono:wght@400;500&amp;family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600;6..72,700&amp;display=swap" rel="stylesheet"/>
-<!-- KaTeX for Math Rendering -->
-<link href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" rel="stylesheet"/>
-<script defer="" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
-<script defer="" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>
+<!-- KaTeX for Math Rendering (CDN first, local fallback) -->
+<link href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" id="katex-css-cdn" rel="stylesheet"/>
+<script defer="" id="katex-js-cdn" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
+<script defer="" id="katex-autorender-cdn" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>
+<script>
+(function () {
+    const localKatexAssets = {
+        css: 'assets/vendor/katex/dist/katex.min.css',
+        js: 'assets/vendor/katex/dist/katex.min.js',
+        autoRender: 'assets/vendor/katex/dist/contrib/auto-render.min.js'
+    };
+
+    window.__katexFallbackState = {
+        attempted: false,
+        reason: '',
+        localAssets: localKatexAssets
+    };
+
+    function loadLocalCss() {
+        if (document.getElementById('katex-css-local')) return;
+        const localCss = document.createElement('link');
+        localCss.id = 'katex-css-local';
+        localCss.rel = 'stylesheet';
+        localCss.href = localKatexAssets.css;
+        document.head.appendChild(localCss);
+    }
+
+    function loadLocalScript(id, src) {
+        if (document.getElementById(id)) return;
+        const script = document.createElement('script');
+        script.id = id;
+        script.defer = true;
+        script.src = src;
+        document.head.appendChild(script);
+    }
+
+    window.loadLocalKatexAssets = function (reason) {
+        if (!window.__katexFallbackState.attempted) {
+            window.__katexFallbackState.attempted = true;
+            window.__katexFallbackState.reason = reason || 'unknown';
+        }
+        loadLocalCss();
+        loadLocalScript('katex-js-local', localKatexAssets.js);
+        loadLocalScript('katex-autorender-local', localKatexAssets.autoRender);
+    };
+
+    window.addEventListener('DOMContentLoaded', function () {
+        const cssCdn = document.getElementById('katex-css-cdn');
+        const jsCdn = document.getElementById('katex-js-cdn');
+        const autoCdn = document.getElementById('katex-autorender-cdn');
+
+        if (cssCdn) cssCdn.addEventListener('error', function () { window.loadLocalKatexAssets('katex-css-cdn-error'); });
+        if (jsCdn) jsCdn.addEventListener('error', function () { window.loadLocalKatexAssets('katex-js-cdn-error'); });
+        if (autoCdn) autoCdn.addEventListener('error', function () { window.loadLocalKatexAssets('katex-autorender-cdn-error'); });
+    });
+})();
+</script>
 <!-- Icons -->
 <script defer="" src="https://cdn.jsdelivr.net/npm/lucide@0.344.0/dist/umd/lucide.min.js"></script>
 <style>
@@ -194,6 +247,24 @@
         .formula-math.steps-math .step-label { font-size: 0.95rem; font-weight: 700; letter-spacing: 0.02em; color: var(--text-muted); text-transform: uppercase; }
         .formula-math.steps-math .katex-display { margin: 0.05rem 0; }
         .formula-vars { color: var(--text-muted); font-size: 0.8rem; margin-top: 0.5rem; line-height: 1.5; }
+        .math-noscript,
+        .math-runtime-warning {
+            margin: 0.9rem 0 1.2rem;
+            padding: 0.75rem 0.9rem;
+            border-radius: 10px;
+            font-size: 0.9rem;
+            line-height: 1.5;
+            background: var(--bg-surface);
+            box-shadow: inset 0 0 0 1px var(--border-transparent);
+        }
+        .math-noscript {
+            border-left: 4px solid var(--text-muted);
+            color: var(--text-muted);
+        }
+        .math-runtime-warning {
+            border-left: 4px solid var(--danger-main);
+            color: var(--danger-main);
+        }
 
         /* Quiz Section */
         .quiz-selector { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 2rem; }
@@ -948,6 +1019,10 @@
 <div class="tab-content" id="tab-formulas">
 <section class="review-section review-section--open">
 <h2>Essential Formulas for Test 2</h2>
+<noscript>
+<div class="math-noscript">JavaScript is required to render the math formulas on this page. Please enable JavaScript to view equations in formatted notation.</div>
+</noscript>
+<div aria-live="polite" class="math-runtime-warning" hidden="" id="math-runtime-warning"></div>
 <div class="checklist-section review-checklist-section">
 <h3>Section 4.2: Exponentials &amp; Interest</h3>
 <div class="formula-section-note">Focus: recognize the two provided interest formulas and when each model is used.</div>
@@ -3908,20 +3983,54 @@
     }
 
     let _mathRetryTimer = null;
+    function showMathRuntimeWarning(message) {
+        const warning = document.getElementById('math-runtime-warning');
+        if (!warning) return;
+        warning.hidden = false;
+        warning.textContent = message;
+    }
+
     function renderMath(retries = 8) {
         if (window.renderMathInElement) {
             renderMathInElement(document.body, {
                 delimiters: [ {left: '$$', right: '$$', display: true}, {left: '$', right: '$', display: false} ],
                 throwOnError: false
             });
-            return;
+            return true;
         }
 
         if (retries > 0) {
             clearTimeout(_mathRetryTimer);
             _mathRetryTimer = setTimeout(() => renderMath(retries - 1), 150);
+            return false;
         }
+
+        showMathRuntimeWarning('Math rendering is unavailable right now. We tried the CDN and local fallback KaTeX assets, but formulas could not be initialized.');
+        return false;
     }
+
+    window.addEventListener('load', () => {
+        const katexReady = !!window.katex;
+        const autoRenderReady = !!window.renderMathInElement;
+
+        if (!katexReady || !autoRenderReady) {
+            if (window.loadLocalKatexAssets) {
+                window.loadLocalKatexAssets('runtime-missing-katex-api');
+            }
+
+            setTimeout(() => {
+                const retryKatexReady = !!window.katex;
+                const retryAutoRenderReady = !!window.renderMathInElement;
+                if (!retryKatexReady || !retryAutoRenderReady) {
+                    showMathRuntimeWarning('Math rendering is unavailable right now. Please refresh the page or check content blocking/network settings.');
+                }
+                renderMath();
+            }, 250);
+            return;
+        }
+
+        renderMath();
+    });
 </script>
 </div>
 </body>

--- a/130Test3.html
+++ b/130Test3.html
@@ -11,10 +11,52 @@
 <!-- Fonts -->
 <!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&amp;family=DM+Sans:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet"/>
-<!-- KaTeX for Math Rendering -->
-<link href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" rel="stylesheet"/>
-<script defer="" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
-<script defer="" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>
+<!-- KaTeX for Math Rendering (CDN first, local fallback) -->
+<link href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" id="katex-css-cdn" rel="stylesheet"/>
+<script defer="" id="katex-js-cdn" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
+<script defer="" id="katex-autorender-cdn" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>
+<script>
+(function () {
+    const localKatexAssets = {
+        css: 'assets/vendor/katex/dist/katex.min.css',
+        js: 'assets/vendor/katex/dist/katex.min.js',
+        autoRender: 'assets/vendor/katex/dist/contrib/auto-render.min.js'
+    };
+
+    function loadLocalCss() {
+        if (document.getElementById('katex-css-local')) return;
+        const localCss = document.createElement('link');
+        localCss.id = 'katex-css-local';
+        localCss.rel = 'stylesheet';
+        localCss.href = localKatexAssets.css;
+        document.head.appendChild(localCss);
+    }
+
+    function loadLocalScript(id, src) {
+        if (document.getElementById(id)) return;
+        const script = document.createElement('script');
+        script.id = id;
+        script.defer = true;
+        script.src = src;
+        document.head.appendChild(script);
+    }
+
+    window.loadLocalKatexAssets = function () {
+        loadLocalCss();
+        loadLocalScript('katex-js-local', localKatexAssets.js);
+        loadLocalScript('katex-autorender-local', localKatexAssets.autoRender);
+    };
+
+    window.addEventListener('DOMContentLoaded', function () {
+        const cssCdn = document.getElementById('katex-css-cdn');
+        const jsCdn = document.getElementById('katex-js-cdn');
+        const autoCdn = document.getElementById('katex-autorender-cdn');
+        if (cssCdn) cssCdn.addEventListener('error', window.loadLocalKatexAssets);
+        if (jsCdn) jsCdn.addEventListener('error', window.loadLocalKatexAssets);
+        if (autoCdn) autoCdn.addEventListener('error', window.loadLocalKatexAssets);
+    });
+})();
+</script>
 <!-- Icons -->
 <script defer="" src="https://cdn.jsdelivr.net/npm/lucide@0.344.0/dist/umd/lucide.min.js"></script>
 <style>
@@ -244,6 +286,18 @@
         .formula-math.steps-math .step-label { font-size: 0.95rem; font-weight: 700; letter-spacing: 0.02em; color: var(--text-muted); text-transform: uppercase; }
         .formula-math.steps-math .katex-display { margin: 0.05rem 0; }
         .formula-vars { color: var(--text-muted); font-size: 0.8rem; margin-top: 0.5rem; line-height: 1.5; }
+        .math-noscript,
+        .math-runtime-warning {
+            margin: 0.9rem 0 1.2rem;
+            padding: 0.75rem 0.9rem;
+            border-radius: 10px;
+            font-size: 0.9rem;
+            line-height: 1.5;
+            background: var(--bg-surface);
+            border: 1px solid var(--border-subtle);
+        }
+        .math-noscript { color: var(--text-muted); border-left: 4px solid var(--text-muted); }
+        .math-runtime-warning { color: var(--danger-main); border-left: 4px solid var(--danger-main); }
 
         /* Quiz Section */
         .quiz-selector { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 2rem; }
@@ -1036,6 +1090,8 @@
 <div class="section-lead">
 <div class="section-eyebrow"><i data-lucide="sigma"></i> Formula priorities</div>
 <h2>Essential Formulas for Test 3</h2>
+<noscript><div class="math-noscript">JavaScript is required to render the math formulas on this page.</div></noscript>
+<div aria-live="polite" class="math-runtime-warning" hidden="" id="math-runtime-warning"></div>
 </div>
 <div class="formula-intro">
 <div aria-label="Formula badge legend" class="formula-legend">
@@ -3424,20 +3480,46 @@
     }
 
     let _mathRetryTimer = null;
+    function showMathRuntimeWarning(message) {
+        const warning = document.getElementById('math-runtime-warning');
+        if (!warning) return;
+        warning.hidden = false;
+        warning.textContent = message;
+    }
+
     function renderMath(retries = 8) {
         if (window.renderMathInElement) {
             renderMathInElement(document.body, {
                 delimiters: [ {left: '$$', right: '$$', display: true}, {left: '$', right: '$', display: false} ],
                 throwOnError: false
             });
-            return;
+            return true;
         }
 
         if (retries > 0) {
             clearTimeout(_mathRetryTimer);
             _mathRetryTimer = setTimeout(() => renderMath(retries - 1), 150);
+            return false;
         }
+
+        showMathRuntimeWarning('Math rendering is unavailable right now. Please refresh or check network/content-blocking settings.');
+        return false;
     }
+
+    window.addEventListener('load', () => {
+        if (!window.katex || !window.renderMathInElement) {
+            if (window.loadLocalKatexAssets) window.loadLocalKatexAssets();
+            setTimeout(() => {
+                if (!window.katex || !window.renderMathInElement) {
+                    showMathRuntimeWarning('Math rendering is unavailable right now. CDN and local KaTeX fallback both failed to initialize.');
+                }
+                renderMath();
+            }, 250);
+            return;
+        }
+
+        renderMath();
+    });
 </script>
 </div>
 </body>

--- a/130Test4.html
+++ b/130Test4.html
@@ -13,9 +13,51 @@
 <!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <!-- Page-specific external CSS: KaTeX styles are required for math formula rendering. -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>
+<link id="katex-css-cdn" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
+<script defer id="katex-js-cdn" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
+<script defer id="katex-autorender-cdn" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>
+<script>
+(function () {
+    const localKatexAssets = {
+        css: 'assets/vendor/katex/dist/katex.min.css',
+        js: 'assets/vendor/katex/dist/katex.min.js',
+        autoRender: 'assets/vendor/katex/dist/contrib/auto-render.min.js'
+    };
+
+    function loadLocalCss() {
+        if (document.getElementById('katex-css-local')) return;
+        const localCss = document.createElement('link');
+        localCss.id = 'katex-css-local';
+        localCss.rel = 'stylesheet';
+        localCss.href = localKatexAssets.css;
+        document.head.appendChild(localCss);
+    }
+
+    function loadLocalScript(id, src) {
+        if (document.getElementById(id)) return;
+        const script = document.createElement('script');
+        script.id = id;
+        script.defer = true;
+        script.src = src;
+        document.head.appendChild(script);
+    }
+
+    window.loadLocalKatexAssets = function () {
+        loadLocalCss();
+        loadLocalScript('katex-js-local', localKatexAssets.js);
+        loadLocalScript('katex-autorender-local', localKatexAssets.autoRender);
+    };
+
+    window.addEventListener('DOMContentLoaded', function () {
+        const cssCdn = document.getElementById('katex-css-cdn');
+        const jsCdn = document.getElementById('katex-js-cdn');
+        const autoCdn = document.getElementById('katex-autorender-cdn');
+        if (cssCdn) cssCdn.addEventListener('error', window.loadLocalKatexAssets);
+        if (jsCdn) jsCdn.addEventListener('error', window.loadLocalKatexAssets);
+        if (autoCdn) autoCdn.addEventListener('error', window.loadLocalKatexAssets);
+    });
+})();
+</script>
 <script defer src="https://cdn.jsdelivr.net/npm/lucide@0.344.0/dist/umd/lucide.min.js"></script>
 
 <style>
@@ -315,6 +357,18 @@
     }
 
     .math-review-page .katex-display { margin: 0.15rem 0; }
+    .math-noscript,
+    .math-runtime-warning {
+        margin: 0.9rem 0 1rem;
+        padding: 0.75rem 0.9rem;
+        border-radius: 10px;
+        font-size: 0.9rem;
+        line-height: 1.5;
+        background: var(--bg-surface);
+        border: 1px solid var(--border-subtle);
+    }
+    .math-noscript { color: var(--text-muted); border-left: 4px solid var(--text-muted); }
+    .math-runtime-warning { color: var(--danger-main); border-left: 4px solid var(--danger-main); }
 
     @media (max-width: 920px) {
         .math-review-page .intro-note,
@@ -589,6 +643,8 @@
         <div class="card review-card">
             <div class="eyebrow"><i data-lucide="sigma"></i> Formula focus</div>
             <h2>Provided on the Final Exam</h2>
+            <noscript><div class="math-noscript">JavaScript is required to render the math formulas on this page.</div></noscript>
+            <div aria-live="polite" class="math-runtime-warning" hidden="" id="math-runtime-warning"></div>
             <p class="muted" style="margin-bottom:1rem;">These formulas are printed on the exam. They still require recognition and correct setup.</p>
 
             <div class="formula-grid">
@@ -830,6 +886,13 @@ document.addEventListener('DOMContentLoaded', function () {
     })();
 
     let _mathRetryTimer = null;
+    function showMathRuntimeWarning(message) {
+        const warning = document.getElementById('math-runtime-warning');
+        if (!warning) return;
+        warning.hidden = false;
+        warning.textContent = message;
+    }
+
     function renderMath(retries) {
         if (retries === undefined) retries = 12;
         if (window.renderMathInElement) {
@@ -837,14 +900,28 @@ document.addEventListener('DOMContentLoaded', function () {
                 delimiters: [ {left: '$$', right: '$$', display: true}, {left: '$', right: '$', display: false} ],
                 throwOnError: false
             });
-            return;
+            return true;
         }
         if (retries > 0) {
             clearTimeout(_mathRetryTimer);
             _mathRetryTimer = setTimeout(function(){ renderMath(retries - 1); }, 150);
+            return false;
         }
+        showMathRuntimeWarning('Math rendering is unavailable right now. Please refresh or check network/content-blocking settings.');
+        return false;
     }
-    renderMath();
+
+    if (!window.katex || !window.renderMathInElement) {
+        if (window.loadLocalKatexAssets) window.loadLocalKatexAssets();
+        setTimeout(function () {
+            if (!window.katex || !window.renderMathInElement) {
+                showMathRuntimeWarning('Math rendering is unavailable right now. CDN and local KaTeX fallback both failed to initialize.');
+            }
+            renderMath();
+        }, 250);
+    } else {
+        renderMath();
+    }
 });
 </script>
 </div>

--- a/assets/vendor/katex/dist/contrib/auto-render.min.js
+++ b/assets/vendor/katex/dist/contrib/auto-render.min.js
@@ -1,0 +1,2 @@
+/* Local KaTeX auto-render fallback placeholder.
+   Replace with official contrib/auto-render.min.js from KaTeX 0.16.9 for full offline rendering support. */

--- a/assets/vendor/katex/dist/katex.min.css
+++ b/assets/vendor/katex/dist/katex.min.css
@@ -1,0 +1,2 @@
+/* Local KaTeX fallback stylesheet placeholder.
+   Replace with official katex.min.css from KaTeX 0.16.9 for full offline rendering support. */

--- a/assets/vendor/katex/dist/katex.min.js
+++ b/assets/vendor/katex/dist/katex.min.js
@@ -1,0 +1,2 @@
+/* Local KaTeX fallback script placeholder.
+   Replace with official katex.min.js from KaTeX 0.16.9 for full offline rendering support. */


### PR DESCRIPTION
### Motivation
- Improve robustness of math formula rendering by attempting CDN first and falling back to bundled local KaTeX assets when CDN or runtime initialization fails.
- Provide clear user-facing feedback when JavaScript is disabled or math rendering cannot initialize due to network/content-blocking issues.

### Description
- Add CDN KaTeX tags with stable IDs and inject a `window.loadLocalKatexAssets` fallback that appends local CSS/JS (`assets/vendor/katex/dist/*`) when CDN resource `error` events fire or when runtime APIs are missing.
- Add `noscript` notices and an aria-live `#math-runtime-warning` element across formula tabs, plus styles for `.math-noscript` and `.math-runtime-warning` to surface status messages to users.
- Update `renderMath` logic to retry initialization, return success/failure, and wire page `load`/`DOMContentLoaded` handlers to attempt local fallback and show contextual warnings via `showMathRuntimeWarning` when both CDN and local fallbacks fail.
- Add placeholder local KaTeX vendor files under `assets/vendor/katex/dist/` (`katex.min.js`, `katex.min.css`, `contrib/auto-render.min.js`) with comments instructing replacement with official KaTeX assets for full offline support.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9813646f48331a334d264d4bc425a)