### PR TITLE
Add Module 10 summary link to Normal Distribution Game

### DIFF
--- a/courses/math114-statistics.html
+++ b/courses/math114-statistics.html
@@ -188,6 +188,9 @@
                 <li>
                   <a href="../pdfs/114Module10Spring25.pdf">Lecture slides</a>
                 </li>
+                <li>
+                  <a href="../projects/NormalDistributionGame.html">Summary</a>
+                </li>
               </ul>
             </article>
             <article class="unit-resource-card">


### PR DESCRIPTION
### Motivation
- Provide a convenient "Summary" link from the Module 10 Slides resource list so students can open the Normal Distribution interactive from the MATH 114 statistics page.

### Description
- Inserted a new `<li>` linking `../projects/NormalDistributionGame.html` into the Module 10 Slides list in `courses/math114-statistics.html`.

### Testing
- Verified the update by printing the modified HTML region with `nl -ba courses/math114-statistics.html | sed -n '170,245p'` and confirmed the new link appears as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca70e1e6a48331973fa763daad1066)