### PR TITLE
Use semantic theme variables for stats pages and normalize dark theme colors

### DIFF
--- a/courses/basic-statistical-measures.html
+++ b/courses/basic-statistical-measures.html
@@ -8,6 +8,29 @@
 
   <!-- Unified & Simplified Styles -->
   <style>
+    :root {
+      --stats-page-bg: var(--bg-base);
+      --stats-shell-surface: var(--bg-surface);
+      --stats-header-surface: var(--text-main);
+      --stats-header-text: var(--bg-surface);
+      --stats-section-border: var(--border-subtle);
+      --stats-card-surface: var(--card-surface);
+      --stats-card-shadow: 0 2px 5px color-mix(in srgb, var(--text-main) 5%, transparent);
+      --stats-dataset-surface: var(--panel-surface);
+      --stats-formula-surface: var(--callout-info-surface);
+      --stats-example-surface: color-mix(in srgb, var(--primary-main) 8%, var(--bg-surface));
+      --stats-interpretation-surface: var(--callout-info-surface);
+      --stats-footer-surface: var(--footer-surface);
+      --stats-excel-accent: var(--excel-accent);
+      --stats-diagram-line: var(--diagram-line);
+      --stats-diagram-label: var(--diagram-label);
+      --stats-table-header-surface: var(--table-header-surface);
+      --stats-table-row-alt-surface: var(--table-row-alt-surface);
+      --stats-pros-surface: var(--callout-success-surface);
+      --stats-cons-surface: var(--callout-danger-surface);
+      --stats-stddev-accent: var(--emerald-main);
+    }
+
     /* Overall reset and font */
     * {
       box-sizing: border-box;
@@ -15,8 +38,8 @@
       padding: 0;
     }
     body {
-      background-color: #f5f7fa;
-      color: var(--text-main);
+      background-color: var(--stats-page-bg);
+      color: var(--text-body);
       margin: 0;
     }
 
@@ -28,7 +51,7 @@
     .infographic {
       max-width: 900px;
       margin: 0 auto;
-      background-color: var(--bg-surface);
+      background-color: var(--stats-shell-surface);
       border-radius: 10px;
       box-shadow: 0 5px 15px var(--border-subtle);
       overflow: hidden;
@@ -36,8 +59,8 @@
 
     /* Header */
     .header {
-      background-color: var(--text-main);
-      color: var(--bg-surface);
+      background-color: var(--stats-header-surface);
+      color: var(--stats-header-text);
       padding: 20px;
       text-align: center;
     }
@@ -53,7 +76,7 @@
     /* Section Layout */
     .section {
       padding: 25px;
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid var(--stats-section-border);
     }
     .section:last-child {
       border-bottom: none;
@@ -68,7 +91,7 @@
 
     /* Dataset Info Boxes */
     .dataset {
-      background-color: var(--bg-base);
+      background-color: var(--stats-dataset-surface);
       padding: 10px;
       border-radius: 5px;
       text-align: center;
@@ -83,11 +106,11 @@
 
     /* Measure Cards */
     .measure-card {
-      background-color: var(--bg-base);
+      background-color: var(--stats-card-surface);
       border-radius: 8px;
       padding: 15px;
       border-top: 4px solid;
-      box-shadow: 0 2px 5px color-mix(in srgb, var(--text-main) 5%, transparent);
+      box-shadow: var(--stats-card-shadow);
       margin-bottom: 15px;
     }
     .mean      { border-top-color: var(--danger-main); }
@@ -95,7 +118,7 @@
     .mode      { border-top-color: var(--emerald-main); }
     .range     { border-top-color: var(--warning-main); }
     .variance  { border-top-color: var(--primary-main); }
-    .std-dev   { border-top-color: #1abc9c; }
+    .std-dev   { border-top-color: var(--stats-stddev-accent); }
     .iqr       { border-top-color: var(--warning-main); }
     .quartiles { border-top-color: var(--warning-main); }
     .five-num  { border-top-color: var(--primary-main); }
@@ -121,7 +144,7 @@
       font-size: 16px;
     }
     .excel-formula {
-      background-color: #eaf2f8;
+      background-color: var(--stats-formula-surface);
       padding: 8px 12px;
       border-radius: 6px;
       font-family: var(--type-meta-family);
@@ -146,11 +169,11 @@
       border-radius: 4px;
     }
     .pros {
-      background-color: rgba(46, 204, 113, 0.1);
+      background-color: var(--stats-pros-surface);
       border-left: 3px solid var(--emerald-main);
     }
     .cons {
-      background-color: rgba(231, 76, 60, 0.1);
+      background-color: var(--stats-cons-surface);
       border-left: 3px solid var(--danger-main);
     }
     .pros h4, .cons h4 {
@@ -160,7 +183,7 @@
 
     /* Example Boxes */
     .example {
-      background-color: #f0f7ff;
+      background-color: var(--stats-example-surface);
       padding: 12px;
       border-radius: 6px;
       margin-top: 15px;
@@ -208,7 +231,7 @@
       display: inline-block;
       width: 16px;
       height: 16px;
-      background-color: #2b7338;
+      background-color: var(--stats-excel-accent);
       border-radius: 3px;
       position: relative;
       top: 3px;
@@ -225,7 +248,7 @@
       font-weight: bold;
     }
     .excel-heading {
-      color: #2b7338;
+      color: var(--stats-excel-accent);
       font-weight: bold;
       margin-top: 15px;
       font-size: 15px;
@@ -249,7 +272,7 @@
       left: 50px;
       width: 400px;
       height: 2px;
-      background-color: var(--text-main);
+      background-color: var(--stats-diagram-line);
     }
     .boxplot-box {
       position: absolute;
@@ -258,7 +281,7 @@
       width: 200px;
       height: 60px;
       border: 2px solid var(--primary-main);
-      background-color: rgba(52, 152, 219, 0.2);
+      background-color: color-mix(in srgb, var(--primary-main) 20%, transparent);
     }
     .boxplot-median {
       position: absolute;
@@ -274,7 +297,7 @@
       left: 80px;
       width: 70px;
       height: 2px;
-      background-color: var(--text-main);
+      background-color: var(--stats-diagram-line);
     }
     .boxplot-whisker-right {
       position: absolute;
@@ -282,7 +305,7 @@
       left: 350px;
       width: 70px;
       height: 2px;
-      background-color: var(--text-main);
+      background-color: var(--stats-diagram-line);
     }
     .boxplot-cap-left {
       position: absolute;
@@ -290,7 +313,7 @@
       left: 80px;
       width: 2px;
       height: 20px;
-      background-color: var(--text-main);
+      background-color: var(--stats-diagram-line);
     }
     .boxplot-cap-right {
       position: absolute;
@@ -298,7 +321,7 @@
       left: 420px;
       width: 2px;
       height: 20px;
-      background-color: var(--text-main);
+      background-color: var(--stats-diagram-line);
     }
     .boxplot-outlier {
       position: absolute;
@@ -313,7 +336,7 @@
     .boxplot-label {
       position: absolute;
       font-size: 12px;
-      color: var(--text-main);
+      color: var(--stats-diagram-label);
     }
     .label-min {
       top: 75px;
@@ -385,16 +408,16 @@
       border: 1px solid var(--border-subtle);
     }
     th {
-      background-color: var(--bg-base);
+      background-color: var(--stats-table-header-surface);
       font-weight: bold;
     }
     tr:nth-child(even) {
-      background-color: var(--bg-base);
+      background-color: var(--stats-table-row-alt-surface);
     }
 
     .interpretation {
       margin: 15px 0;
-      background-color: #eaf7fd;
+      background-color: var(--stats-interpretation-surface);
       padding: 12px;
       border-radius: 6px;
       border-left: 3px solid var(--primary-main);
@@ -407,7 +430,7 @@
 
     /* Footer */
     .footer {
-      background-color: #ecf0f1;
+      background-color: var(--stats-footer-surface);
       padding: 15px;
       text-align: center;
       font-size: 14px;

--- a/projects/NormalDistributionGame.html
+++ b/projects/NormalDistributionGame.html
@@ -48,7 +48,7 @@
             background-color: var(--primary-main);
         }
         .question {
-            background-color: #f0f8ff;
+            background-color: color-mix(in srgb, var(--primary-main) 10%, var(--bg-surface));
             padding: 15px;
             border-radius: 5px;
             margin-bottom: 15px;
@@ -57,7 +57,7 @@
             display: none;
             margin-top: 10px;
             padding: 10px;
-            background-color: #e8f4f8;
+            background-color: color-mix(in srgb, var(--primary-main) 12%, var(--bg-surface));
             border-radius: 4px;
         }
         .explanation {
@@ -67,12 +67,12 @@
             border-radius: 5px;
         }
         .highlight {
-            background-color: #fffacd;
+            background-color: color-mix(in srgb, var(--warning-main) 25%, var(--bg-surface));
             padding: 2px 4px;
             border-radius: 3px;
         }
         .calculator {
-            background-color: #e8f8f5;
+            background-color: color-mix(in srgb, var(--emerald-main) 12%, var(--bg-surface));
             padding: 20px;
             border-radius: 5px;
             margin-top: 20px;
@@ -97,7 +97,7 @@
         .result {
             margin-top: 15px;
             padding: 10px;
-            background-color: #d5f5e3;
+            background-color: color-mix(in srgb, var(--emerald-main) 22%, var(--bg-surface));
             border-radius: 4px;
             display: none;
         }
@@ -293,7 +293,7 @@
         const fillColors = ['var(--danger-main)', 'var(--emerald-main)', 'var(--primary-main)'];
         const customFillColor = 'var(--warning-main)';
         const segmentColors = [
-            'var(--danger-main)', 'var(--warning-main)', '#f1c40f', 'var(--emerald-main)', 
+            'var(--danger-main)', 'var(--warning-main)', 'var(--warning-main)', 'var(--emerald-main)', 
             'var(--primary-main)', 'var(--primary-main)', 'var(--danger-main)'
         ];
         

--- a/styles.css
+++ b/styles.css
@@ -65,10 +65,18 @@
   --bg-body: var(--bg-base);
   --bg-subtle: var(--bg-base);
   --bg-inverse: var(--primary);
+  --card-surface: var(--bg-surface);
+  --card-surface-alt: var(--bg-base);
+  --panel-surface: var(--bg-base);
+  --table-header-surface: var(--bg-base);
+  --table-row-alt-surface: var(--bg-base);
+  --footer-surface: var(--bg-base);
   --text-heading: var(--primary);
   --text-body: var(--on-surface);
   --text-muted: #64748b;
   --text-on-primary: var(--on-primary);
+  --text-link: var(--primary-main);
+  --text-link-hover: var(--primary-hover);
   --primary-base: var(--bg-surface);
   --primary-hover: color-mix(in srgb, var(--bg-surface) 82%, var(--primary-main) 18%);
   --primary-surface: color-mix(in srgb, var(--bg-surface) 10%, var(--bg-surface));
@@ -91,6 +99,23 @@
   --status-info: var(--primary-main);
   --status-info-bg: var(--primary-soft);
   --status-info-border: color-mix(in srgb, var(--primary-main) 32%, transparent);
+  --callout-info-surface: var(--status-info-bg);
+  --callout-info-border: var(--status-info-border);
+  --callout-success-surface: var(--status-success-bg);
+  --callout-success-border: var(--status-success-border);
+  --callout-danger-surface: var(--status-error-bg);
+  --callout-danger-border: var(--status-error-border);
+  --diagram-line: var(--text-main);
+  --diagram-label: var(--text-main);
+  --diagram-accent: var(--primary-main);
+  --excel-accent: var(--emerald-main);
+  --nav-surface: linear-gradient(180deg, var(--nav-surface-start), var(--nav-surface-end));
+  --nav-text: var(--text-main);
+  --nav-text-hover: var(--primary-hover);
+  --nav-text-current: var(--text-main);
+  --nav-border: var(--border-transparent);
+  --nav-dropdown-surface: var(--glass-surface);
+  --nav-dropdown-text: var(--text-main);
   --emerald-soft: color-mix(in srgb, var(--emerald-main) 12%, transparent);
   --danger-soft: color-mix(in srgb, var(--danger-main) 12%, transparent);
   --primary-soft: color-mix(in srgb, var(--primary-main) 12%, transparent);
@@ -1814,6 +1839,12 @@ main.error-main {
 /* Dark Theme Variables applied via JS */
 :root[data-theme="dark"] {
   color-scheme: dark;
+  --bg-base: #111614;
+  --bg-surface: #1f2724;
+  --bg-subtle: #18201d;
+  --text-main: #f2f5f2;
+  --text-body: #f2f5f2;
+  --text-muted: #bac4bf;
   --surface: #111614;
   --surface-container-low: #18201d;
   --surface-container-lowest: #1f2724;
@@ -1830,17 +1861,13 @@ main.error-main {
   --surface-tint: #8bb1a8;
   --on-surface: #f2f5f2;
   --on-surface-variant: #bac4bf;
-  --bg-body: var(--bg-surface);
-  --bg-surface: var(--bg-base);
-  --bg-subtle: var(--bg-base);
+  --bg-body: var(--bg-base);
   --bg-inverse: #f8faf7;
-  --text-heading: var(--bg-surface);
-  --text-body: var(--on-surface);
-  --text-muted: var(--on-surface-variant);
+  --text-heading: var(--text-main);
   --text-on-primary: #f8faf7;
   --primary-base: var(--bg-surface);
-  --primary-hover: color-mix(in srgb, var(--bg-surface) 84%, var(--bg-surface) 16%);
-  --primary-surface: color-mix(in srgb, var(--bg-surface) 22%, var(--bg-surface));
+  --primary-hover: color-mix(in srgb, var(--primary-main) 65%, var(--bg-surface) 35%);
+  --primary-surface: color-mix(in srgb, var(--primary-main) 18%, var(--bg-surface));
   --primary-text: var(--text-on-primary);
   --border-subtle: color-mix(in srgb, var(--outline-variant) 52%, transparent);
   --border-base: var(--border-subtle);
@@ -1859,6 +1886,22 @@ main.error-main {
   --status-info: #7ea8ff;
   --status-info-bg: rgba(126, 168, 255, 0.2);
   --status-info-border: rgba(126, 168, 255, 0.4);
+  --card-surface: #1f2724;
+  --card-surface-alt: #18201d;
+  --panel-surface: #18201d;
+  --table-header-surface: #202825;
+  --table-row-alt-surface: #18201d;
+  --footer-surface: #18201d;
+  --callout-info-surface: rgba(126, 168, 255, 0.16);
+  --callout-info-border: rgba(126, 168, 255, 0.38);
+  --callout-success-surface: rgba(52, 211, 153, 0.18);
+  --callout-success-border: rgba(52, 211, 153, 0.38);
+  --callout-danger-surface: rgba(248, 113, 113, 0.18);
+  --callout-danger-border: rgba(248, 113, 113, 0.42);
+  --diagram-line: var(--text-main);
+  --diagram-label: var(--text-body);
+  --diagram-accent: #7ea8ff;
+  --excel-accent: #34d399;
   --primary-color: var(--primary-main);
   --secondary-color: var(--text-main);
   --accent-color: var(--primary-main);
@@ -1882,6 +1925,13 @@ main.error-main {
   --nav-mobile-panel-start: rgba(31, 39, 36, 0.96);
   --nav-mobile-panel-end: rgba(24, 32, 29, 0.92);
   --nav-mobile-menu-surface: rgba(24, 32, 29, 0.98);
+  --nav-surface: linear-gradient(180deg, var(--nav-surface-start), var(--nav-surface-end));
+  --nav-text: #f2f5f2;
+  --nav-text-hover: #c8d9ff;
+  --nav-text-current: #f8faf7;
+  --nav-border: color-mix(in srgb, var(--outline-variant) 42%, transparent);
+  --nav-dropdown-surface: rgba(24, 32, 29, 0.98);
+  --nav-dropdown-text: #f2f5f2;
   --gradient-library-glow: radial-gradient(
       circle at top left,
       rgba(126, 168, 255, 0.12),
@@ -2188,12 +2238,11 @@ main.error-main {
   position: sticky;
   top: 0;
   z-index: 1000;
-  background:
-    linear-gradient(180deg, var(--nav-surface-start), var(--nav-surface-end));
+  background: var(--nav-surface);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border-bottom: none;
-  box-shadow: inset 0 -1px 0 var(--border-transparent);
+  box-shadow: inset 0 -1px 0 var(--nav-border);
 }
 
 .top-nav-inner {
@@ -2215,18 +2264,18 @@ main.error-main {
 }
 
 .top-nav-title {
-  color: var(--text-main);
+  color: var(--nav-text);
   font-weight: 700;
   font-size: 1rem;
   line-height: 1.2;
   letter-spacing: 0.01em;
   text-decoration: none;
-  var(--bg-surface)-space: nowrap;
+  white-space: nowrap;
 }
 
 .top-nav-title:hover,
 .top-nav-title:focus-visible {
-  color: var(--primary-main);
+  color: var(--nav-text-hover);
 }
 
 .top-nav-links,
@@ -2265,7 +2314,7 @@ main.error-main {
 .top-nav-utilities .dropdown-menu a,
 .top-nav-links .dropdown-menu a {
   display: block;
-  color: var(--text-main);
+  color: var(--nav-text);
   text-decoration: none;
   font-size: 0.95rem;
   font-weight: 500;
@@ -2289,7 +2338,7 @@ main.error-main {
 .top-nav-links .dropdown-menu a:focus-visible,
 .top-nav-utilities .dropdown-menu a:hover,
 .top-nav-utilities .dropdown-menu a:focus-visible {
-  color: var(--primary-hover);
+  color: var(--nav-text-hover);
   background: var(--primary-surface);
   text-decoration-line: underline;
   text-decoration-thickness: 0.1em;
@@ -2318,7 +2367,7 @@ main.error-main {
 .top-nav-links button[aria-current="page"],
 .top-nav-utilities a[aria-current="page"],
 .top-nav-utilities button[aria-current="page"] {
-  color: var(--text-main);
+  color: var(--nav-text-current);
   background: linear-gradient(135deg, color-mix(in srgb, var(--bg-subtle) 88%, transparent), var(--surface-transparent));
   box-shadow: inset 0 0 0 999px var(--surface-transparent);
 }
@@ -2331,7 +2380,7 @@ main.error-main {
 .top-nav-utilities a[aria-current="page"]:focus-visible,
 .top-nav-utilities button[aria-current="page"]:hover,
 .top-nav-utilities button[aria-current="page"]:focus-visible {
-  color: var(--text-main);
+  color: var(--nav-text-current);
   background: linear-gradient(135deg, color-mix(in srgb, var(--bg-subtle) 96%, transparent), var(--surface-transparent));
 }
 
@@ -2407,9 +2456,9 @@ main.error-main {
   margin: 0;
   padding: 0.4rem;
   list-style: none;
-  background: var(--glass-surface);
+  background: var(--nav-dropdown-surface);
   border-radius: 0.75rem;
-  box-shadow: inset 0 0 0 1px var(--border-transparent);
+  box-shadow: inset 0 0 0 1px var(--nav-border);
 }
 
 .top-nav-links .dropdown:hover .dropdown-menu,
@@ -2434,7 +2483,7 @@ main.error-main {
 
 .top-nav-utilities > li > a,
 .top-nav-utilities > li > button {
-  color: var(--text-muted);
+  color: var(--nav-text);
   font-size: 0.9rem;
 }
 


### PR DESCRIPTION
### Motivation
- Migrate hardcoded colors and surface tones to semantic design tokens to ensure the statistics pages and widgets follow the site theme and support dark mode consistently.
- Improve maintainability by introducing scoped CSS variables for statistics pages and mapping them into the global `styles.css` token set.

### Description
- Added a `:root` block with stats-specific tokens (for example `--stats-shell-surface`, `--stats-card-surface`, `--stats-diagram-line`, `--stats-excel-accent`) in `courses/basic-statistical-measures.html` and replaced many inline literal colors with those variables or `color-mix` calls.
- Extended `styles.css` with Tier-2 semantic tokens such as `--card-surface`, `--panel-surface`, `--table-header-surface`, `--callout-info-surface`, `--diagram-line`, and `--excel-accent`, and wired dark-theme values for these tokens under `:root[data-theme="dark"]`.
- Updated components to use the new tokens, including header/footer/shell backgrounds, measure cards, formula and example boxes, boxplot diagram lines, table row alternates, pros/cons callouts, and Excel accent colors; also fixed a CSS bug by replacing an incorrect token line with `white-space: nowrap;`.
- Updated `projects/NormalDistributionGame.html` visuals to use theme-aware `color-mix` fills and swapped a literal `#f1c40f` color in `segmentColors` to use `var(--warning-main)` for consistent semantics.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca741ede688331925d760ca56fada3)