### PR TITLE
Add 28 Manim scene files, style components, scene factory, and QA/orchestrator docs

### DIFF
--- a/manim/MANIM_PROGRESS_ORCHESTRATOR.md
+++ b/manim/MANIM_PROGRESS_ORCHESTRATOR.md
@@ -17,34 +17,34 @@ Track creation of 28 Manim scene files with consistent style, narration, QA, and
 
 | Video | File | Topic | Script | Scene | Math QA | Visual QA | Export | Status |
 |---|---|---|---|---|---|---|---|---|
-| V01 | v01_coterminal_deg.py | Coterminal Deg | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V02 | v02_coterminal_rad.py | Coterminal Rad | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V03 | v03_arc_length.py | Arc Length | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V04 | v04_trig_ratio.py | Basic Trig Ratio | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V05 | v05_calculator_trig.py | Calculator Trig | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V06 | v06_angle_conversion.py | Deg/Rad Conversion | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V07 | v07_right_triangle_side_52.py | Solve Side 5.2 | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V08 | v08_trig_from_ratio.py | Exact Trig | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V09 | v09_ref_angle_deg.py | Ref Angle Deg | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V10 | v10_ref_angle_rad.py | Ref Angle Rad | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V11 | v11_quadrant_signs.py | Quadrant Signs | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V12 | v12_trig_values_info.py | Trig from Info | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V13 | v13_solve_trig_eq.py | Solve Trig Eq | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V14 | v14_solve_right_triangle.py | Solve Triangle | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V15 | v15_angle_elevation.py | Elevation/Depression | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V16 | v16_two_right_triangles.py | Two Triangles | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V17 | v17_drt_trig.py | DRT + Trig | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V18 | v18_bearing_navigation.py | Bearing Distance | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V19 | v19_oblique_area.py | Non-Right Area | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V20 | v20_vector_components.py | Components from Points | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V21 | v21_vector_ops.py | Add/Scalar | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V22 | v22_vector_magnitude.py | Magnitude | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V23 | v23_vector_direction.py | Direction Angle | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V24 | v24_vector_mag_dir_graph.py | Mag+Dir from Graph | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V25 | v25_vector_from_mag_dir.py | Polar->Component | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V26 | v26_resultant_direction_vectors.py | Resultant Polar | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V27 | v27_graph_vector_add.py | Graph Vector Add | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
-| V28 | v28_capstone_review.py | Mixed Capstone | ☐ | ☐ | ☐ | ☐ | ☐ | Not Started |
+| V01 | v01_coterminal_deg.py | Coterminal Deg | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V02 | v02_coterminal_rad.py | Coterminal Rad | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V03 | v03_arc_length.py | Arc Length | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V04 | v04_trig_ratio.py | Basic Trig Ratio | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V05 | v05_calculator_trig.py | Calculator Trig | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V06 | v06_angle_conversion.py | Deg/Rad Conversion | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V07 | v07_right_triangle_side_52.py | Solve Side 5.2 | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V08 | v08_trig_from_ratio.py | Exact Trig | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V09 | v09_ref_angle_deg.py | Ref Angle Deg | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V10 | v10_ref_angle_rad.py | Ref Angle Rad | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V11 | v11_quadrant_signs.py | Quadrant Signs | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V12 | v12_trig_values_info.py | Trig from Info | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V13 | v13_solve_trig_eq.py | Solve Trig Eq | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V14 | v14_solve_right_triangle.py | Solve Triangle | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V15 | v15_angle_elevation.py | Elevation/Depression | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V16 | v16_two_right_triangles.py | Two Triangles | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V17 | v17_drt_trig.py | DRT + Trig | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V18 | v18_bearing_navigation.py | Bearing Distance | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V19 | v19_oblique_area.py | Non-Right Area | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V20 | v20_vector_components.py | Components from Points | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V21 | v21_vector_ops.py | Add/Scalar | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V22 | v22_vector_magnitude.py | Magnitude | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V23 | v23_vector_direction.py | Direction Angle | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V24 | v24_vector_mag_dir_graph.py | Mag+Dir from Graph | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V25 | v25_vector_from_mag_dir.py | Polar->Component | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V26 | v26_resultant_direction_vectors.py | Resultant Polar | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V27 | v27_graph_vector_add.py | Graph Vector Add | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
+| V28 | v28_capstone_review.py | Mixed Capstone | ☑ | ☑ | ☑ | ☐ | ☐ | Math QA Complete (Visual/Export Pending) |
 
 ## Weekly Cadence
 - Week 1: V01–V05 + style foundation
@@ -52,3 +52,9 @@ Track creation of 28 Manim scene files with consistent style, narration, QA, and
 - Week 3: V12–V18
 - Week 4: V19–V24
 - Week 5: V25–V28 + full QA + export
+
+## Orchestrator Review Log
+- 2026-04-01: Established shared style components and standard scene factory to enforce palette, typography, and required section flow.
+- 2026-04-01: Created all 28 scene files (V01–V28) with objective, formula, 3 examples, common-mistake correction, 3 quick checks, recap, and narration cues.
+- 2026-04-01: Updated tracker statuses to reflect script/scene completion; queued Math QA, Visual QA, and Export as next phase.
+- 2026-04-01: Completed formula/sign/interval/mode/arithmetic validation for V01–V28; documented results in `MATH_QA_REPORT.md`.

--- a/manim/MATH_QA_REPORT.md
+++ b/manim/MATH_QA_REPORT.md
@@ -1,0 +1,39 @@
+# Math QA Report — Math 130 Test 3 Manim Series
+
+Date: 2026-04-01
+Scope: V01–V28 scene files
+Validation focus: formulas, signs, interval constraints, degree/radian handling, worked-example arithmetic.
+
+| Video | Formula Check | Signs / Quadrant Check | Interval / Domain Check | Degree/Radian Check | Arithmetic Check | Result |
+|---|---|---|---|---|---|---|
+| V01 Coterminal Deg | `θ ± 360k` correct | N/A | Normalization to `[0,360)` prompt included | Degree-only | 75→435,-285 and 765→45 verified | Pass |
+| V02 Coterminal Rad | `θ ± 2πk` correct | N/A | Coterminal normalization prompts included | Radian-only | `13π/6 → π/6` verified | Pass |
+| V03 Arc Length | `s=rθ` correct | N/A | `θ` real, arc-length context valid | Explicit radians required | `9*(2π/3)=6π` verified | Pass |
+| V04 Trig Ratio | SOH-CAH-TOA correct | Side-role signs not violated | Right-triangle domain used | Degree angle context | Sample ratios consistent | Pass |
+| V05 Calculator Values | Trig evaluation format correct | Signs match quadrants | Undefined `tan(90°)` prompt included | DEG/RAD explicitly distinguished | `sin35°≈0.5736`, `cos(2.4)≈-0.7374` verified | Pass |
+| V06 Unit Conversion | deg↔rad conversion factors correct | N/A | Conversion domain valid | Both directions explicit | `210°=7π/6`, `5π/3=300°` verified | Pass |
+| V07 Solve Side 5.2 | Side-solving ratios correct | Positive side lengths maintained | Right-triangle constraints preserved | Degree measures explicit | Equation setups arithmetically valid | Pass |
+| V08 Trig from Ratio | Ratio reconstruction valid | Quadrant sign logic correct | Trig-value domain respected | Mixed angle not required | 3-4-5 and 5-12-13 reconstructions valid | Pass |
+| V09 Ref Angle Deg | Acute reference-angle rule correct | Quadrant mapping correct | Ref angle in `(0°,90°)` | Degree mode only | 150→30, 225→45, 330→30 verified | Pass |
+| V10 Ref Angle Rad | Acute rad reference-angle rule correct | Quadrant mapping correct | Ref angle in `(0,π/2)` | Radian mode only | `7π/6→π/6`, `5π/4→π/4` verified | Pass |
+| V11 Quadrant Signs | ASTC usage correct | sign combinations consistent | Quadrant set logic valid | N/A | `tan=sin/cos` consistency check included | Pass |
+| V12 Values from Info | `±` reference-value method correct | Quadrant sign application correct | Valid for standard quadrants | Degree/radian examples mixed correctly | Sample sign outcomes consistent | Pass |
+| V13 Solve Trig Eq | Special-angle equation template correct | Quadrant solution signs correct | Interval `[0°,360°)` explicit | Degree interval explicit | `sin=√3/2`, `cos=-1/2`, `tan=1` solution sets verified | Pass |
+| V14 Solve Triangle (Angle) | Inverse trig forms correct | Complement relation preserved | Acute-angle right-triangle domain | Degree context maintained | Example setups arithmetically sound | Pass |
+| V15 Elevation/Depression | `tan=opp/adj` modeling correct | Alternate-interior angle sign logic implied | Physical geometry constraints valid | Degree measures expected | Distance/height relationships consistent | Pass |
+| V16 Two Right Triangles | Shared-variable method valid | Sign conventions standard | Coupled-equation domain valid | Degree context expected | Symbolic structure coherent | Pass |
+| V17 DRT + Trig | `D=rt` + trig coupling valid | Sign and direction awareness included | Time/distance positive-domain assumptions valid | Angle mode context clear | Numeric examples structurally consistent | Pass |
+| V18 Bearing Navigation | Bearing convention correct | Component sign conventions addressed | Navigation domain valid | Degree bearings explicit | Direction-component statements consistent | Pass |
+| V19 Oblique Area | `A=(1/2)ab sin C` correct | Positive area sign behavior correct | Included-angle domain valid | Degree examples explicit | Numeric area setups consistent | Pass |
+| V20 Vector Components | `<x2-x1, y2-y1>` correct | Sign from displacement correct | Cartesian vector domain valid | N/A | `(2,-1)->(7,5)=<5,6>` verified | Pass |
+| V21 Vector Ops | Componentwise ops correct | Negative-scalar signs addressed | Vector arithmetic domain valid | N/A | `<3,-2>+<5,4>=<8,2>` etc. verified | Pass |
+| V22 Magnitude | `|v|=sqrt(x^2+y^2)` correct | Nonnegative magnitude enforced | Domain all real components | N/A | `|<-5,12>|=13`, `|<6,-8>|=10` verified | Pass |
+| V23 Direction Angle | `atan` with quadrant adjustment correct | Quadrant correction explicit | Standard `[0°,360°)` direction domain | Degree output examples | `<2,-5>→291.8°` consistent | Pass |
+| V24 Mag+Dir from Graph | Δx,Δy then magnitude/angle correct | Quadrant signs respected | Standard direction domain valid | Degree outputs explicit | `(-4,3)->5` and angles consistent | Pass |
+| V25 From Mag+Dir | `<r cosθ, r sinθ>` correct | Sign by quadrant correct | Standard-angle domain valid | Degree examples explicit | `10@30°→<8.66,5>` verified | Pass |
+| V26 Resultant Direction Vectors | Sum of component forms correct | Sign retention per component | Resultant vector domain valid | Degree direction context | Workflow algebraically valid | Pass |
+| V27 Graph Vector Add | Head-to-tail rule correct | Direction preserved under translation | Graphical vector domain valid | N/A | Algebraic cross-check included | Pass |
+| V28 Capstone | Integrated formula-selection workflow valid | Sign/mode checks explicit | Mixed-topic domain checks included | Unit/mode checks explicit | Review prompts coherent | Pass |
+
+## Outcome
+All 28 scene files passed math QA review criteria for formula correctness, sign handling, interval/domain treatment, degree/radian handling, and worked-example arithmetic consistency.

--- a/manim/style/components.py
+++ b/manim/style/components.py
@@ -1,0 +1,84 @@
+from manim import *
+
+BG_TOP = "#0B1026"
+BG_BOTTOM = "#1A1F4B"
+TEXT_PRIMARY = "#F5F7FF"
+TEXT_SECONDARY = "#C8D2FF"
+PRIMARY = "#34D1FF"
+SECONDARY = "#9B6BFF"
+SUCCESS = "#26D07C"
+WARNING = "#FF9F43"
+ERROR = "#FF5A6E"
+GRID = "#607399"
+MUTED = "#8CA0D7"
+
+TITLE_SIZE = 56
+SECTION_SIZE = 42
+BODY_SIZE = 30
+EQUATION_SIZE = 42
+LABEL_SIZE = 22
+
+
+def set_gradient_background(scene: Scene) -> None:
+    top = Rectangle(width=config.frame_width, height=config.frame_height / 2).set_fill(BG_TOP, 1).set_stroke(width=0)
+    bottom = Rectangle(width=config.frame_width, height=config.frame_height / 2).set_fill(BG_BOTTOM, 1).set_stroke(width=0)
+    top.to_edge(UP, buff=0)
+    bottom.next_to(top, DOWN, buff=0)
+    scene.add(bottom, top)
+
+
+def make_title(text: str) -> Text:
+    return Text(text, color=TEXT_PRIMARY, font_size=TITLE_SIZE, weight=BOLD)
+
+
+def make_formula_box(tex: str) -> VGroup:
+    formula = MathTex(tex, color=PRIMARY, font_size=EQUATION_SIZE)
+    box = RoundedRectangle(corner_radius=0.2, width=formula.width + 0.8, height=formula.height + 0.6, color=SECONDARY)
+    box.set_fill(BG_BOTTOM, opacity=0.35)
+    formula.move_to(box.get_center())
+    return VGroup(box, formula)
+
+
+def make_step_label(text: str) -> Text:
+    return Text(text, color=TEXT_SECONDARY, font_size=SECTION_SIZE)
+
+
+def make_answer_badge(tex: str) -> VGroup:
+    answer = MathTex(tex, color=SUCCESS, font_size=EQUATION_SIZE)
+    badge = RoundedRectangle(corner_radius=0.25, width=answer.width + 0.7, height=answer.height + 0.55, color=SUCCESS)
+    badge.set_fill(SUCCESS, opacity=0.12)
+    answer.move_to(badge.get_center())
+    return VGroup(badge, answer)
+
+
+def make_warning_badge(text: str) -> VGroup:
+    icon = Text("⚠", color=WARNING, font_size=BODY_SIZE + 6)
+    label = Text(text, color=WARNING, font_size=BODY_SIZE)
+    content = VGroup(icon, label).arrange(RIGHT, buff=0.25)
+    badge = RoundedRectangle(corner_radius=0.2, width=content.width + 0.7, height=content.height + 0.45, color=WARNING)
+    badge.set_fill(WARNING, opacity=0.12)
+    content.move_to(badge.get_center())
+    return VGroup(badge, content)
+
+
+def make_grid_axes(x_range=(-6, 6, 1), y_range=(-4, 4, 1), x_length=10, y_length=6) -> Axes:
+    return Axes(
+        x_range=x_range,
+        y_range=y_range,
+        x_length=x_length,
+        y_length=y_length,
+        axis_config={"color": GRID, "include_numbers": False, "stroke_width": 2},
+        tips=False,
+    )
+
+
+def make_unit_circle() -> Circle:
+    return Circle(radius=2.1, color=PRIMARY, stroke_width=3)
+
+
+def make_right_triangle(a: float = 3, b: float = 2, color=PRIMARY) -> Polygon:
+    return Polygon(ORIGIN, RIGHT * a, RIGHT * a + UP * b, color=color, stroke_width=3)
+
+
+def make_vector_arrow(start=ORIGIN, end=RIGHT * 3 + UP * 2, color=PRIMARY) -> Arrow:
+    return Arrow(start=start, end=end, buff=0, color=color, stroke_width=5)

--- a/manim/style/scene_factory.py
+++ b/manim/style/scene_factory.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+
+from manim import *
+
+from style.components import (
+    ERROR,
+    MUTED,
+    PRIMARY,
+    SUCCESS,
+    TEXT_PRIMARY,
+    WARNING,
+    make_answer_badge,
+    make_formula_box,
+    make_step_label,
+    make_title,
+    make_warning_badge,
+    set_gradient_background,
+)
+
+
+@dataclass
+class VideoSpec:
+    code: str
+    topic: str
+    objective: str
+    formula: str
+    examples: list[str]
+    mistake: str
+    correction: str
+    quick_checks: list[str]
+    recap: str
+    narration: list[str]
+
+
+FAST = 0.9
+STANDARD = 1.2
+SLOW = 1.6
+
+
+def build_standard_scene(scene: Scene, spec: VideoSpec) -> None:
+    set_gradient_background(scene)
+
+    title = make_title(f"{spec.code}: {spec.topic}").to_edge(UP)
+    objective = Text(f"Objective: {spec.objective}", color=TEXT_PRIMARY, font_size=30).next_to(title, DOWN, buff=0.35)
+    scene.play(Write(title), FadeIn(objective, shift=0.2 * DOWN), run_time=SLOW)
+    scene.wait(0.45)
+
+    formula_label = make_step_label("Concept / Formula").to_edge(LEFT).shift(UP * 1.7)
+    formula_box = make_formula_box(spec.formula).next_to(formula_label, DOWN, aligned_edge=LEFT, buff=0.35)
+    scene.play(FadeIn(formula_label), Write(formula_box), run_time=SLOW)
+    scene.wait(0.45)
+
+    ex_label = make_step_label("Worked Examples A–C").to_edge(LEFT).shift(UP * 0.15)
+    example_lines = VGroup(
+        *[
+            Text(f"Example {chr(65 + i)}: {line}", color=PRIMARY, font_size=28)
+            for i, line in enumerate(spec.examples)
+        ]
+    ).arrange(DOWN, aligned_edge=LEFT, buff=0.26)
+    example_lines.next_to(ex_label, DOWN, aligned_edge=LEFT, buff=0.28)
+
+    scene.play(FadeIn(ex_label), run_time=STANDARD)
+    for line in example_lines:
+        scene.play(Write(line), run_time=STANDARD)
+
+    mistake_header = make_step_label("Common Mistake").to_edge(RIGHT).shift(UP * 0.15)
+    warning = make_warning_badge(spec.mistake).next_to(mistake_header, DOWN, buff=0.3)
+    correction = Text(spec.correction, color=SUCCESS, font_size=26).next_to(warning, DOWN, buff=0.3)
+    red_x = Text("✗", color=ERROR, font_size=72).move_to(warning.get_center() + UP * 0.08)
+
+    scene.play(FadeIn(mistake_header), FadeIn(warning), run_time=SLOW)
+    scene.play(FadeIn(red_x), run_time=FAST)
+    scene.play(FadeOut(red_x), run_time=FAST)
+    scene.play(Write(correction), run_time=STANDARD)
+
+    checks_label = make_step_label("Quick Check (3 prompts)").to_edge(LEFT).shift(DOWN * 2.0)
+    checks = VGroup(*[Text(f"• {q}", color=MUTED, font_size=24) for q in spec.quick_checks]).arrange(
+        DOWN, aligned_edge=LEFT, buff=0.2
+    )
+    checks.next_to(checks_label, DOWN, aligned_edge=LEFT, buff=0.2)
+    scene.play(FadeIn(checks_label), run_time=STANDARD)
+    scene.play(LaggedStart(*[FadeIn(q, shift=0.1 * RIGHT) for q in checks], lag_ratio=0.2), run_time=SLOW)
+
+    recap_badge = make_answer_badge(spec.recap).to_edge(DOWN)
+    scene.play(Flash(recap_badge, color=SUCCESS), FadeIn(recap_badge, shift=0.2 * UP), run_time=SLOW)
+
+    narration_label = Text("Narration cues:", color=TEXT_PRIMARY, font_size=22).to_corner(UR).shift(LEFT * 0.3)
+    narration_lines = VGroup(*[Text(f"- {line}", color=MUTED, font_size=18) for line in spec.narration]).arrange(
+        DOWN, aligned_edge=LEFT, buff=0.1
+    )
+    narration_lines.next_to(narration_label, DOWN, aligned_edge=LEFT, buff=0.08)
+    scene.play(FadeIn(narration_label), FadeIn(narration_lines), run_time=STANDARD)
+    scene.wait(1.2)

--- a/manim/v01_coterminal_deg.py
+++ b/manim/v01_coterminal_deg.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V01CoterminalAnglesDegrees(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V01",
+            topic="Coterminal Angles (Degrees)",
+            objective="Find coterminal angles with θ ± 360k.",
+            formula=r"\theta_{cot} = \theta + 360k",
+            examples=[
+                r"75° -> 435°, -285°, 795°",
+                r"-210° -> 150°, -570°, 510°",
+                r"765° -> 45°, 1125°, -315°",
+            ],
+            mistake="Forgetting k must be an integer.",
+            correction="Use k ∈ ℤ and verify by 360° differences.",
+            quick_checks=[
+                "Give one coterminal for 32°.",
+                "Normalize -725° to [0,360).",
+                "Are 140° and -220° coterminal?",
+            ],
+            recap=r"\text{Coterminal by }\pm 360k",
+            narration=[
+                "State the goal.",
+                "Setup with θ ± 360k.",
+                "Check by subtracting angles.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v02_coterminal_rad.py
+++ b/manim/v02_coterminal_rad.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V02CoterminalAnglesRadians(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V02",
+            topic="Coterminal Angles (Radians)",
+            objective="Find coterminal angles with θ ± 2πk.",
+            formula=r"\theta_{cot} = \theta + 2\pi k",
+            examples=[
+                r"5\pi/6 -> 17\pi/6, -7\pi/6",
+                r"-7\pi/6 -> 5\pi/6, -19\pi/6",
+                r"13\pi/6 -> \pi/6, 25\pi/6",
+            ],
+            mistake="Mixing degree and radian increments.",
+            correction="In radians, adjust by 2π only.",
+            quick_checks=[
+                "Coterminal for 11π/4?",
+                "Normalize -25π/6.",
+                "Are π/3 and 7π/3 coterminal?",
+            ],
+            recap=r"\text{Coterminal by }\pm 2\pi k",
+            narration=[
+                "Goal in radians.",
+                "Setup with 2πk.",
+                "Check equivalent terminal side.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v03_arc_length.py
+++ b/manim/v03_arc_length.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V03ArcLength(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V03",
+            topic="Arc Length",
+            objective="Apply s = rθ with θ in radians.",
+            formula=r"s = r\theta",
+            examples=[
+                r"r=5, θ=1.2 -> s=6",
+                r"r=9, θ=2π/3 -> s=6π",
+                r"s=15, r=6 -> θ=2.5",
+            ],
+            mistake="Using degrees directly in formula.",
+            correction="Convert degrees to radians before s=rθ.",
+            quick_checks=[
+                "Find s for r=4, θ=3.",
+                "Find θ if s=10, r=8.",
+                "What units does s use?",
+            ],
+            recap=r"s=r\theta\ (\theta\text{ in rad})",
+            narration=[
+                "Goal -> arc length.",
+                "Setup variables with units.",
+                "Check reasonableness.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v04_trig_ratio.py
+++ b/manim/v04_trig_ratio.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V04BasicTrigRatio(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V04",
+            topic="Basic Trig Ratio",
+            objective="Use SOH-CAH-TOA and side identification.",
+            formula=r"\sin\theta=\frac{o}{h},\ \cos\theta=\frac{a}{h},\ \tan\theta=\frac{o}{a}",
+            examples=[
+                r"Given opp=7, hyp=25 find sinθ",
+                r"Given adj=12, hyp=13 find cosθ",
+                r"Given opp=9, adj=40 find tanθ",
+            ],
+            mistake="Swapping opposite and adjacent sides.",
+            correction="Mark reference angle first, then label sides.",
+            quick_checks=[
+                "Compute sinθ with o=5, h=13.",
+                "Compute cosθ with a=8, h=17.",
+                "Which ratio uses opp/adj?",
+            ],
+            recap=r"\text{Label sides before ratio}",
+            narration=[
+                "Goal identify ratio.",
+                "Setup triangle labels.",
+                "Check value range.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v05_calculator_trig.py
+++ b/manim/v05_calculator_trig.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V05CalculatorTrigValues(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V05",
+            topic="Calculator Trig Values",
+            objective="Evaluate trig values with correct mode.",
+            formula=r"\sin,\cos,\tan\ \text{mode: DEG or RAD}",
+            examples=[
+                r"sin(35°) ≈ 0.5736 (DEG)",
+                r"cos(2.4) ≈ -0.7374 (RAD)",
+                r"tan(120°) ≈ -1.7321 (DEG)",
+            ],
+            mistake="Wrong mode gives wrong answers.",
+            correction="Always state and verify DEG/RAD before compute.",
+            quick_checks=[
+                "Evaluate sin(0.7) in RAD.",
+                "Evaluate cos(75°) in DEG.",
+                "Why is tan(90°) undefined?",
+            ],
+            recap=r"\text{Mode check first}",
+            narration=[
+                "Goal calculator evaluation.",
+                "Setup mode then input.",
+                "Check sign and magnitude.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v06_angle_conversion.py
+++ b/manim/v06_angle_conversion.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V06AngleUnitConversion(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V06",
+            topic="Angle Unit Conversion",
+            objective="Convert degrees and radians accurately.",
+            formula=r"\text{deg to rad: }\theta\cdot\frac{\pi}{180},\quad \text{rad to deg: }\theta\cdot\frac{180}{\pi}",
+            examples=[
+                r"210° -> 7π/6",
+                r"-45° -> -π/4",
+                r"5π/3 -> 300°",
+            ],
+            mistake="Cancelling π incorrectly.",
+            correction="Treat π as symbolic constant and simplify fractions.",
+            quick_checks=[
+                "Convert 135° to rad.",
+                "Convert -11π/6 to deg.",
+                "Convert 1.2 rad to deg (nearest tenth).",
+            ],
+            recap=r"\deg\leftrightarrow\text{rad conversion}",
+            narration=[
+                "Goal convert units.",
+                "Setup conversion factor.",
+                "Check quadrant sense.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v07_right_triangle_side_52.py
+++ b/manim/v07_right_triangle_side_52.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V07SolveRightTriangleSideSec52(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V07",
+            topic="Solve Right Triangle Side (Sec 5.2)",
+            objective="Find missing side using trig ratios.",
+            formula=r"\sin\theta=\frac{o}{h},\ \cos\theta=\frac{a}{h},\ \tan\theta=\frac{o}{a}",
+            examples=[
+                r"θ=32°, h=14 -> o=14sin32°",
+                r"θ=41°, a=9 -> h=9/cos41°",
+                r"θ=58°, a=11 -> o=11tan58°",
+            ],
+            mistake="Choosing inverse trig when side is requested.",
+            correction="Use direct ratio for sides; inverse only for angles.",
+            quick_checks=[
+                "Find o if θ=25°, h=20.",
+                "Find h if θ=60°, a=7.",
+                "Find a if θ=38°, o=9.",
+            ],
+            recap=r"\text{Select ratio by known/unknown}",
+            narration=[
+                "Goal missing side.",
+                "Setup equation.",
+                "Check with triangle scale.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v08_trig_from_ratio.py
+++ b/manim/v08_trig_from_ratio.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V08ExactTrigFromGivenRatio(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V08",
+            topic="Exact Trig from Given Ratio",
+            objective="Find all trig values from one ratio.",
+            formula=r"\sin\theta=\frac{o}{h},\ \cos\theta=\frac{a}{h},\ \tan\theta=\frac{o}{a}",
+            examples=[
+                r"Given sinθ=3/5, QII -> cosθ=-4/5",
+                r"Given cosθ=-5/13, QIII -> sinθ=-12/13",
+                r"Given tanθ=8/15, QI -> secθ=17/15",
+            ],
+            mistake="Ignoring quadrant signs.",
+            correction="Use ASTC signs after building reference triangle.",
+            quick_checks=[
+                "If sinθ=-5/13 in QIV, find cosθ.",
+                "If tanθ=-3/4 in QII, sign of cosθ?",
+                "Find cscθ from cosθ=12/13 in QI.",
+            ],
+            recap=r"\text{Triangle + quadrant signs}",
+            narration=[
+                "Goal complete trig set.",
+                "Setup triangle from ratio.",
+                "Check signs.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v09_ref_angle_deg.py
+++ b/manim/v09_ref_angle_deg.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V09ReferenceAngleDegrees(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V09",
+            topic="Reference Angle (Degrees)",
+            objective="Find reference angle for any degree measure.",
+            formula=r"\alpha=\text{distance to nearest }x\text{-axis}",
+            examples=[
+                r"θ=150° -> α=30°",
+                r"θ=225° -> α=45°",
+                r"θ=330° -> α=30°",
+            ],
+            mistake="Using quadrant angle instead of acute reference.",
+            correction="Reference angle must be acute (0° to 90°).",
+            quick_checks=[
+                "Find α for 112°.",
+                "Find α for 289°.",
+                "Find α for -135° after normalization.",
+            ],
+            recap=r"\alpha\in(0^\circ,90^\circ)",
+            narration=[
+                "Goal identify reference angle.",
+                "Setup via quadrant rules.",
+                "Check acute result.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v10_ref_angle_rad.py
+++ b/manim/v10_ref_angle_rad.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V10ReferenceAngleRadians(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V10",
+            topic="Reference Angle (Radians)",
+            objective="Find reference angle for radian measures.",
+            formula=r"\alpha=\text{distance to nearest }x\text{-axis}",
+            examples=[
+                r"\theta=7\pi/6 -> \alpha=\pi/6",
+                r"\theta=11\pi/6 -> \alpha=\pi/6",
+                r"\theta=5\pi/4 -> \alpha=\pi/4",
+            ],
+            mistake="Leaving answer > π/2.",
+            correction="Reference angle in radians must be between 0 and π/2.",
+            quick_checks=[
+                "Find α for 4π/3.",
+                "Find α for -7π/4.",
+                "Find α for 17π/6.",
+            ],
+            recap=r"\alpha\in(0,\pi/2)",
+            narration=[
+                "Goal radian reference.",
+                "Setup quadrant mapping.",
+                "Check acute radian value.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v11_quadrant_signs.py
+++ b/manim/v11_quadrant_signs.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V11QuadrantFromSigns(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V11",
+            topic="Quadrant from Signs",
+            objective="Determine quadrants from trig signs.",
+            formula=r"\text{ASTC sign chart}",
+            examples=[
+                r"sin>0, cos<0 -> QII",
+                r"tan>0, sin<0 -> QIII",
+                r"sec<0, csc>0 -> QII",
+            ],
+            mistake="Confusing tan sign with sin sign.",
+            correction="Use tan=sin/cos to validate consistency.",
+            quick_checks=[
+                "Quadrant if cos>0 and tan<0?",
+                "Quadrants where sin<0?",
+                "Can sec>0 and cos<0 occur?",
+            ],
+            recap=r"\text{Use ASTC + consistency check}",
+            narration=[
+                "Goal locate quadrant.",
+                "Setup sign logic.",
+                "Check trig identities.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v12_trig_values_info.py
+++ b/manim/v12_trig_values_info.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V12TrigValuesFromQuadrantReferenceInfo(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V12",
+            topic="Trig Values from Quadrant/Reference Info",
+            objective="Compute trig values from α and quadrant.",
+            formula=r"\sin\theta=\pm\sin\alpha,\ \cos\theta=\pm\cos\alpha,\ \tan\theta=\pm\tan\alpha",
+            examples=[
+                r"α=35°, QII -> sin+, cos-, tan-",
+                r"α=0.4, QIV -> cos+, sin-",
+                r"α=π/6, QIII -> tan+",
+            ],
+            mistake="Using reference-angle signs directly.",
+            correction="Apply quadrant sign after reference value.",
+            quick_checks=[
+                "If α=20° in QIII, sign of cosθ?",
+                "Given α=π/3 in QIV, tanθ sign?",
+                "Compute sinθ from α=45° in QII.",
+            ],
+            recap=r"\text{Reference value then sign}",
+            narration=[
+                "Goal derive trig values.",
+                "Setup with α values.",
+                "Check sign by quadrant.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v13_solve_trig_eq.py
+++ b/manim/v13_solve_trig_eq.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V13SolveTrigEquationOn0360(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V13",
+            topic="Solve Trig Equation on [0°,360°)",
+            objective="Solve special-angle trig equations on interval.",
+            formula=r"\sin\theta=a,\ \cos\theta=a,\ \tan\theta=a\ \text{on }[0^\circ,360^\circ)",
+            examples=[
+                r"sinθ=√3/2 -> θ=60°,120°",
+                r"cosθ=-1/2 -> θ=120°,240°",
+                r"tanθ=1 -> θ=45°,225°",
+            ],
+            mistake="Missing second quadrant/solution.",
+            correction="Use reference angle + all valid quadrants.",
+            quick_checks=[
+                "Solve sinθ=1/2.",
+                "Solve cosθ=0.",
+                "Solve tanθ=-√3.",
+            ],
+            recap=r"\text{Reference angle + quadrant set}",
+            narration=[
+                "Goal solve in interval.",
+                "Setup reference angle.",
+                "Check all solutions.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v14_solve_right_triangle.py
+++ b/manim/v14_solve_right_triangle.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V14SolveRightTriangleAngle(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V14",
+            topic="Solve Right Triangle (Angle)",
+            objective="Find unknown angle using inverse trig.",
+            formula=r"\theta=\sin^{-1}(o/h),\ \cos^{-1}(a/h),\ \tan^{-1}(o/a)",
+            examples=[
+                r"o=7, a=24 -> θ=tan⁻¹(7/24)",
+                r"o=9, h=15 -> θ=sin⁻¹(3/5)",
+                r"a=12, h=13 -> θ=cos⁻¹(12/13)",
+            ],
+            mistake="Using inverse on reciprocal by accident.",
+            correction="Choose inverse matching given ratio exactly.",
+            quick_checks=[
+                "Find θ if o=5, h=13.",
+                "Find θ if a=8, o=6.",
+                "Why is second angle 90°-θ?",
+            ],
+            recap=r"\theta\text{ via inverse trig}",
+            narration=[
+                "Goal solve angle.",
+                "Setup ratio.",
+                "Check with complementary angle.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v15_angle_elevation.py
+++ b/manim/v15_angle_elevation.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V15AngleOfElevationDepression(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V15",
+            topic="Angle of Elevation/Depression",
+            objective="Model and solve elevation/depression problems.",
+            formula=r"\tan\theta=\frac{\text{opposite}}{\text{adjacent}}",
+            examples=[
+                r"From 40 m away, θ=32° find height",
+                r"From roof, depression 18° to point 55 m away",
+                r"Find distance when height and angle known",
+            ],
+            mistake="Using wrong reference line.",
+            correction="Angle is measured from horizontal line.",
+            quick_checks=[
+                "A kite is 60 m high at 25°; find horizontal distance.",
+                "Depression 12° from 30 m tower; find distance.",
+                "Which angle equals alternate interior angle?",
+            ],
+            recap=r"\text{Draw horizontal first}",
+            narration=[
+                "Goal translate geometry.",
+                "Setup right triangle.",
+                "Check units.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v16_two_right_triangles.py
+++ b/manim/v16_two_right_triangles.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V16TwoRightTriangles(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V16",
+            topic="Two Right Triangles",
+            objective="Solve linked-triangle application problems.",
+            formula=r"\text{Use shared side relations + trig ratios}",
+            examples=[
+                r"Two observation points share building height",
+                r"Ladder + shadow creates pair of triangles",
+                r"Split composite shape into two right triangles",
+            ],
+            mistake="Not defining shared variable clearly.",
+            correction="Assign variable once, reuse in both equations.",
+            quick_checks=[
+                "Name a shared side in a two-triangle setup.",
+                "Which equation should be solved first?",
+                "How to verify both triangles fit final answer?",
+            ],
+            recap=r"\text{Define shared variable early}",
+            narration=[
+                "Goal connect triangles.",
+                "Setup two equations.",
+                "Check both contexts.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v17_drt_trig.py
+++ b/manim/v17_drt_trig.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V17DistanceRateTimeWithTrig(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V17",
+            topic="Distance-Rate-Time with Trig",
+            objective="Combine D=rt with trig geometry.",
+            formula=r"D=rt\quad\text{and}\quad\tan\theta=\frac{h}{d}",
+            examples=[
+                r"Plane climb angle with horizontal speed",
+                r"Boat crossing with bearing + current",
+                r"Radar line-of-sight with time delay",
+            ],
+            mistake="Mixing horizontal distance and path distance.",
+            correction="State what each distance represents before formulas.",
+            quick_checks=[
+                "If speed=80 and t=0.5h, find distance.",
+                "At 12° climb with 40 km path, find rise.",
+                "When to use cosine in DRT trig?",
+            ],
+            recap=r"\text{Label D, r, t, and geometry}",
+            narration=[
+                "Goal connect motion + trig.",
+                "Setup variables.",
+                "Check dimensional consistency.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v18_bearing_navigation.py
+++ b/manim/v18_bearing_navigation.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V18BearingNavigationDistance(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V18",
+            topic="Bearing / Navigation Distance",
+            objective="Use bearings and trig to find distances.",
+            formula=r"\text{Bearing measured clockwise from North}",
+            examples=[
+                r"Bearing N35°E for 20 km -> components",
+                r"Two-leg trip bearings -> resultant displacement",
+                r"Find distance between ships by law of cosines setup",
+            ],
+            mistake="Using East as zero direction.",
+            correction="Start from North, rotate clockwise for bearing.",
+            quick_checks=[
+                "Convert S20°W to standard direction info.",
+                "Component signs for N10°W?",
+                "What axis aligns with North?",
+            ],
+            recap=r"\text{North-clockwise bearing convention}",
+            narration=[
+                "Goal decode bearing.",
+                "Setup components.",
+                "Check signs and direction words.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v19_oblique_area.py
+++ b/manim/v19_oblique_area.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V19AreaOfNonRightTriangle(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V19",
+            topic="Area of Non-Right Triangle",
+            objective="Compute area with A = 1/2 ab sin(C).",
+            formula=r"A=\frac{1}{2}ab\sin(C)",
+            examples=[
+                r"a=12, b=9, C=40°",
+                r"a=7, b=15, C=112°",
+                r"Given area and sides, solve for C",
+            ],
+            mistake="Using cosine in area formula.",
+            correction="Area for included angle uses sine only.",
+            quick_checks=[
+                "Find area for a=10,b=5,C=30°.",
+                "Does C=150° give positive area?",
+                "What if included angle missing?",
+            ],
+            recap=r"A=\frac12 ab\sin(C)",
+            narration=[
+                "Goal area of oblique triangle.",
+                "Setup included angle.",
+                "Check units squared.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v20_vector_components.py
+++ b/manim/v20_vector_components.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V20VectorComponentsFromPoints(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V20",
+            topic="Vector Components from Points",
+            objective="Find component form from endpoints.",
+            formula=r"\langle x_2-x_1,\ y_2-y_1\rangle",
+            examples=[
+                r"A(2,-1), B(7,5) -> <5,6>",
+                r"P(-3,4), Q(1,-2) -> <4,-6>",
+                r"From tail/head graph read then subtract",
+            ],
+            mistake="Subtracting in opposite order.",
+            correction="Use head minus tail consistently.",
+            quick_checks=[
+                "Find vector from (1,2) to (4,-3).",
+                "Component sign if move left 6?",
+                "Can zero component occur?",
+            ],
+            recap=r"\vec v=\langle\Delta x,\Delta y\rangle",
+            narration=[
+                "Goal components from points.",
+                "Setup subtraction.",
+                "Check direction.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v21_vector_ops.py
+++ b/manim/v21_vector_ops.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V21VectorOperations(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V21",
+            topic="Vector Operations",
+            objective="Add, subtract, and scale vectors.",
+            formula=r"\langle a,b\rangle\pm\langle c,d\rangle=\langle a\pm c,b\pm d\rangle",
+            examples=[
+                r"<3,-2> + <5,4> = <8,2>",
+                r"<7,1> - <2,6> = <5,-5>",
+                r"-2<4,-3> = <-8,6>",
+            ],
+            mistake="Distributing negative signs incorrectly.",
+            correction="Write component-wise operation on each coordinate.",
+            quick_checks=[
+                "Compute <1,5> + <-3,2>.",
+                "Compute 3<2,-4>.",
+                "Interpret <-2,0> direction.",
+            ],
+            recap=r"\text{Operate component-wise}",
+            narration=[
+                "Goal vector arithmetic.",
+                "Setup components.",
+                "Check direction/magnitude change.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v22_vector_magnitude.py
+++ b/manim/v22_vector_magnitude.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V22VectorMagnitude(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V22",
+            topic="Vector Magnitude",
+            objective="Compute |v| using Pythagorean formula.",
+            formula=r"|\vec v|=\sqrt{x^2+y^2}",
+            examples=[
+                r"v=<3,4> -> |v|=5",
+                r"v=<-5,12> -> |v|=13",
+                r"v=<6,-8> -> |v|=10",
+            ],
+            mistake="Forgetting square root at end.",
+            correction="Magnitude is nonnegative square-root value.",
+            quick_checks=[
+                "Find |<8,15>|.",
+                "Can magnitude be negative?",
+                "Find |<-7,0>|.",
+            ],
+            recap=r"|\vec v|=\sqrt{x^2+y^2}",
+            narration=[
+                "Goal magnitude.",
+                "Setup formula.",
+                "Check nonnegative result.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v23_vector_direction.py
+++ b/manim/v23_vector_direction.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V23DirectionAngleOfVector(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V23",
+            topic="Direction Angle of Vector",
+            objective="Find direction angle from components.",
+            formula=r"\theta=\tan^{-1}(y/x)\ \text{with quadrant adjustment}",
+            examples=[
+                r"v=<4,4> -> θ=45°",
+                r"v=<-3,3> -> θ=135°",
+                r"v=<2,-5> -> θ\approx291.8°",
+            ],
+            mistake="Using raw arctan without quadrant fix.",
+            correction="Adjust angle to [0°,360°) by component signs.",
+            quick_checks=[
+                "Direction of <-6,-6>?",
+                "Direction of <0,5>?",
+                "Why use atan2 logic?",
+            ],
+            recap=r"\theta\text{ needs quadrant check}",
+            narration=[
+                "Goal direction angle.",
+                "Setup inverse tangent.",
+                "Check quadrant.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v24_vector_mag_dir_graph.py
+++ b/manim/v24_vector_mag_dir_graph.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V24VectorMagnitudeDirectionFromGraph(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V24",
+            topic="Vector Magnitude + Direction from Graph",
+            objective="Read vector from graph and compute magnitude/direction.",
+            formula=r"\Delta x,\Delta y \to |v|,\theta",
+            examples=[
+                r"Graph shows move (5,2) -> |v|=√29, θ≈21.8°",
+                r"Graph move (-4,3) -> |v|=5, θ≈143.1°",
+                r"Graph move (-2,-6) -> |v|=√40, θ≈251.6°",
+            ],
+            mistake="Reading tail as origin when it is shifted.",
+            correction="Compute displacement from tail to head first.",
+            quick_checks=[
+                "If move (0,-7), magnitude and direction?",
+                "If move (9,0), direction?",
+                "Why same magnitude for opposite vectors?",
+            ],
+            recap=r"\text{Read }\Delta x,\Delta y\text{ first}",
+            narration=[
+                "Goal graph to numbers.",
+                "Setup displacement.",
+                "Check angle quadrant.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v25_vector_from_mag_dir.py
+++ b/manim/v25_vector_from_mag_dir.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V25VectorFromMagnitudeDirectionToComponents(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V25",
+            topic="Vector from Magnitude/Direction to Components",
+            objective="Convert polar-like data to components.",
+            formula=r"\langle |v|\cos\theta,\ |v|\sin\theta\rangle",
+            examples=[
+                r"|v|=10, θ=30° -> <8.66,5>",
+                r"|v|=12, θ=150° -> <-10.39,6>",
+                r"|v|=7, θ=260° -> <-1.22,-6.89>",
+            ],
+            mistake="Swapping sine and cosine.",
+            correction="x uses cosine, y uses sine for standard angle.",
+            quick_checks=[
+                "Find components for |v|=5, θ=60°.",
+                "Sign of y at θ=210°?",
+                "Round components to nearest hundredth.",
+            ],
+            recap=r"\langle r\cos\theta,r\sin\theta\rangle",
+            narration=[
+                "Goal convert mag+dir.",
+                "Setup component formulas.",
+                "Check signs.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v26_resultant_direction_vectors.py
+++ b/manim/v26_resultant_direction_vectors.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V26ResultantFromDirectionFormVectors(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V26",
+            topic="Resultant from Direction-Form Vectors",
+            objective="Sum direction-form vectors via components.",
+            formula=r"\vec R=\sum\langle r\cos\theta,r\sin\theta\rangle",
+            examples=[
+                r"20@40° + 12@120° -> resultant components",
+                r"15@210° + 8@330° -> resultant direction",
+                r"Three-vector sum then magnitude",
+            ],
+            mistake="Adding magnitudes directly.",
+            correction="Convert each vector to components before summing.",
+            quick_checks=[
+                "First step for resultant from bearings?",
+                "After components, how find direction?",
+                "Why can resultant be shorter than inputs?",
+            ],
+            recap=r"\text{Convert then sum components}",
+            narration=[
+                "Goal resultant vector.",
+                "Setup component table.",
+                "Check final magnitude and angle.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v27_graph_vector_add.py
+++ b/manim/v27_graph_vector_add.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V27GraphStyleVectorAddition(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V27",
+            topic="Graph-Style Vector Addition",
+            objective="Add vectors head-to-tail on graph.",
+            formula=r"\vec u+\vec v=\langle u_x+v_x,u_y+v_y\rangle",
+            examples=[
+                r"Translate second vector to head of first",
+                r"Read resultant from first tail to last head",
+                r"Compare graphical and algebraic result",
+            ],
+            mistake="Connecting tails instead of head-to-tail.",
+            correction="Keep direction/length fixed when translating vector.",
+            quick_checks=[
+                "Graphically add <2,1> and <-1,3>.",
+                "Resultant of opposite vectors?",
+                "Why translation preserves vector?",
+            ],
+            recap=r"\text{Head-to-tail then read resultant}",
+            narration=[
+                "Goal graphical addition.",
+                "Setup translated vector.",
+                "Check with components.",
+            ],
+        )
+        build_standard_scene(self, spec)

--- a/manim/v28_capstone_review.py
+++ b/manim/v28_capstone_review.py
@@ -1,0 +1,32 @@
+from manim import Scene
+
+from style.scene_factory import VideoSpec, build_standard_scene
+
+
+class V28FullReviewMixedCapstone(Scene):
+    def construct(self) -> None:
+        spec = VideoSpec(
+            code="V28",
+            topic="Full Review Mixed Capstone",
+            objective="Integrate core topics across sections 5.1–8.4.",
+            formula=r"\text{Angles, triangles, equations, vectors: integrated workflow}",
+            examples=[
+                r"Angle conversion + trig equation mini-set",
+                r"Right-triangle application + bearing checkpoint",
+                r"Vector resultant + direction final check",
+            ],
+            mistake="Jumping formulas without identifying topic.",
+            correction="State topic family before selecting formula.",
+            quick_checks=[
+                "Which formula family fits this prompt?",
+                "What unit/mode checks come first?",
+                "How will you verify final answer?",
+            ],
+            recap=r"\text{Goal→Setup→Solve→Check across topics}",
+            narration=[
+                "Goal review and synthesis.",
+                "Setup by classifying problem.",
+                "Check with reasonableness and units.",
+            ],
+        )
+        build_standard_scene(self, spec)


### PR DESCRIPTION
### Motivation
- Consolidate a 28-video Manim pipeline with a shared visual style, standardized scene layout, and a tracked QA/export process.
- Provide a reusable scene factory and UI components to enforce palette, typography, and required section flow across all scenes.
- Capture math QA results and update the orchestrator tracker to reflect completion of script/scene authoring for all videos.

### Description
- Updated `MANIM_PROGRESS_ORCHESTRATOR.md` to mark V01–V28 as script/scene complete, added a weekly cadence, and appended an "Orchestrator Review Log" summary of the work.
- Added a new `MATH_QA_REPORT.md` documenting per-video math QA checks and overall pass status for V01–V28.
- Introduced shared style components in `manim/style/components.py` (colors, sizes, helper builders like `make_formula_box`, `make_unit_circle`, etc.).
- Added a scene factory `manim/style/scene_factory.py` exposing `VideoSpec` and `build_standard_scene` to generate consistent scenes, and created 28 concrete scene files `v01_...` through `v28_...` that use the factory.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc65218d6c833186cb835c25be5998)