### PR TITLE
Handle generator lookup/generation failures in Test 3 quiz flow

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -2859,6 +2859,12 @@
     function startQuiz(id) {
         currentQuiz = generators.find(g => g.id === id);
         document.getElementById('quiz-active-area').style.display = 'block';
+        if (!currentQuiz) {
+            const feedback = document.getElementById('feedback-display');
+            feedback.className = 'feedback incorrect';
+            feedback.textContent = 'Could not load this practice generator. Please refresh.';
+            return;
+        }
         loadQuestion();
     }
 
@@ -2878,11 +2884,27 @@
             const gen = examState.questions[examState.currentIndex];
             currentQuiz = gen;
             currentRetries = 0;
-            currentQuestion = gen.generate();
+            try {
+                currentQuestion = gen.generate();
+            } catch (err) {
+                const feedback = document.getElementById('feedback-display');
+                feedback.className = 'feedback incorrect';
+                feedback.textContent = 'This practice generator ran into an error. Please refresh and try again.';
+                console.error('Generator failed', { id: gen?.id, err });
+                return;
+            }
         } else {
             if (!currentQuiz) return;
             currentRetries = 0;
-            currentQuestion = currentQuiz.generate();
+            try {
+                currentQuestion = currentQuiz.generate();
+            } catch (err) {
+                const feedback = document.getElementById('feedback-display');
+                feedback.className = 'feedback incorrect';
+                feedback.textContent = 'This practice generator ran into an error. Please refresh and try again.';
+                console.error('Generator failed', { id: currentQuiz?.id, err });
+                return;
+            }
         }
         
         document.getElementById('question-display').innerHTML = currentQuestion.q;


### PR DESCRIPTION
### Motivation
- Make generator lookup/generation failures visible to users instead of failing silently when starting or advancing a practice quiz. 
- Provide a consistent user-facing error in `#feedback-display` and keep the quiz area shown so users understand something went wrong. 
- Surface errors to developers via `console.error` for easier debugging of broken generator implementations. 

### Description
- In `130Test3.html` updated `startQuiz(id)` to check the result of `generators.find(...)` and, if missing, keep `#quiz-active-area` visible and write a clear message to `#feedback-display` before returning. 
- In `loadQuestion()` wrapped the exam-mode `gen.generate()` call in `try/catch` and on error show a user-facing message in `#feedback-display` and log `console.error('Generator failed', { id, err })`. 
- In `loadQuestion()` wrapped the normal-mode `currentQuiz.generate()` call in `try/catch` and on error show the same user-facing message and log the error. 
- Left the existing success path and UI rendering unchanged so working generators behave as before. 

### Testing
- Ran a targeted code search with `rg` to confirm the presence of the new checks and error strings and verified the modified lines in `130Test3.html`, which succeeded. 
- Inspected the updated file region (`nl`/file snippet) to validate the `try/catch` blocks and feedback updates were inserted as intended, which succeeded. 
- No automated unit tests were present or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd6bf5df188331b8b9dea7708f1914)