### PR TITLE
Use semantic body/theme classes in final exam review guide

### DIFF
--- a/courses/final-exam-review-guide.html
+++ b/courses/final-exam-review-guide.html
@@ -38,6 +38,9 @@
             padding-bottom: 1rem;
             margin-bottom: 1rem;
         }
+        .review-guide-title {
+            color: var(--primary-main);
+        }
         .question-guide h2 {
             font-size: 1.125rem; /* text-lg */
             font-weight: 600; /* semibold */
@@ -67,7 +70,7 @@
     <link rel="stylesheet" href="/styles.css">
     <script src="../theme.js"></script>
 </head>
-<body class="bg-gray-50 text-gray-800">
+<body class="reading-page">
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
@@ -125,7 +128,7 @@
 
 
     <article class="reading-flow reading-flow--wide">
-        <h1 class="text-2xl font-bold text-center mb-6 border-b pb-3 text-blue-700">Final Exam Review Guide</h1>
+        <h1 class="review-guide-title text-2xl font-bold text-center mb-6 border-b pb-3">Final Exam Review Guide</h1>
 
         <div class="question-guide">
             <h2>1. Hourly Wage:</h2>


### PR DESCRIPTION
### Motivation
- Remove hardcoded Tailwind gray utilities from the page root and heading so the page background and text are driven by the site theme tokens and support theming.

### Description
- Replaced the `<body>` classes `bg-gray-50 text-gray-800` with the semantic `reading-page` class so colors come from `styles.css` tokens.
- Added a local semantic heading class `.review-guide-title { color: var(--primary-main); }` and replaced the `text-blue-700` utility on the page `<h1>` with `review-guide-title`.
- Kept other markup and inline styles intact, adding the small CSS rule into the page's `<style>` block.

### Testing
- Ran `rg -n "bg-gray-|text-gray-" courses/final-exam-review-guide.html` and confirmed there are no remaining `bg-gray-` or `text-gray-` utilities.
- Verified the working tree and committed the change using `git status --short` and a commit; the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfec294cc083319830bb880a51d8fa)