### PR TITLE
Rename Test 3 review to Unit 3 Study Guide and update slide copy/layout

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <link rel="stylesheet" href="/styles.css">
 <script src="theme.js"></script>
-    <title>Math 130 – Test 3 Review (Spring 2026)</title>
+    <title>Math 130 – Unit 3 Study Guide (Spring 2026)</title>
 
 <!-- Fonts -->
 <!-- Page-specific external CSS: Google Fonts requested by this page's typography design. -->
@@ -680,7 +680,6 @@
             box-shadow: 0 14px 28px color-mix(in srgb, var(--text-main) 12%, transparent);
         }
         .slide-card-featured {
-            order: -1;
             grid-column: span 2;
             border-color: color-mix(in srgb, var(--primary-main) 55%, var(--border-subtle));
             background: linear-gradient(180deg, color-mix(in srgb, var(--primary-main) 12%, var(--bg-surface)) 0%, var(--bg-surface) 100%);
@@ -922,7 +921,7 @@
       <span aria-hidden="true" class="breadcrumb-sep">›</span>
       <a href="courses/math130.html">MATH 130</a>
       <span aria-hidden="true" class="breadcrumb-sep">›</span>
-      <span class="breadcrumb-current" aria-current="page">Test 3 Review</span>
+      <span class="breadcrumb-current" aria-current="page">Unit 3 Study Guide</span>
     </nav>
   </div>
 </div>
@@ -930,8 +929,8 @@
 <header class="page-shell-header review-page-header">
   <div class="container">
     <p class="page-shell-header__eyebrow">Spring 2026 · Prof. Young &amp; Prof. Volk</p>
-    <h1>Math 130 – Test 3 Review</h1>
-    <p class="subtitle">Topics: Sections 5.1–5.3, 7.1, and 8.4</p>
+    <h1>Math 130 – Unit 3 Study Guide</h1>
+    <p class="subtitle">Unit 3 coverage (Sections 5.1–5.3, 7.1, and 8.4) that builds to Test 3.</p>
   </div>
 </header>
 
@@ -954,16 +953,16 @@
 <div class="section-lead">
 <div class="section-eyebrow"><i data-lucide="layers-3"></i> Start here</div>
 <h2>Lecture Slides</h2>
-<p>Open the lead deck first, then work forward through the supporting modules so the highest-priority review materials stand out immediately.</p>
+<p>Work through Unit 3 modules in order (10 → 13), then finish with the Unit 3 wrap-up deck as your Test 3 final pass.</p>
 </div>
 <div class="section-summary-grid">
 <div class="section-summary-card review-summary-card">
-<span class="section-summary-label">Lead review deck</span>
-<span class="section-summary-value">Math 130 Unit 3: Test 3 Review (Module 3E)</span>
+<span class="section-summary-label">Start with</span>
+<span class="section-summary-value">Module 10 (5.1–5.2): Trig Foundations</span>
 </div>
 <div class="section-summary-card review-summary-card">
 <span class="section-summary-label">Support sequence</span>
-<span class="section-summary-value">Modules 10–13 for foundations, then Unit 3E for final consolidation.</span>
+<span class="section-summary-value">Module 10 → Module 11 → Module 12 → Module 13 → Unit 3 Wrap-Up (Test 3)</span>
 </div>
 </div>
 <div class="slides-shell">
@@ -1063,19 +1062,19 @@
 </div>
 <div class="slide-card slide-card-featured">
 <div class="slide-card-top">
-<div class="slide-badge"><i data-lucide="presentation"></i> Unit 3 Review</div>
+<div class="slide-badge"><i data-lucide="presentation"></i> Unit 3 Wrap-Up</div>
 <div class="slide-format-tags"><span class="slide-tag pdf">PDF</span><span class="slide-tag pptx">PPTX</span></div>
 </div>
-<a class="slide-thumb-wrap" href="slides/Math130Unit3E.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Unit 3 Review PDF slides">
-<img alt="Thumbnail preview for Math 130 Unit 3 Review lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3E.png"/>
+<a class="slide-thumb-wrap" href="slides/Math130Unit3E.pdf" target="_blank" rel="noopener noreferrer" aria-label="Open Unit 3 Wrap-Up PDF slides">
+<img alt="Thumbnail preview for Math 130 Unit 3 Wrap-Up lecture slides" class="slide-thumb" loading="lazy" onerror="this.closest('.slide-thumb-wrap').classList.add('is-missing')" src="slides/Math130Unit3E.png"/>
 <div class="slide-thumb-placeholder">
 <i data-lucide="image"></i>
 <div class="slide-thumb-label">Click to Open PDF</div>
 <div class="slide-thumb-note">Add <code>Math130Unit3E.png</code> to the slides folder.</div>
 </div>
 </a>
-<h3>Math 130 Unit 3: Test 3 Review</h3>
-<p class="slide-subtitle">Consolidates Modules 10–13 into a focused Test 3 review aligned to the Unit 3 checklist.</p>
+<h3>Math 130 Unit 3: Wrap-Up for Test 3</h3>
+<p class="slide-subtitle">Consolidates Modules 10–13 into a full Unit 3 wrap-up aligned to the checklist and ending with Test 3 prep.</p>
 <div class="slide-actions">
 <a class="btn-primary" href="slides/Math130Unit3E.pdf" target="_blank" rel="noopener noreferrer"><i data-lucide="file-text"></i><span>View PDF</span></a>
 <a class="btn-secondary" href="slides/Math130Unit3E.pptx" target="_blank" rel="noopener noreferrer"><i data-lucide="download"></i><span>Download PPTX</span></a>


### PR DESCRIPTION
### Motivation

- Clarify that the page is a Unit 3 study guide and wrap-up that leads into Test 3 rather than being titled solely as a "Test 3 Review". 
- Adjust slide labels and ordering behavior so the module flow and featured card presentation better reflect the intended study sequence.

### Description

- Updated the document `<title>` to `Math 130 – Unit 3 Study Guide (Spring 2026)` and changed the breadcrumb and header from "Test 3 Review" to "Unit 3 Study Guide" with a revised subtitle. 
- Revised slide-section copy and ordering guidance to instruct students to work through modules `10 → 13` then finish with the Unit 3 wrap-up, and changed summary cards accordingly. 
- Renamed module/slide labels and assets (e.g., Module names, featured card badge from "Unit 3 Review" to "Unit 3 Wrap-Up", alt text and headings for the featured slide, and a few aria/aria-label strings to match the new wording). 
- Removed the inline CSS rule `order: -1;` from `.slide-card-featured` so the featured card no longer forces a negative order in the grid layout.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cffe1f2fc08331a8c37ca6850c69b2)