### PR TITLE
Add answer labels, π-insert helper, and robust π-expression parsing for radian inputs

### DIFF
--- a/130Test2.html
+++ b/130Test2.html
@@ -307,6 +307,15 @@
             color: var(--text-main);
         }
         .log-arg-input { width: 140px; }
+        .answer-label {
+            width: 100%;
+            text-align: left;
+            max-width: 420px;
+            margin: 0 auto 0.35rem auto;
+            color: var(--text-main);
+            font-weight: 600;
+            font-size: 0.98rem;
+        }
 
         /* Multi-input grid (interest table, circle multi-part) */
         .multi-input-grid { 
@@ -3424,6 +3433,7 @@
             `;
         } else if (currentQuestion.inputType === 'log_argument') {
             inputArea.innerHTML = `
+                <label class="answer-label" for="answer-input">Answer (decimal only)</label>
                 <div class="log-arg-template" aria-label="Enter the argument of the logarithm">
                     <span class="math-text">log</span>
                     <span class="log-base-stack">${currentQuestion.displayBase}</span>
@@ -3485,7 +3495,10 @@
                 </div>
             `;
         } else {
-            inputArea.innerHTML = `<input type="number" step="any" id="answer-input" class="inp-standard" placeholder="Your Answer" autocomplete="off">`;
+            inputArea.innerHTML = `
+                <label class="answer-label" for="answer-input">Answer (decimal only)</label>
+                <input type="number" step="any" id="answer-input" class="inp-standard" placeholder="Your Answer" autocomplete="off">
+            `;
         }
         
         // Focus first input

--- a/130Test3.html
+++ b/130Test3.html
@@ -334,6 +334,49 @@
             color: var(--text-main);
         }
         .log-arg-input { width: 140px; }
+        .answer-label {
+            width: 100%;
+            text-align: left;
+            max-width: 420px;
+            margin: 0 auto 0.35rem auto;
+            color: var(--text-main);
+            font-weight: 600;
+            font-size: 0.98rem;
+        }
+        .answer-helper {
+            width: 100%;
+            text-align: left;
+            max-width: 420px;
+            margin: 0.35rem auto 0 auto;
+            color: var(--text-muted);
+            font-size: 0.9rem;
+            line-height: 1.45;
+        }
+        .coterminal-rad-row {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+        .pi-insert-btn {
+            border: 1px solid var(--border-subtle);
+            background: var(--bg-surface);
+            color: var(--text-main);
+            border-radius: 10px;
+            padding: 0.65rem 0.8rem;
+            min-width: 44px;
+            min-height: 44px;
+            font-size: 1.05rem;
+            cursor: pointer;
+            font-family: var(--type-display-family);
+        }
+        .pi-insert-btn:hover,
+        .pi-insert-btn:focus-visible {
+            border-color: var(--primary-main);
+            outline: none;
+            background: color-mix(in srgb, var(--primary-main) 12%, var(--bg-surface));
+        }
 
         /* Multi-input grid (interest table, circle multi-part) */
         .multi-input-grid { 
@@ -3161,10 +3204,35 @@
                     <input type="number" step="any" id="inp-vdir" placeholder="degrees">
                 </div>
             `;
+        } else if (currentQuestion.inputType === 'coterminal_rad') {
+            inputArea.innerHTML = `
+                <label class="answer-label" for="answer-input">Answer (decimal or pi notation)</label>
+                <div class="coterminal-rad-row">
+                    <input type="text" id="answer-input" class="inp-standard" placeholder="Example: pi, 2pi/3, -5pi/6, or 3.142" inputmode="decimal" autocapitalize="off" autocomplete="off" spellcheck="false">
+                    <button type="button" id="insert-pi-btn" class="pi-insert-btn" aria-label="Insert pi">π</button>
+                </div>
+                <div class="answer-helper">You may enter a decimal or pi notation. Type pi if you do not have a π key.</div>
+            `;
         } else if (currentQuestion.inputType === 'quadrant_int') {
             inputArea.innerHTML = `<input type="number" min="1" max="4" step="1" id="answer-input" class="inp-standard" placeholder="1-4" autocomplete="off">`;
         } else {
-            inputArea.innerHTML = `<input type="number" step="any" id="answer-input" class="inp-standard" placeholder="Your Answer" autocomplete="off">`;
+            inputArea.innerHTML = `
+                <label class="answer-label" for="answer-input">Answer (decimal only)</label>
+                <input type="number" step="any" id="answer-input" class="inp-standard" placeholder="Your Answer" autocomplete="off">
+            `;
+        }
+
+        if (currentQuestion.inputType === 'coterminal_rad') {
+            const answerInput = document.getElementById('answer-input');
+            const insertPiBtn = document.getElementById('insert-pi-btn');
+            if (answerInput && insertPiBtn) {
+                insertPiBtn.addEventListener('click', () => {
+                    const start = answerInput.selectionStart ?? answerInput.value.length;
+                    const end = answerInput.selectionEnd ?? answerInput.value.length;
+                    answerInput.setRangeText('pi', start, end, 'end');
+                    answerInput.focus();
+                });
+            }
         }
         
         // Focus first input
@@ -3193,20 +3261,29 @@
     function parsePiRadiansExpression(rawValue) {
         const trimmed = rawValue.trim().toLowerCase().replace(/\s+/g, '').replace(/π/g, 'pi');
         if (!trimmed) return null;
-        const piPattern = /^([+-]?\d*(?:\.\d+)?)?\*?pi(?:\/(\d+(?:\.\d+)?))?$/;
-        const match = trimmed.match(piPattern);
-        if (!match) return null;
+        const coeffBeforePi = trimmed.match(/^([+-]?\d*(?:\.\d+)?)?\*?pi(?:\/([+-]?\d+(?:\.\d+)?))?$/);
+        if (coeffBeforePi) {
+            let coeffRaw = coeffBeforePi[1];
+            let coeff;
+            if (coeffRaw === undefined || coeffRaw === '') coeff = 1;
+            else if (coeffRaw === '+') coeff = 1;
+            else if (coeffRaw === '-') coeff = -1;
+            else coeff = Number(coeffRaw);
 
-        let coeffRaw = match[1];
-        let coeff;
-        if (coeffRaw === undefined || coeffRaw === '') coeff = 1;
-        else if (coeffRaw === '+') coeff = 1;
-        else if (coeffRaw === '-') coeff = -1;
-        else coeff = Number(coeffRaw);
+            const denom = coeffBeforePi[2] ? Number(coeffBeforePi[2]) : 1;
+            if (!Number.isFinite(coeff) || !Number.isFinite(denom) || denom === 0) return null;
+            return coeff * Math.PI / denom;
+        }
 
-        const denom = match[2] ? Number(match[2]) : 1;
-        if (!Number.isFinite(coeff) || !Number.isFinite(denom) || denom === 0) return null;
-        return coeff * Math.PI / denom;
+        const fractionBeforePi = trimmed.match(/^([+-]?\d+(?:\.\d+)?)\/([+-]?\d+(?:\.\d+)?)\*?pi$/);
+        if (fractionBeforePi) {
+            const numerator = Number(fractionBeforePi[1]);
+            const denominator = Number(fractionBeforePi[2]);
+            if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator === 0) return null;
+            return (numerator / denominator) * Math.PI;
+        }
+
+        return null;
     }
 
     function showInvalidNumberFeedback(message = 'Enter a decimal number only (not π notation).') {
@@ -3316,7 +3393,7 @@
                 userVal = parsePiRadiansExpression(input.value);
             }
             if (userVal === null) {
-                showInvalidNumberFeedback('Enter a decimal or simple π expression (e.g., pi, 2pi/3, -5pi/6).');
+                showInvalidNumberFeedback('Enter a decimal or simple pi notation such as pi, 2pi/3, or -5pi/6.');
                 return;
             }
             const tol = currentQuestion.tol ?? 0.01;


### PR DESCRIPTION
### Motivation
- Clarify input expectations for numeric answers and log arguments by adding explicit labels and helper copy. 
- Improve usability for radian/coterminal entry by allowing common π notation and a quick π insert button. 
- Make parsing of π-based expressions more robust so common user formats are accepted and converted to numeric radians.

### Description
- Added an `.answer-label` and inline label markup before single-answer inputs and the `log_argument` input to indicate `Answer (decimal only)`. 
- Introduced a dedicated UI for `coterminal_rad` input consisting of a text input, a `π` insert button, and an `.answer-helper` hint, plus related styles (`.coterminal-rad-row`, `.pi-insert-btn`). 
- Wired an event listener to the `π` button to insert the literal `pi` at the caret position in the input. 
- Reworked `parsePiRadiansExpression` to accept both coefficient-before-`pi` forms (e.g. `2pi/3`, `-pi/6`) and fraction-before-`pi` forms (e.g. `3/2pi`), normalizing `π` to `pi` and returning a numeric radian value. 
- Updated coterminal-radian validation messaging to recommend accepted `pi` notations and updated the default single-answer input markup to include the label.

### Testing
- No automated tests were run as part of this change; changes are limited to front-end HTML/CSS/JS and require interactive/manual validation in the browser.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d002030af883319f43a0b0e131e9fa)