### PR TITLE
Fix 404 page navigation links with absolute paths

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,28 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found - Prof. Volk's Office</title>
     <link rel="stylesheet" href="/styles.css">
-    <script src="theme.js"></script>
+    <script src="/theme.js"></script>
 </head>
 <body>
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
-      <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+      <a class="top-nav-title" href="/index.html">Prof. Volk's Office</a>
     </div>
     <div class="top-nav-actions">
       <ul class="top-nav-links">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="CV.html">About</a></li>
+        <li><a href="/index.html">Home</a></li>
+        <li><a href="/CV.html">About</a></li>
         <li class="dropdown">
           <button class="dropdown-trigger" type="button" aria-haspopup="true">Courses ▾</button>
           <ul class="dropdown-menu">
-            <li><a href="learn.html">All Courses</a></li>
-            <li><a href="courses/math114.html">MATH 114</a></li>
-            <li><a href="courses/math130.html">MATH 130</a></li>
-            <li><a href="courses/physics-labs.html">Physics Labs</a></li>
+            <li><a href="/learn.html">All Courses</a></li>
+            <li><a href="/courses/math114.html">MATH 114</a></li>
+            <li><a href="/courses/math130.html">MATH 130</a></li>
+            <li><a href="/courses/physics-labs.html">Physics Labs</a></li>
           </ul>
         </li>
-        <li><a href="projects.html">Tools</a></li>
+        <li><a href="/projects.html">Tools</a></li>
       </ul>
       <ul class="top-nav-utilities" aria-label="More">
         <li class="dropdown">


### PR DESCRIPTION
### Motivation
- The 404 page used relative internal links and a relative theme script include which break when GitHub Pages serves the 404 from a nested request path, making the nav and theme JS nonfunctional.

### Description
- Updated `404.html` to use root-absolute URLs for internal navigation links (Home, About, Courses entries, Tools) and changed the theme script include from `theme.js` to `/theme.js` so resources load correctly from any path.

### Testing
- Ran `rg` against `404.html` to verify no remaining relative `href` or `src` references (the check returned no matches), confirming the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4652a96488331b22a7fb8064399d3)