### PR TITLE
Update Module 11 resources: add links and rename Slides header

### DIFF
--- a/courses/math114-statistics.html
+++ b/courses/math114-statistics.html
@@ -251,8 +251,18 @@
           </div>
           <div class="unit-resource-grid">
             <article class="unit-resource-card">
-              <h3>Slides</h3>
-              <p>Slides will be posted as available.</p>
+              <h3>Slides and Resources</h3>
+              <ul>
+                <li>
+                  <a href="knowledgegrowth.html">Knowledge Growth Review</a>
+                </li>
+                <li>
+                  <a href="../growth.html">Growth Models Quiz Prep</a>
+                </li>
+                <li>
+                  <a href="../chessboard.html">Chessboard Rice Growth</a>
+                </li>
+              </ul>
             </article>
             <article class="unit-resource-card">
               <h3>Videos</h3>


### PR DESCRIPTION
### Motivation
- Replace the placeholder slides note in the Module 11 resources card with direct links to review materials so students can access relevant review pages (`knowledgegrowth.html`, `../growth.html`, `../chessboard.html`).

### Description
- Rename the Module 11 resources card header to "Slides and Resources" and replace the paragraph with an unordered list containing links to `knowledgegrowth.html`, `../growth.html`, and `../chessboard.html`.

### Testing
- No automated tests were run for this content-only HTML update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4f49937188331b000ee06d8b71912)