### PR TITLE
Move Quiz 9 to 4/10 and update schedule rows in 130Test3.html

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -1426,16 +1426,16 @@
 </tr>
 <tr data-date="2026-04-08">
 <td>Wed, 4/8</td>
-<td>Quiz 9 &amp; Section 5.2</td>
+<td>Section 5.3</td>
+<td><span class="badge badge-class">CLASS</span></td>
+</tr>
+<tr data-date="2026-04-10">
+<td>Fri, 4/10</td>
+<td>Quiz 9 &amp; Section 5.3</td>
 <td>
 <span class="badge badge-class">CLASS</span>
 <span class="badge badge-quiz">QUIZ</span>
 </td>
-</tr>
-<tr data-date="2026-04-10">
-<td>Fri, 4/10</td>
-<td>Section 5.3</td>
-<td><span class="badge badge-class">CLASS</span></td>
 </tr>
 <tr data-date="2026-04-13">
 <td>Mon, 4/13</td>


### PR DESCRIPTION
### Motivation
- Fix the course schedule to move Quiz 9 from Wed 4/8 to Fri 4/10 and eliminate the duplicated "Section 5.3" entry so the dates and topics align correctly.

### Description
- Update `130Test3.html` by changing the `2026-04-08` row to show `Section 5.3` and replacing the `2026-04-10` row with `Quiz 9 & Section 5.3` including both `CLASS` and `QUIZ` badges, and removing the old duplicate `Section 5.3` row.

### Testing
- No automated tests were run for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a4845d488331aa49060c43c7cd3e)