### PR TITLE
Add lecture slides links for Modules 6, 7, and 11

### DIFF
--- a/courses/math114-financial-math.html
+++ b/courses/math114-financial-math.html
@@ -187,7 +187,11 @@
           <div class="unit-resource-grid">
             <article class="unit-resource-card">
               <h3>Slides</h3>
-              <p>Slides will be posted as available.</p>
+              <ul>
+                <li>
+                  <a href="../pdfs/114Module6Slides.pdf">Lecture slides</a>
+                </li>
+              </ul>
             </article>
             <article class="unit-resource-card">
               <h3>Videos</h3>
@@ -238,7 +242,11 @@
           <div class="unit-resource-grid">
             <article class="unit-resource-card">
               <h3>Slides</h3>
-              <p>Slides will be posted as available.</p>
+              <ul>
+                <li>
+                  <a href="../pdfs/114Module7Slides.pdf">Lecture slides</a>
+                </li>
+              </ul>
             </article>
             <article class="unit-resource-card">
               <h3>Videos</h3>

--- a/courses/math114-statistics.html
+++ b/courses/math114-statistics.html
@@ -254,6 +254,9 @@
               <h3>Slides and Resources</h3>
               <ul>
                 <li>
+                  <a href="../pdfs/114Module11Slides.pdf">Lecture slides</a>
+                </li>
+                <li>
                   <a href="knowledgegrowth.html">Knowledge Growth Review</a>
                 </li>
                 <li>


### PR DESCRIPTION
### Motivation
- Provide direct access to lecture slide PDFs from the unit pages so students can quickly find module materials.

### Description
- Replace the placeholder `Slides will be posted as available.` in `courses/math114-financial-math.html` for Module 6 and Module 7 with unordered lists linking to `../pdfs/114Module6Slides.pdf` and `../pdfs/114Module7Slides.pdf` respectively.
- Add a link to `../pdfs/114Module11Slides.pdf` in the "Slides and Resources" list in `courses/math114-statistics.html`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d6366058833185e927123d0e6aaa)