### PR TITLE
Add module slide labels to Unit 3 schedule in 130Test3.html

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -1411,12 +1411,12 @@
 <tbody id="schedule-body">
 <tr data-date="2026-04-01">
 <td>Wed, 4/1</td>
-<td>Section 5.1</td>
+<td>Section 5.1 (Module 10 Slides)</td>
 <td><span class="badge badge-class">CLASS</span></td>
 </tr>
 <tr data-date="2026-04-03">
 <td>Fri, 4/3</td>
-<td>Section 5.2</td>
+<td>Section 5.2 (Module 10 Slides)</td>
 <td><span class="badge badge-class">CLASS</span></td>
 </tr>
 <tr data-date="2026-04-06">
@@ -1426,12 +1426,12 @@
 </tr>
 <tr data-date="2026-04-08">
 <td>Wed, 4/8</td>
-<td>Section 5.3</td>
+<td>Section 5.3 (Module 11 Slides)</td>
 <td><span class="badge badge-class">CLASS</span></td>
 </tr>
 <tr data-date="2026-04-10">
 <td>Fri, 4/10</td>
-<td>Quiz 9 &amp; Section 5.3</td>
+<td>Quiz 9 &amp; Section 5.3 (Module 11 Slides)</td>
 <td>
 <span class="badge badge-class">CLASS</span>
 <span class="badge badge-quiz">QUIZ</span>
@@ -1439,12 +1439,12 @@
 </tr>
 <tr data-date="2026-04-13">
 <td>Mon, 4/13</td>
-<td>Section 5.3</td>
+<td>Section 5.3 (Module 11 Slides)</td>
 <td><span class="badge badge-class">CLASS</span></td>
 </tr>
 <tr data-date="2026-04-15">
 <td>Wed, 4/15</td>
-<td>Quiz 10 &amp; Sections 5.2–7.1</td>
+<td>Quiz 10 &amp; Sections 5.2–7.1 (Module 12 Slides)</td>
 <td>
 <span class="badge badge-class">CLASS</span>
 <span class="badge badge-quiz">QUIZ</span>
@@ -1452,17 +1452,17 @@
 </tr>
 <tr data-date="2026-04-17">
 <td>Fri, 4/17</td>
-<td>Section 7.1</td>
+<td>Section 7.1 (Module 12 Slides)</td>
 <td><span class="badge badge-class">CLASS</span></td>
 </tr>
 <tr data-date="2026-04-20">
 <td>Mon, 4/20</td>
-<td>Section 7.1</td>
+<td>Section 7.1 (Module 12 Slides)</td>
 <td><span class="badge badge-class">CLASS</span></td>
 </tr>
 <tr data-date="2026-04-22">
 <td>Wed, 4/22</td>
-<td>Quiz 11 &amp; Section 8.4</td>
+<td>Quiz 11 &amp; Section 8.4 (Module 13 Slides)</td>
 <td>
 <span class="badge badge-class">CLASS</span>
 <span class="badge badge-quiz">QUIZ</span>
@@ -1470,17 +1470,17 @@
 </tr>
 <tr data-date="2026-04-24">
 <td>Fri, 4/24</td>
-<td>Section 8.4</td>
+<td>Section 8.4 (Module 13 Slides)</td>
 <td><span class="badge badge-class">CLASS</span></td>
 </tr>
 <tr data-date="2026-04-27">
 <td>Mon, 4/27</td>
-<td>Section 8.4, applications</td>
+<td>Section 8.4, applications (Module 13 Slides)</td>
 <td><span class="badge badge-class">CLASS</span></td>
 </tr>
 <tr data-date="2026-04-29">
 <td>Wed, 4/29</td>
-<td>Quiz 12 &amp; Review</td>
+<td>Quiz 12 &amp; Review (Unit 3 Wrap-Up Slides)</td>
 <td>
 <span class="badge badge-retry">REVIEW</span>
 <span class="badge badge-quiz">QUIZ</span>
@@ -1493,7 +1493,7 @@
 </tr>
 <tr data-date="2026-05-04">
 <td>Mon, 5/4</td>
-<td>Quiz 13 &amp; Review</td>
+<td>Quiz 13 &amp; Review (Unit 3 Wrap-Up Slides)</td>
 <td>
 <span class="badge badge-retry">REVIEW</span>
 <span class="badge badge-quiz">QUIZ</span>


### PR DESCRIPTION
### Motivation
- Make it explicit which slide deck corresponds to each instructional or review class day so instructors and students can quickly open the correct Module slides (e.g., Module 10 on Wed, 4/1 and Fri, 4/3). 
- Improve clarity of the Unit 3 schedule without changing holiday, exam, or no-class entries.

### Description
- Updated the Course Schedule table in `130Test3.html` to append slide labels like `(Module 10 Slides)`, `(Module 11 Slides)`, `(Module 12 Slides)`, `(Module 13 Slides)`, and `(Unit 3 Wrap-Up Slides)` to the Topic/Section cells for the corresponding dates. 
- Applied the label mapping across the Unit 3 range of dates so each class/review row references the appropriate module slide deck. 
- Preserved non-instruction rows such as holidays, the Test 3 entry, reading day, and the final exam unchanged.

### Testing
- Inspected the updated schedule block with `sed -n '1408,1504p' 130Test3.html` and confirmed the new slide labels appear on the expected rows. 
- Verified line-level changes with `nl -ba 130Test3.html | sed -n '1410,1510p'` to ensure the replacements are present and correctly formatted. 
- Ran a content search (`rg -n "Module|slides|Wed|Fri" 130Test3.html`) and other quick checks which completed successfully to validate the update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3779f5c48331874a81dbcc7743a3)