### PR TITLE
Add Test 3 formulas link to MATH 114 Module 12 Test 3 page

### DIFF
--- a/courses/math114-test3.html
+++ b/courses/math114-test3.html
@@ -144,6 +144,9 @@
             <h3>Tools</h3>
             <ul>
               <li>
+                <a href="test3-formulas.html">Test 3 Formulas</a>
+              </li>
+              <li>
                 <a href="https://www.desmos.com/scientific"
                   >Desmos Scientific Calculator</a
                 >


### PR DESCRIPTION
## Summary
- Added a **Test 3 Formulas** link to the Tools section on `courses/math114-test3.html`
- Link points to `courses/test3-formulas.html` so students can quickly access formulas from the Module 12 / Test 3 review page

## Why
Students requested that Test 3 formulas be listed directly on the MATH 114 Test 3 page for easier access during review.

## Files changed
- `courses/math114-test3.html`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4553598c83319ce4866b46cc6e9d)