### PR TITLE
Add Module 12 practice test link to MATH 114 Module 12 page

### DIFF
--- a/courses/math114-test3.html
+++ b/courses/math114-test3.html
@@ -133,6 +133,14 @@
         </div>
         <div class="unit-resource-grid">
           <article class="unit-resource-card">
+            <h3>Slides and such</h3>
+            <ul>
+              <li>
+                <a href="Module12_Practice_Test.html">Module 12 Practice Test</a>
+              </li>
+            </ul>
+          </article>
+          <article class="unit-resource-card">
             <h3>Videos</h3>
             <ul>
               <li>


### PR DESCRIPTION
### Motivation
- Provide direct access to the Module 12 practice test from the Module 12 (Test 3 Review) resources area so students can find practice materials more quickly.

### Description
- Inserted a new resource card with the heading `Slides and such` that links to `Module12_Practice_Test.html` in `courses/math114-test3.html` inside the existing `.unit-resource-grid`.
- The update is confined to `courses/math114-test3.html` and adds the new list item without altering other content or layout.

### Testing
- Ran `git status --short` to confirm the file change was detected and staged successfully.
- Ran `git show --stat --oneline HEAD` to confirm the commit (`f6daf2d`) contains the expected diff and 8 insertions.
- Inspected `courses/math114-test3.html` with `nl`/`sed` to verify the new `Module12_Practice_Test.html` link appears in the markup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e235900da4833199317ea4e150f2af)