### PR TITLE
Fix bugs, contrast issues, and unclear solutions in 130Test3 practice generators

### DIFF
--- a/130Test3.html
+++ b/130Test3.html
@@ -430,7 +430,7 @@
         /* Feedback */
         .feedback { margin-top: 1.5rem; padding: 1.25rem; border-radius: 12px; font-weight: 500; display: none; animation: fadeIn 0.3s ease; text-align: left; }
         @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
-        .feedback.correct { display: block; background: var(--emerald-soft); color: var(--emerald-main); border: 1px solid var(--emerald-main); text-align: center; }
+        .feedback.correct { display: block; background: var(--emerald-soft); color: var(--text-main); border: 1px solid var(--emerald-main); text-align: center; }
         .feedback.incorrect { display: block; background: var(--bg-surface); color: var(--text-main); border: 1px solid var(--danger-main); border-left: 6px solid var(--danger-main); }
         .solution-step { margin-top: 1rem; padding-top: 1rem; border-top: 1px dashed var(--border-subtle); color: var(--text-muted); font-size: 1.05rem; }
 
@@ -459,7 +459,7 @@
         .tab-content.active { display: block; animation: fadeIn 0.4s ease; }
 
         /* Schedule date states */
-        .schedule-past td { opacity: 0.4; }
+        .schedule-past td { opacity: 0.55; }
         .schedule-past td .badge { opacity: 0.6; }
         .schedule-today { background: var(--accent-glow) !important; border-left: 4px solid var(--primary-main); }
         .schedule-next { background: var(--bg-surface); }
@@ -1942,17 +1942,17 @@
                         <polygon points="0 0, 9 4.5, 0 9" fill="var(--danger-main)"></polygon>
                     </marker>
                 </defs>
-                <rect x="0" y="0" width="${size}" height="${size}" fill="var(--text-main)"></rect>
-                <g stroke="var(--text-main)" stroke-width="1">
+                <rect x="0" y="0" width="${size}" height="${size}" fill="var(--diagram-bg)"></rect>
+                <g stroke="var(--diagram-grid)" stroke-width="1">
                     ${Array.from({ length: 15 }, (_, i) => `<line x1="${i * 20 + 10}" y1="10" x2="${i * 20 + 10}" y2="290"></line>`).join('')}
                     ${Array.from({ length: 15 }, (_, i) => `<line x1="10" y1="${i * 20 + 10}" x2="290" y2="${i * 20 + 10}"></line>`).join('')}
                 </g>
-                <line x1="10" y1="${center}" x2="290" y2="${center}" stroke="var(--border-subtle)" stroke-width="2"></line>
-                <line x1="${center}" y1="10" x2="${center}" y2="290" stroke="var(--border-subtle)" stroke-width="2"></line>
-                <text x="293" y="${center - 5}" fill="var(--border-subtle)" font-size="12">x</text>
-                <text x="${center + 6}" y="16" fill="var(--border-subtle)" font-size="12">y</text>
+                <line x1="10" y1="${center}" x2="290" y2="${center}" stroke="var(--diagram-axis)" stroke-width="2"></line>
+                <line x1="${center}" y1="10" x2="${center}" y2="290" stroke="var(--diagram-axis)" stroke-width="2"></line>
+                <text x="293" y="${center - 5}" fill="var(--diagram-axis-label)" font-size="12">x</text>
+                <text x="${center + 6}" y="16" fill="var(--diagram-axis-label)" font-size="12">y</text>
                 <line x1="${center}" y1="${center}" x2="${endX.toFixed(2)}" y2="${endY.toFixed(2)}" stroke="var(--danger-main)" stroke-width="3" marker-end="url(#vec-arrow)"></line>
-                <circle cx="${center}" cy="${center}" r="4" fill="var(--border-subtle)"></circle>
+                <circle cx="${center}" cy="${center}" r="4" fill="var(--diagram-origin)"></circle>
                 <circle cx="${endX.toFixed(2)}" cy="${endY.toFixed(2)}" r="4" fill="var(--emerald-main)"></circle>
                 <text x="${Math.min(258, endX + 8).toFixed(2)}" y="${Math.max(18, endY - 8).toFixed(2)}" fill="var(--emerald-main)" font-size="13">(${x}, ${y})</text>
                 <text x="36" y="286" fill="var(--text-muted)" font-size="12">scale: 1 unit per grid line</text>
@@ -1968,7 +1968,8 @@
             generate: () => {
                 const theta = (Math.floor(Math.random() * 25) + 1) * 15 * (Math.random() > 0.5 ? 1 : -1);
                 const k = Math.floor(Math.random() * 3) + 1;
-                const ans = theta + 360 * (Math.random() > 0.5 ? k : -k);
+                const signedK = Math.random() > 0.5 ? k : -k;
+                const ans = theta + 360 * signedK;
                 const normalizedTheta = normalizeDegrees(theta);
                 const turnCount = Math.round((theta - normalizedTheta) / 360);
                 const directionWord = theta >= 0 ? 'counterclockwise' : 'clockwise';
@@ -1985,7 +1986,7 @@
                     }),
                     svgAltText: fallbackText,
                     inputType: 'coterminal_deg', baseTheta: theta, tol: 0.1,
-                    solution: `Coterminal angles differ by multiples of $360^\\circ$, so infinitely many answers are valid. One sample valid answer is $${theta} ${ans > theta ? '+' : '-'} ${Math.abs(ans - theta)} = ${ans}^\\circ$.`
+                    solution: `Coterminal angles differ by multiples of $360^\\circ$, so infinitely many answers are valid. Use $\\theta \\pm 360k$ for any integer $k$. One sample valid answer: $${theta} ${signedK > 0 ? '+' : '-'} ${Math.abs(signedK)} \\cdot 360 = ${ans}^\\circ$.`
                 };
             }
         },
@@ -2127,13 +2128,41 @@
             generate: () => {
                 const angle = [25, 30, 35, 40, 45, 50, 60][Math.floor(Math.random() * 7)];
                 const known = Math.floor(Math.random() * 14) + 6;
-                const type = Math.random() > 0.5 ? 'opp' : 'adj';
-                const ans = type === 'opp' ? known * Math.tan(angle * Math.PI / 180) : known / Math.tan(angle * Math.PI / 180);
-                return {
-                    q: type === 'opp' ? `A right triangle has angle $${angle}^\\circ$ and adjacent side $${known}$. Find the opposite side. (Round to 2 decimals)` : `A right triangle has angle $${angle}^\\circ$ and opposite side $${known}$. Find the adjacent side. (Round to 2 decimals)`,
-                    inputType: 'number', a: ans, tol: 0.05,
-                    solution: type === 'opp' ? `$\\tan(${angle}^\\circ)=\\frac{x}{${known}}\\Rightarrow x=${known}\\tan(${angle}^\\circ)=${ans.toFixed(2)}$.` : `$\\tan(${angle}^\\circ)=\\frac{${known}}{x}\\Rightarrow x=\\frac{${known}}{\\tan(${angle}^\\circ)}=${ans.toFixed(2)}$.`
-                };
+                const caseType = ['sinOpp', 'cosAdj', 'tanOpp', 'tanAdj', 'sinHyp', 'cosHyp'][Math.floor(Math.random() * 6)];
+                const angleRad = angle * Math.PI / 180;
+                let q, ans, solution;
+                if (caseType === 'sinOpp') {
+                    // given hyp, find opp: opp = hyp * sin
+                    ans = known * Math.sin(angleRad);
+                    q = `A right triangle has angle $${angle}^\\circ$ and hypotenuse $${known}$. Find the opposite side. (Round to 2 decimals)`;
+                    solution = `$\\sin(${angle}^\\circ)=\\frac{x}{${known}}\\Rightarrow x=${known}\\sin(${angle}^\\circ)=${ans.toFixed(2)}$.`;
+                } else if (caseType === 'cosAdj') {
+                    // given hyp, find adj: adj = hyp * cos
+                    ans = known * Math.cos(angleRad);
+                    q = `A right triangle has angle $${angle}^\\circ$ and hypotenuse $${known}$. Find the adjacent side. (Round to 2 decimals)`;
+                    solution = `$\\cos(${angle}^\\circ)=\\frac{x}{${known}}\\Rightarrow x=${known}\\cos(${angle}^\\circ)=${ans.toFixed(2)}$.`;
+                } else if (caseType === 'tanOpp') {
+                    // given adj, find opp: opp = adj * tan
+                    ans = known * Math.tan(angleRad);
+                    q = `A right triangle has angle $${angle}^\\circ$ and adjacent side $${known}$. Find the opposite side. (Round to 2 decimals)`;
+                    solution = `$\\tan(${angle}^\\circ)=\\frac{x}{${known}}\\Rightarrow x=${known}\\tan(${angle}^\\circ)=${ans.toFixed(2)}$.`;
+                } else if (caseType === 'tanAdj') {
+                    // given opp, find adj: adj = opp / tan
+                    ans = known / Math.tan(angleRad);
+                    q = `A right triangle has angle $${angle}^\\circ$ and opposite side $${known}$. Find the adjacent side. (Round to 2 decimals)`;
+                    solution = `$\\tan(${angle}^\\circ)=\\frac{${known}}{x}\\Rightarrow x=\\frac{${known}}{\\tan(${angle}^\\circ)}=${ans.toFixed(2)}$.`;
+                } else if (caseType === 'sinHyp') {
+                    // given opp, find hyp: hyp = opp / sin
+                    ans = known / Math.sin(angleRad);
+                    q = `A right triangle has angle $${angle}^\\circ$ and opposite side $${known}$. Find the hypotenuse. (Round to 2 decimals)`;
+                    solution = `$\\sin(${angle}^\\circ)=\\frac{${known}}{x}\\Rightarrow x=\\frac{${known}}{\\sin(${angle}^\\circ)}=${ans.toFixed(2)}$.`;
+                } else {
+                    // given adj, find hyp: hyp = adj / cos
+                    ans = known / Math.cos(angleRad);
+                    q = `A right triangle has angle $${angle}^\\circ$ and adjacent side $${known}$. Find the hypotenuse. (Round to 2 decimals)`;
+                    solution = `$\\cos(${angle}^\\circ)=\\frac{${known}}{x}\\Rightarrow x=\\frac{${known}}{\\cos(${angle}^\\circ)}=${ans.toFixed(2)}$.`;
+                }
+                return { q, inputType: 'number', a: ans, tol: 0.05, solution };
             }
         },
         {
@@ -2321,7 +2350,7 @@
                 const t = Math.floor(Math.random()*4)+2;
                 const ans = speed * t * Math.sin(angle*Math.PI/180);
                 return {
-                    q: `A plane travels ${speed} miles/hour for ${t} hours at an angle of elevation of ${angle}^\\circ$. Approximate the vertical rise. (Round to 1 decimal)`,
+                    q: `A plane travels ${speed} miles/hour for ${t} hours at an angle of elevation of $${angle}^\\circ$. Approximate the vertical rise. (Round to 1 decimal)`,
                     inputType: 'number', a: ans, tol: 0.2,
                     solution: `Distance traveled is $d=rt=${speed}(${t})=${speed*t}$. Vertical rise $=d\\sin(${angle}^\\circ)=${ans.toFixed(1)}$.`
                 };
@@ -2346,15 +2375,15 @@
                                 <polygon points="0 0, 9 4.5, 0 9" fill="var(--danger-main)"></polygon>
                             </marker>
                         </defs>
-                        <rect x="0" y="0" width="300" height="300" fill="var(--text-main)"></rect>
-                        <g stroke="var(--text-main)" stroke-width="1">
+                        <rect x="0" y="0" width="300" height="300" fill="var(--diagram-bg)"></rect>
+                        <g stroke="var(--diagram-grid)" stroke-width="1">
                             ${Array.from({ length: 15 }, (_, i) => `<line x1="${i * 20 + 10}" y1="10" x2="${i * 20 + 10}" y2="290"></line>`).join('')}
                             ${Array.from({ length: 15 }, (_, i) => `<line x1="10" y1="${i * 20 + 10}" x2="290" y2="${i * 20 + 10}"></line>`).join('')}
                         </g>
-                        <line x1="10" y1="150" x2="290" y2="150" stroke="var(--border-subtle)" stroke-width="2"></line>
-                        <line x1="150" y1="10" x2="150" y2="290" stroke="var(--border-subtle)" stroke-width="2"></line>
-                        <text x="293" y="145" fill="var(--border-subtle)" font-size="12">x</text>
-                        <text x="156" y="16" fill="var(--border-subtle)" font-size="12">y</text>
+                        <line x1="10" y1="150" x2="290" y2="150" stroke="var(--diagram-axis)" stroke-width="2"></line>
+                        <line x1="150" y1="10" x2="150" y2="290" stroke="var(--diagram-axis)" stroke-width="2"></line>
+                        <text x="293" y="145" fill="var(--diagram-axis-label)" font-size="12">x</text>
+                        <text x="156" y="16" fill="var(--diagram-axis-label)" font-size="12">y</text>
                         <line x1="${150 + x1 * 20}" y1="${150 - y1 * 20}" x2="${150 + x2 * 20}" y2="${150 - y2 * 20}" stroke="var(--danger-main)" stroke-width="3" marker-end="url(#arrowhead-pq)"></line>
                         <circle cx="${150 + x1 * 20}" cy="${150 - y1 * 20}" r="4" fill="var(--primary-hover)"></circle>
                         <circle cx="${150 + x2 * 20}" cy="${150 - y2 * 20}" r="4" fill="var(--emerald-main)"></circle>
@@ -2416,7 +2445,7 @@
                     inputType: 'vector_mag_dir',
                     a: { mag: magnitude, dir: direction },
                     tol: { mag: 0.005, dir: 0.15 },
-                    solution: `Magnitude: $\sqrt{(${a})^2 + (${b})^2} = ${magnitude.toFixed(3)}$. Direction: use $\\theta = \\operatorname{atan2}(${b}, ${a}) = ${direction.toFixed(1)}^\\circ$.`
+                    solution: `Magnitude: $\\sqrt{(${a})^2 + (${b})^2} = ${magnitude.toFixed(3)}$. Direction: use $\\theta = \\operatorname{atan2}(${b}, ${a}) = ${direction.toFixed(1)}^\\circ$.`
                 };
             }
         },
@@ -2431,7 +2460,7 @@
                 return {
                     q: `Find the magnitude of vector $\\langle ${a}, ${b}\\rangle$. (Round to 3 decimals)`,
                     inputType: 'number', a: ans, tol: 0.005,
-                    solution: `$|\\vec v|=\sqrt{a^2+b^2}=\sqrt{(${a})^2+(${b})^2}=${ans.toFixed(3)}$.`
+                    solution: `$|\\vec v|=\\sqrt{a^2+b^2}=\\sqrt{(${a})^2+(${b})^2}=${ans.toFixed(3)}$.`
                 };
             }
         },
@@ -2448,7 +2477,11 @@
                 return {
                     q: `Find the direction angle (between $0^\\circ$ and $360^\\circ$) of vector $\\langle ${a}, ${b}\\rangle$. Round to 1 decimal.`,
                     inputType: 'number', a: ans, tol: 0.15,
-                    solution: `Use $\\theta=\\tan^{-1}(b/a)$ and adjust for quadrant. Final direction angle: ${ans.toFixed(1)}^\\circ$.`
+                    solution: (() => {
+                        const rawDeg = Math.atan2(b, a) * 180 / Math.PI;
+                        const needsAdjust = rawDeg < 0;
+                        return `Use $\\operatorname{atan2}(${b},\\,${a}) = ${rawDeg.toFixed(1)}^\\circ$${needsAdjust ? `. Since the result is negative, add $360^\\circ$: $${rawDeg.toFixed(1)} + 360 = ${ans.toFixed(1)}^\\circ$` : `. This is already in $[0^\\circ,360^\\circ)$, so the direction angle is $${ans.toFixed(1)}^\\circ$`}.`;
+                    })()
                 };
             }
         }
@@ -2466,7 +2499,7 @@
                 return {
                     q: `For an acute angle $\\theta$ in a right triangle, suppose $\\${knownType}\\theta=${known.toFixed(4)}$. Find $\\${targetType}\\theta$. (Round to 4 decimals)`,
                     inputType: 'number', a: ans, tol: 0.002,
-                    solution: `Use a compatible right-triangle ratio and the Pythagorean relationship. The corresponding value is $\\${targetType}\\theta=${ans.toFixed(4)}$.`
+                    solution: `Identify the sides: $\\${knownType}\\theta = ${known.toFixed(4)}$ matches a triangle with ${knownType === 'cos' ? `adj = ${t.adj}, hyp = ${t.hyp}` : `opp = ${t.opp}, hyp = ${t.hyp}`}. The missing side is ${knownType === 'cos' ? `opp = ${t.opp}` : `adj = ${t.adj}`} (Pythagorean triple). Then $\\${targetType}\\theta = ${targetType === 'tan' ? `\\frac{opp}{adj} = \\frac{${t.opp}}{${t.adj}}` : `\\frac{adj}{hyp} = \\frac{${t.adj}}{${t.hyp}}`} = ${ans.toFixed(4)}$.`
                 };
             }
         },
@@ -2482,9 +2515,9 @@
                 ];
                 const p = opts[Math.floor(Math.random()*opts.length)];
                 return {
-                    q: `Solve $\\${p.func}\\theta=${p.val.toFixed(4)}$ for $0^\\circ \\le \\theta < 360^\\circ$. Enter the smaller angle in x and larger angle in y.`,
-                    inputType: 'vector_xy', a: { x: p.a1, y: p.a2 }, tol: { x: 0.1, y: 0.1 },
-                    solution: `Using special-angle unit-circle values, the two solutions in one rotation are $${p.a1}^\\circ$ and $${p.a2}^\\circ$.`
+                    q: `Solve $\\${p.func}\\theta=${p.val.toFixed(4)}$ for $0^\\circ \\le \\theta < 360^\\circ$. Enter both solutions below.`,
+                    inputType: 'two_angle_solutions', a: { x: p.a1, y: p.a2 }, tol: { x: 0.1, y: 0.1 },
+                    solution: `Step 1: Find the reference angle using $\\${p.func}^{-1}(${p.val.toFixed(4)}) = ${p.a1}^\\circ$. Step 2: $\\${p.func}$ is positive in Q${p.func === 'sin' ? 'I and QII' : 'I and QIV'}, so the two solutions are $${p.a1}^\\circ$ and $${p.a2}^\\circ$.`
                 };
             }
         },
@@ -2548,7 +2581,7 @@
                 return {
                     q: `Vectors $\\vec u$ and $\\vec v$ have magnitudes/directions (${r1}, ${t1}^\\circ) and (${r2}, ${t2}^\\circ). Find the resultant magnitude and direction.`,
                     inputType: 'vector_mag_dir', a: {mag, dir}, tol: {mag: 0.02, dir: 0.2},
-                    solution: `Convert each to components, add components, then compute resultant magnitude/direction. Final: magnitude ${mag.toFixed(3)}, direction ${dir.toFixed(1)}^\\circ.`
+                    solution: `Convert: $\\vec u = \\langle ${r1}\\cos(${t1}^\\circ), ${r1}\\sin(${t1}^\\circ)\\rangle$, $\\vec v = \\langle ${r2}\\cos(${t2}^\\circ), ${r2}\\sin(${t2}^\\circ)\\rangle$. Sum: $\\langle ${x.toFixed(3)}, ${y.toFixed(3)}\\rangle$. Magnitude: $\\sqrt{${x.toFixed(3)}^2+${y.toFixed(3)}^2}=${mag.toFixed(3)}$. Direction: $\\operatorname{atan2}(${y.toFixed(3)},${x.toFixed(3)})=${dir.toFixed(1)}^\\circ$.`
                 };
             }
         },
@@ -3193,6 +3226,15 @@
                     <input type="number" step="any" id="inp-c4" placeholder="°">
                 </div>
             `;
+        } else if (currentQuestion.inputType === 'two_angle_solutions') {
+            inputArea.innerHTML = `
+                <div class="multi-input-grid">
+                    <span class="mig-label">Smaller angle (°) =</span>
+                    <input type="number" step="any" id="inp-vx" placeholder="°">
+                    <span class="mig-label">Larger angle (°) =</span>
+                    <input type="number" step="any" id="inp-vy" placeholder="°">
+                </div>
+            `;
         } else if (currentQuestion.inputType === 'vector_xy') {
             inputArea.innerHTML = `
                 <div class="multi-input-grid">
@@ -3421,7 +3463,7 @@
             document.getElementById('inp-vmag').classList.add(magOk ? 'inp-correct' : 'inp-wrong');
             document.getElementById('inp-vdir').classList.add(dirOk ? 'inp-correct' : 'inp-wrong');
             isCorrect = magOk && dirOk;
-        } else if (currentQuestion.inputType === 'vector_xy') {
+        } else if (currentQuestion.inputType === 'two_angle_solutions' || currentQuestion.inputType === 'vector_xy') {
             const ux = parseStrictNumber(document.getElementById('inp-vx').value);
             const uy = parseStrictNumber(document.getElementById('inp-vy').value);
             if (ux === null || uy === null) {

--- a/styles.css
+++ b/styles.css
@@ -153,7 +153,7 @@
   --diagram-arc: var(--emerald-main);
   --diagram-turn: var(--text-muted);
   --diagram-reference: var(--warning-main);
-  --diagram-origin: var(--border-subtle);
+  --diagram-origin: var(--primary-main);
   --excel-accent: var(--emerald-main);
   --nav-surface: linear-gradient(180deg, var(--nav-surface-start), var(--nav-surface-end));
   --nav-text: var(--text-main);
@@ -1955,7 +1955,7 @@ main.error-main {
   --diagram-arc: color-mix(in srgb, var(--emerald-main) 82%, white);
   --diagram-turn: var(--text-muted);
   --diagram-reference: color-mix(in srgb, var(--warning-main) 82%, white);
-  --diagram-origin: var(--border-subtle);
+  --diagram-origin: color-mix(in srgb, var(--primary-main) 82%, white);
   --excel-accent: #34d399;
 
   --hero-on-dark: #f8faf7;


### PR DESCRIPTION
- Fix SVG background: vector_components and createVectorSvg used --text-main
  as the rect fill and grid stroke, making the background opaque and the grid
  invisible; replaced with --diagram-bg / --diagram-grid / --diagram-axis /
  --diagram-axis-label / --diagram-origin throughout
- Fix KaTeX rendering: \sqrt in vector_magnitude and vector_mag_direction
  solutions was missing the double backslash (JS drops unrecognized escapes),
  so the sqrt symbol never rendered; fixed to \\sqrt
- Fix missing LaTeX delimiter in distance_rate_time question (lone $ → $$angle$$)
- Fix coterminal_deg solution: capture signedK so the ±360k example always
  matches the actual computed answer
- Differentiate duplicate generators: solve_right_triangle_side (7.1) now
  covers all six sin/cos/tan side-solving cases (including hypotenuse) instead
  of duplicating the tan-only 5.2 generator
- Improve solve_trig_equation_special UX: rename inputType to two_angle_solutions
  with labels "Smaller angle" / "Larger angle" instead of x/y vector labels;
  add rendering block and checkAnswer branch; expand solution to show reference
  angle + quadrant reasoning
- Improve vague solutions: trig_from_given_ratio now shows the Pythagorean
  triple sides; resultant_from_direction_vectors shows full component
  arithmetic; vector_direction solution shows atan2 result and 360° adjustment
- Contrast fixes: feedback.correct text changed from --emerald-main (~2.7:1)
  to --text-main; --diagram-origin changed from --border-subtle (1.3:1 on
  white) to --primary-main; schedule-past opacity raised from 0.4 to 0.55

https://claude.ai/code/session_01SaX8ykj8DTpjJDFxdcWF2b