### PR TITLE
Simplify duplicate half-life formula in Test 4 sheet

### DIFF
--- a/courses/test4-formulas.html
+++ b/courses/test4-formulas.html
@@ -181,8 +181,7 @@
                 <div class="ml-2">
                     <h3 class="text-base font-semibold mb-1">Exponential Decay (Half-Life)</h3>
                     <ul class="list-none ml-3">
-                        <li class="latex-formula">Formula (half-life $T_{half}$): $ Q = Q_0 \times (0.5)^{(t / T_{half})} $ <span class="latex-source">Q = Q_0 * (0.5)^(t / T_half)</span></li>
-                        <li class="latex-formula">Alternate form: $ Q = Q_0 \times \left(\frac{1}{2}\right)^{(t / T_{half})} $ <span class="latex-source">Q = Q_0 * (1/2)^(t / T_half)</span></li>
+                        <li class="latex-formula">Formula (half-life $T_{half}$): $ Q = Q_0 \times (0.5)^{(t / T_{half})} $ (equivalently $\left(\frac{1}{2}\right)^{(t / T_{half})}$) <span class="latex-source">Q = Q_0 * (0.5)^(t / T_half) (equivalently (1/2)^(t / T_half))</span></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
### Motivation
- Reduce redundancy in the Growth Models → Exponential Decay (Half-Life) section by keeping a single canonical half-life formula and optionally noting the equivalent form.

### Description
- Modified `courses/test4-formulas.html` to remove the duplicate alternate list item and replace both lines with a single list item showing `$ Q = Q_0 \times (0.5)^{(t / T_{half})} $` with an inline note `(equivalently (1/2)^{(t / T_{half})})`, and updated the `.latex-source` text accordingly.

### Testing
- Ran `git -C /workspace/andrewhvolk.github.io diff -- courses/test4-formulas.html`, committed with `git -C /workspace/andrewhvolk.github.io commit -m "Simplify half-life formula notation"`, and inspected the updated file with `nl -ba /workspace/andrewhvolk.github.io/courses/test4-formulas.html | sed -n '174,190p'`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fb7c3728833189831396139292e1)