### PR TITLE
Add dimensional analysis conversion note to Test 4 formula sheet

### DIFF
--- a/courses/test4-formulas.html
+++ b/courses/test4-formulas.html
@@ -170,6 +170,13 @@
                     </ul>
                 </div>
                 <div class="ml-2 mb-2">
+                    <h3 class="text-base font-semibold mb-1">Conversions</h3>
+                    <ul class="list-none ml-3 space-y-1">
+                        <li class="latex-formula">Dimensional analysis: Multiply by conversion factors so units cancel: $\text{result} = \text{given} \times \frac{\text{wanted unit}}{\text{current unit}}$. <span class="latex-source">result = given * (wanted unit/current unit)</span></li>
+                        <li>Quick examples: monthly $\to$ annual (×12), annual $\to$ monthly (÷12).</li>
+                    </ul>
+                </div>
+                <div class="ml-2 mb-2">
                     <h3 class="text-base font-semibold mb-1">Exponential Growth</h3>
                     <ul class="list-none ml-3 space-y-1">
                         <li class="latex-formula">Formula (rate 'r'): $ Q = Q_0 \times (1 + r)^t $ <span class="latex-source">Q = Q_0 * (1 + r)^t</span></li>


### PR DESCRIPTION
### Motivation
- Provide a very brief conversion reminder in the formula sheet so students have a compact rule-of-thumb for unit cancellation and simple monthly/annual conversions.

### Description
- Inserted a new `Conversions` subsection under Growth Models in `courses/test4-formulas.html` that shows the dimensional-analysis pattern using MathJax: `\text{result} = \text{given} \times \frac{\text{wanted unit}}{\text{current unit}}`.
- Added two tiny inline examples: `monthly → annual (×12)` and `annual → monthly (÷12)`.
- Formatting follows the page's existing `latex-formula`/`latex-source` conventions and is intentionally concise.

### Testing
- Verified the new HTML fragment appears in `courses/test4-formulas.html` by inspecting the file with `nl -ba ... | sed -n '172,178p'`, which showed the `Conversions` subsection as added.
- Executed the scripted in-place edit used to apply the change and confirmed the file was written with the expected MathJax-escaped content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fb7715ec8331bbb4c623c4fe9386)