### PR TITLE
Add FV-from-PMT annuity formula to Test 4 reference

### DIFF
--- a/courses/test4-formulas.html
+++ b/courses/test4-formulas.html
@@ -246,7 +246,11 @@
                             $$ PMT = \frac{PV \times \left(\frac{APR}{n}\right)}{\left[1 - \left(1 + \frac{APR}{n}\right)^{(-nY)}\right]} $$
                              <span class="latex-source">PMT = (PV * (APR/n)) / (1 - (1 + APR/n)^(-nY))</span>
                          </li>
-                         <li>PMT: Regular Payment, PV: Principal/Loan Amount, FV: Future Value</li>
+                         <li class="latex-formula">Future Value (FV) from regular payment (PMT):
+                            $$ FV = PMT \cdot \frac{\left(1+\frac{APR}{n}\right)^{nY}-1}{\frac{APR}{n}} $$
+                            <span class="latex-source">FV = PMT * (((1 + APR/n)^(nY)) - 1) / (APR/n)</span>
+                         </li>
+                         <li>PMT: Regular Payment, PV: Principal/Loan Amount, FV: Future Value, APR: Annual Percentage Rate (decimal), n: Payments/compounding periods per year, Y: Years</li>
                     </ul>
                 </div>
                  <div class="ml-2">


### PR DESCRIPTION
### Motivation
- Provide the missing ordinary-annuity formula for computing Future Value (FV) from a regular payment (PMT) in the Financial Formulas section so students have the direct FV-from-PMT expression available.
- Include a short variable reminder for `PMT`, `APR`, `n`, and `Y` and keep formatting consistent with the existing LaTeX entries.

### Description
- Added a new `latex-formula` list item with the expression `FV = PMT \cdot \frac{(1+\frac{APR}{n})^{nY}-1}{\frac{APR}{n}}` and a matching `latex-source` span to the Savings/Loan Payments (Ordinary Annuity) block in `courses/test4-formulas.html`.
- Expanded the existing variable reminder line in the same block to include `PMT`, `APR`, `n`, and `Y` while retaining `PV`/`FV` context.

### Testing
- No automated tests were run because this is a content-only HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fb6cce608331b2695d303fa1a7af)