### PR TITLE
Update Math 130 Test 4 page copy

### DIFF
--- a/130Test4.html
+++ b/130Test4.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<title>Math 130 – Final Exam Review</title>
+<title>Math 130 – Test 4 Review</title>
 
 <link rel="stylesheet" href="/styles.css">
 <script src="theme.js"></script>
@@ -461,37 +461,37 @@
       <span class="breadcrumb-sep" aria-hidden="true">›</span>
       <a href="courses/math130.html">MATH 130</a>
       <span class="breadcrumb-sep" aria-hidden="true">›</span>
-      <span class="breadcrumb-current" aria-current="page">Final Exam</span>
+      <span class="breadcrumb-current" aria-current="page">Math 130 Test 4</span>
     </nav>
   </div>
 </div>
 
 <header class="page-shell-header review-page-header">
   <div class="container">
-    <p class="page-shell-header__eyebrow">MATH 130 · Final Exam</p>
-    <h1>Final Exam Review</h1>
-    <p class="subtitle">Comprehensive review covering Quiz 13 vectors, key formulas, and all tested topics.</p>
+    <p class="page-shell-header__eyebrow">MATH 130 · Test 4</p>
+    <h1>Math 130 Test 4 Review</h1>
+    <p class="subtitle">Focused review and recreation practice for Math 130 Test 4 topics, formulas, and problem types.</p>
   </div>
 </header>
 
 <nav class="review-section-nav" aria-label="Page sections">
   <div class="review-section-nav__inner">
-    <a href="#tab-finalexam">Overview</a>
-    <a href="#tab-formulas">Formulas</a>
-    <a href="#tab-quiz13">Practice</a>
-    <a href="#tab-schedule">Schedule</a>
+    <a href="#tab-overview">Test 4 Overview</a>
+    <a href="#tab-formulas">Test 4 Formulas</a>
+    <a href="#tab-practice">Test 4 Practice</a>
+    <a href="#tab-plan">Test 4 Plan</a>
   </div>
 </nav>
 
 <div class="container review-shell review-shell--below-banner">
 
-    <section class="tab-content" id="tab-finalexam">
+    <section class="tab-content" id="tab-overview">
         <div class="intro-note">
             <div class="callout">
-                <strong>Comprehensive final.</strong> The exam covers all course topics — algebra, geometry, trigonometry, logarithms, applications, and vectors — in roughly 25–30 questions.
+                <strong>Math 130 Test 4.</strong> Use this page to review and recreate the major Test 4 problem types — algebra, geometry, trigonometry, logarithms, applications, and vectors — in roughly 25–30 questions.
             </div>
             <div class="callout">
-                <strong>Practical takeaway.</strong> Review broadly. The exam mixes short skill checks with multi-step application problems, so accuracy in setup matters as much as calculation.
+                <strong>Practical takeaway.</strong> Review broadly. Test 4 mixes short skill checks with multi-step application problems, so accuracy in setup matters as much as calculation.
             </div>
         </div>
 
@@ -518,7 +518,7 @@
             </div>
             <div class="scope-card">
                 <h4>Vectors</h4>
-                <p>Vector-resultant problems are part of the final, so Quiz 13 content carries forward into the exam.</p>
+                <p>Vector-resultant problems are part of Math 130 Test 4, so component form, magnitude, direction, and vector addition should stay in your review rotation.</p>
             </div>
         </div>
 
@@ -642,10 +642,10 @@
     <section class="tab-content" id="tab-formulas">
         <div class="card review-card">
             <div class="eyebrow"><i data-lucide="sigma"></i> Formula focus</div>
-            <h2>Provided on the Final Exam</h2>
+            <h2>Provided on Math 130 Test 4</h2>
             <noscript><div class="math-noscript">JavaScript is required to render the math formulas on this page.</div></noscript>
             <div aria-live="polite" class="math-runtime-warning" hidden="" id="math-runtime-warning"></div>
-            <p class="muted" style="margin-bottom:1rem;">These formulas are printed on the exam. They still require recognition and correct setup.</p>
+            <p class="muted" style="margin-bottom:1rem;">These formulas are printed on Math 130 Test 4. They still require recognition and correct setup.</p>
 
             <div class="formula-grid">
                 <div class="formula-card provided">
@@ -707,7 +707,7 @@
                 <div class="formula-card core">
                     <h4>Vector components</h4>
                     <div class="formula-math">$$\langle r\cos\theta,\;r\sin\theta\rangle$$</div>
-                    <div class="formula-note">Essential for Quiz 13 and still relevant on the final.</div>
+                    <div class="formula-note">Essential for Math 130 Test 4 vector and resultant problems.</div>
                 </div>
                 <div class="formula-card core">
                     <h4>Trig ratios</h4>
@@ -717,13 +717,13 @@
             </div>
         </div>
 
-        <p class="foot">Streamlined for Quiz 13 vectors and the comprehensive final exam.</p>
+        <p class="foot">Streamlined for Math 130 Test 4 review and recreation practice.</p>
     </section>
 
-    <section class="tab-content" id="tab-quiz13">
+    <section class="tab-content" id="tab-practice">
         <div class="intro-note">
             <div class="callout">
-                <strong>Quiz 13 is Section 8.4: Vectors.</strong> The quiz covers component form, magnitude, direction, graphical vector addition, and resultant vectors.
+                <strong>Math 130 Test 4 vector practice.</strong> This review covers component form, magnitude, direction, graphical vector addition, and resultant vectors.
                 <div class="pill-row">
                     <span class="soft-pill">components</span>
                     <span class="soft-pill">magnitude</span>
@@ -753,7 +753,7 @@
 
         <div class="card review-card" style="margin-top:1rem;">
             <div class="eyebrow"><i data-lucide="compass"></i> Core vector moves</div>
-            <h2>Quiz 13 essentials</h2>
+            <h2>Math 130 Test 4 vector essentials</h2>
             <div class="formula-grid">
                 <div class="formula-card core">
                     <h4>Component form</h4>
@@ -789,35 +789,35 @@
         </div>
     </section>
 
-    <section class="tab-content" id="tab-schedule">
+    <section class="tab-content" id="tab-plan">
         <div class="card review-card">
-            <div class="eyebrow"><i data-lucide="calendar-days"></i> Final week schedule</div>
-            <h2>Final Week at a Glance</h2>
-            <p class="muted">The typical final week includes a last quiz, a reading/review day, and the comprehensive final exam. Check your syllabus for exact dates and times.</p>
+            <div class="eyebrow"><i data-lucide="calendar-days"></i> Test 4 review plan</div>
+            <h2>Math 130 Test 4 at a Glance</h2>
+            <p class="muted">Use this sequence to turn the review list into a Test 4 recreation plan: identify the target skills, practice the supplied formulas, then rehearse mixed problems under test-like conditions.</p>
 
             <div style="margin-top:1rem;">
-                <table class="schedule-table" aria-label="Final week schedule">
+                <table class="schedule-table" aria-label="Math 130 Test 4 review plan">
                     <tbody>
                         <tr>
-                            <td class="day">Mon, 5/4</td>
-                            <td class="event">Quiz 13 &amp; Review</td>
+                            <td class="day">Step 1</td>
+                            <td class="event">Map the Test 4 topics</td>
                             <td class="tags">
                                 <span class="tag review">Review</span>
-                                <span class="tag quiz">Quiz</span>
+                                <span class="tag quiz">Topics</span>
                             </td>
                         </tr>
                         <tr>
-                            <td class="day">Wed, 5/6</td>
-                            <td class="event">Reading Day</td>
+                            <td class="day">Step 2</td>
+                            <td class="event">Rehearse formulas and setup work</td>
                             <td class="tags">
-                                <span class="tag noclass">No Class</span>
+                                <span class="tag noclass">Formulas</span>
                             </td>
                         </tr>
                         <tr>
-                            <td class="day">Thu, 5/7</td>
-                            <td class="event"><strong>Final Exam</strong> (1:00–3:00 for Section 1, 3:30–5:30 for Section 2)</td>
+                            <td class="day">Step 3</td>
+                            <td class="event"><strong>Recreate Math 130 Test 4</strong> with mixed timed practice</td>
                             <td class="tags">
-                                <span class="tag final">Final</span>
+                                <span class="tag final">Test 4</span>
                             </td>
                         </tr>
                     </tbody>
@@ -827,16 +827,16 @@
 
         <div class="plan-grid">
             <div class="plan-card">
-                <h4>Before the last class</h4>
-                <p>Finish vector review first, then use class review time to identify any final-exam weak spots that still need attention.</p>
+                <h4>Start with the topic map</h4>
+                <p>Finish vector review first, then mark any Test 4 weak spots that still need focused practice.</p>
             </div>
             <div class="plan-card">
-                <h4>Reading day</h4>
-                <p>Do cumulative practice across algebra, geometry, trigonometry, logs, and applications. Aim for breadth, not just one topic.</p>
+                <h4>Build a formula pass</h4>
+                <p>Practice across algebra, geometry, trigonometry, logs, and applications. Aim for breadth, not just one topic.</p>
             </div>
             <div class="plan-card">
-                <h4>Exam day</h4>
-                <p>Before the exam, revisit provided formulas, angle conversions, line formulas, and vector basics so setup work is quick and accurate.</p>
+                <h4>Finish with test-like practice</h4>
+                <p>Before your Test 4 attempt, revisit provided formulas, angle conversions, line formulas, and vector basics so setup work is quick and accurate.</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
### Motivation
- The page copy referred to “Final Exam” and “Quiz 13” but the page is being repurposed as a Test 4 review/recreation resource, so headings, navigation, and explanatory text needed updating to reflect “Math 130 Test 4.”

### Description
- Retitled the page `<title>` and updated the breadcrumb current page, header eyebrow, main `<h1>`, and subtitle to reference `Math 130 Test 4` and a Test 4 review/recreation focus. 
- Renamed section navigation labels and targets and updated section `id`s (for example `tab-finalexam` → `tab-overview`, `tab-quiz13` → `tab-practice`, `tab-schedule` → `tab-plan`) and adjusted in-page links to match. 
- Replaced specific body text mentions of `Final Exam`, `Quiz 13`, and related phrases with Test 4 language, including formula notes and the footer. 
- Converted the “Final Week at a Glance” schedule into a step-based `Math 130 Test 4 review plan` and adjusted table cells and tags to describe review steps instead of dated exam events.

### Testing
- Ran an HTML link verification script (`python - <<'PY' ... PY`) that parsed `130Test4.html` and verified in-page section links, which succeeded. 
- Performed a search-and-replace verification with `rg` to ensure the old strings were removed, which succeeded. 
- Ran `git diff --check` to confirm no whitespace/patch errors, which succeeded and the changes were committed. 
- Attempted to capture a screenshot with Playwright (`npx --yes playwright@1.52.0 ...`) but the attempt failed due to `npm` registry `403 Forbidden` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa41fa89c88331a384e46b960f4ca0)