### PR TITLE
Add Test 4 instruction block

### DIFF
--- a/130Test4.html
+++ b/130Test4.html
@@ -95,6 +95,30 @@
 
     .math-review-page .callout strong { color: var(--text-main); }
 
+    .math-review-page .instruction-block {
+        margin-bottom: 1.2rem;
+        padding: 1.1rem 1.2rem;
+        border: 2px solid var(--primary-main);
+        border-left-width: 8px;
+        border-radius: 18px;
+        background: linear-gradient(135deg, var(--accent-soft), var(--bg-surface));
+        box-shadow: var(--shadow);
+    }
+
+    .math-review-page .instruction-block h2 {
+        margin-bottom: 0.65rem;
+        font-size: 1.35rem;
+    }
+
+    .math-review-page .instruction-list {
+        display: grid;
+        gap: 0.45rem;
+        margin: 0;
+        padding-left: 1.15rem;
+        color: var(--text-main);
+        font-weight: 700;
+    }
+
     .math-review-page .mini-grid,
     .math-review-page .scope-grid,
     .math-review-page .formula-grid,
@@ -484,6 +508,17 @@
 </nav>
 
 <div class="container review-shell review-shell--below-banner">
+
+    <section class="instruction-block" aria-labelledby="test-4-instructions">
+        <div class="eyebrow"><i data-lucide="info"></i> Test 4 instructions</div>
+        <h2 id="test-4-instructions">Read before using the recreated versions</h2>
+        <ul class="instruction-list">
+            <li>Show work for full credit.</li>
+            <li>Unless otherwise stated, round answers to one decimal place.</li>
+            <li>Equivalent versions use the same question sequence and skill targets with changed parameters.</li>
+            <li>Use the helpful formula list at the end.</li>
+        </ul>
+    </section>
 
     <section class="tab-content" id="tab-overview">
         <div class="intro-note">


### PR DESCRIPTION
### Motivation
- Provide clear, prominent guidance for students and instructors about how to treat recreated Test 4 versions by placing instructions before the question-by-question content.

### Description
- Inserted an instruction block into `130Test4.html` immediately after the review shell and before the `#tab-overview` section containing the four requested statements: “Show work for full credit.”, “Unless otherwise stated, round answers to one decimal place.”, “Equivalent versions use the same question sequence and skill targets with changed parameters.”, and “Use the helpful formula list at the end.”
- Added scoped CSS for `.math-review-page .instruction-block` and `.math-review-page .instruction-list` to give the block a prominent accent border, background, spacing, and bolded list styling.
- Made the block accessible with `aria-labelledby="test-4-instructions"` and included an eyebrow/icon and heading for clear affordance.

### Testing
- Parsed the updated HTML with Python's `HTMLParser` which completed successfully.
- Ran `git diff --check` which reported no issues.
- Attempted an automated screenshot via Playwright/`npx`, but the attempt failed due to the environment returning `403 Forbidden` from the npm registry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faae837efc8331895cf860f12719ea)