### PR TITLE
Fix mobile navigation dropdown taps

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -158,16 +158,9 @@ function setupGlobalNav(navRoot, index) {
         };
 
         trigger.addEventListener('click', (event) => {
-            if (!mobileNavMediaQuery.matches) {
-                const expanded = trigger.getAttribute('aria-expanded') === 'true';
-                setDropdownExpanded(!expanded, { focusFirstItem: !expanded });
-                event.preventDefault();
-                return;
-            }
-
             event.preventDefault();
             const expanded = trigger.getAttribute('aria-expanded') === 'true';
-            setDropdownExpanded(!expanded, { focusFirstItem: !expanded });
+            setDropdownExpanded(!expanded);
         });
 
         trigger.addEventListener('keydown', (event) => {
@@ -195,6 +188,8 @@ function setupGlobalNav(navRoot, index) {
         });
 
         dropdown.addEventListener('focusout', (event) => {
+            if (mobileNavMediaQuery.matches) return;
+
             if (!dropdown.contains(event.relatedTarget)) {
                 setDropdownExpanded(false);
             }


### PR DESCRIPTION
### Motivation
- Mobile users could not reliably tap dropdowns because the trigger click moved focus into the submenu or the submenu closed on focus changes, making links hard to activate.
- The change aims to keep mobile dropdowns tappable while preserving desktop keyboard/hover behavior.

### Description
- Update `theme.js` so dropdown `click` handlers call `event.preventDefault()` and toggle the submenu without forcing focus into the first submenu item, preventing accidental focus jumps on touch devices.
- Add a guard to the dropdown `focusout` handler that skips the auto-close behavior when `mobileNavMediaQuery.matches`, so mobile submenus remain open and their links stay tappable.
- Desktop interactions (hover, keyboard navigation, and focus-return behavior) are preserved.

### Testing
- Ran `node --check theme.js` and it completed successfully.
- Ran `git diff --check` and it reported no check issues.
- Attempted `npx --yes playwright --version` for a browser-based validation but it failed due to an npm registry 403 so no Playwright screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac66b23dc83319736be765eb2acd9)