### PR TITLE
Add page shell, responsive layout, and math formatting helpers to Test 4 practice lab

### DIFF
--- a/130Test4.html
+++ b/130Test4.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Math 130 Test 4 Blueprint Practice Lab</title>
+    <link rel="stylesheet" href="/styles.css">
+    <script src="/theme.js" defer></script>
     <style>
         :root {
             --primary: #23395d;
@@ -24,18 +26,21 @@
 
         * { box-sizing: border-box; }
 
-        body {
-            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        body { margin: 0; }
+
+        .test4-lab-page {
+            min-height: 100vh;
             background:
                 radial-gradient(circle at top left, rgba(37, 99, 235, 0.18), transparent 32rem),
                 linear-gradient(135deg, #eef4ff 0%, #f8fafc 55%, #e0f2fe 100%);
             color: var(--dark);
+        }
+
+        .test4-lab-main {
             display: flex;
             justify-content: center;
-            align-items: center;
-            min-height: 100vh;
-            margin: 0;
-            padding: 24px;
+            align-items: flex-start;
+            padding: 2rem 24px 4rem;
         }
 
         #app-container {
@@ -49,10 +54,10 @@
             border: 1px solid rgba(148, 163, 184, 0.35);
         }
 
-        h1, h2, h3 { color: var(--primary); margin-top: 0; }
-        h1 { font-size: clamp(2rem, 4vw, 3rem); margin-bottom: 0.35rem; }
-        h2 { font-size: clamp(1.45rem, 3vw, 2rem); }
-        p { line-height: 1.6; }
+        #app-container h1, #app-container h2, #app-container h3 { color: var(--primary); margin-top: 0; }
+        #app-container h1 { font-size: clamp(2rem, 4vw, 3rem); margin-bottom: 0.35rem; }
+        #app-container h2 { font-size: clamp(1.45rem, 3vw, 2rem); }
+        #app-container p { line-height: 1.6; }
 
         .eyebrow {
             color: var(--secondary);
@@ -65,7 +70,7 @@
 
         .subtle { color: var(--muted); }
 
-        input[type="text"], input[type="number"] {
+        #app-container input[type="text"], #app-container input[type="number"] {
             width: min(100%, 360px);
             padding: 12px;
             margin: 8px 0;
@@ -74,7 +79,7 @@
             font-size: 16px;
         }
 
-        button {
+        #app-container button {
             background-color: var(--secondary);
             color: white;
             border: none;
@@ -86,10 +91,10 @@
             cursor: pointer;
             transition: transform 0.2s, background 0.2s, box-shadow 0.2s;
         }
-        button:hover:not(:disabled) { background-color: #1d4ed8; transform: translateY(-1px); box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25); }
-        button:disabled { background-color: #94a3b8; cursor: not-allowed; transform: none; box-shadow: none; }
-        .button-success { background-color: var(--success); }
-        .button-success:hover:not(:disabled) { background-color: #166534; box-shadow: 0 8px 20px rgba(21, 128, 61, 0.25); }
+        #app-container button:hover:not(:disabled) { background-color: #1d4ed8; transform: translateY(-1px); box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25); }
+        #app-container button:disabled { background-color: #94a3b8; cursor: not-allowed; transform: none; box-shadow: none; }
+        #app-container .button-success { background-color: var(--success); }
+        #app-container .button-success:hover:not(:disabled) { background-color: #166534; box-shadow: 0 8px 20px rgba(21, 128, 61, 0.25); }
 
         .hidden { display: none !important; }
 
@@ -265,15 +270,79 @@
         .cert-title { font-size: 28px; font-weight: 900; margin-bottom: 10px; color: var(--primary); }
 
         @media (max-width: 650px) {
-            body { padding: 12px; align-items: flex-start; }
+            .test4-lab-main { padding: 1rem 12px 3rem; }
             #app-container { padding: 22px; }
             .stats-row { grid-template-columns: 1fr; }
             .formula-list { columns: 1; }
         }
     </style>
 </head>
-<body>
-
+<body class="review-page">
+<div class="math-review-page test4-lab-page">
+<nav class="top-nav" aria-label="Primary">
+  <div class="top-nav-inner">
+    <div class="top-nav-branding">
+      <a class="top-nav-title" href="index.html">Prof. Volk's Office</a>
+    </div>
+    <div class="top-nav-actions">
+      <button class="menu-toggle global-nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav-links primary-nav-utilities" aria-label="Toggle navigation">
+        <span>Menu</span>
+        <span class="menu-toggle__icon" aria-hidden="true"></span>
+      </button>
+      <ul class="top-nav-links" id="primary-nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="CV.html">About</a></li>
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true" aria-current="page">Courses ▾</button>
+          <ul class="dropdown-menu">
+            <li><a href="learn.html">All Courses</a></li>
+            <li><a href="courses/math114.html">MATH 114</a></li>
+            <li><a href="courses/math130.html">MATH 130</a></li>
+            <li><a href="courses/physics-labs.html">Physics Labs</a></li>
+          </ul>
+        </li>
+        <li><a href="projects.html">Tools</a></li>
+      </ul>
+      <ul class="top-nav-utilities" id="primary-nav-utilities" aria-label="More">
+        <li class="dropdown">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
+          <ul class="dropdown-menu dropdown-menu--right">
+            <li><a href="https://andrewhvolk.github.io/LibertyMathClub/" target="_blank" rel="noopener noreferrer">Math Club</a></li>
+            <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
+            <li><a href="/cdn-cgi/l/email-protection#a3c2cbd5cccfc8e3cfcac1c6d1d7da8dc6c7d6">Contact</a></li>
+          </ul>
+        </li>
+      </ul>
+      <button id="theme-toggle-btn" class="theme-toggle" aria-label="Toggle Theme"></button>
+    </div>
+  </div>
+</nav>
+<div class="page-context-bar">
+  <div class="container">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a href="index.html">Home</a>
+      <span class="breadcrumb-sep" aria-hidden="true">›</span>
+      <a href="learn.html">Courses</a>
+      <span class="breadcrumb-sep" aria-hidden="true">›</span>
+      <a href="courses/math130.html">MATH 130</a>
+      <span class="breadcrumb-sep" aria-hidden="true">›</span>
+      <span class="breadcrumb-current" aria-current="page">Test 4 Practice Lab</span>
+    </nav>
+  </div>
+</div>
+<header class="page-shell-header review-page-header">
+  <div class="container">
+    <p class="page-shell-header__eyebrow">Spring 2026</p>
+    <h1>Math 130 — Test 4</h1>
+    <p class="subtitle">Interactive blueprint practice lab with generated questions, immediate feedback, and guided solutions.</p>
+    <div class="review-page-header__chips">
+      <span class="review-page-header__chip">🧭 Blueprint Sequence</span>
+      <span class="review-page-header__chip">🔁 Unlimited Practice</span>
+      <span class="review-page-header__chip--accent review-page-header__chip">📐 Trig + Algebra Review</span>
+    </div>
+  </div>
+</header>
+<main class="test4-lab-main">
 <div id="app-container">
     <div id="screen-welcome">
         <div class="eyebrow">Math 130 · Test 4</div>
@@ -341,17 +410,19 @@
             <strong>On-test formula reminders:</strong>
             <p class="subtle" style="margin: 6px 0 10px;">The actual Test 4 formula list is intentionally limited to these items; all other setup comes from the question context and student work.</p>
             <ul class="formula-list">
-                <li>Heron: A = √(s(s-a)(s-b)(s-c))</li>
-                <li>Semiperimeter: s = (a+b+c)/2</li>
-                <li>Triangle area: A = 1/2 bc sin(A)</li>
+                <li>Heron: A = √(s(s - a)(s - b)(s - c))</li>
+                <li>Semiperimeter: s = (a + b + c)/2</li>
+                <li>Triangle area: A = ½bc sin(A)</li>
                 <li>Arc length: s = rθ</li>
-                <li>Sector area: A = 1/2 r²θ</li>
+                <li>Sector area: A = ½r²θ</li>
                 <li>Circumference: C = 2πr</li>
             </ul>
         </div>
         <p style="font-size: 0.9em; margin-top: 24px;">Show this screen to your instructor if requested, then keep practicing any mission you found challenging.</p>
         <button type="button" onclick="restartLab()">Practice Again</button>
     </div>
+</div>
+</main>
 </div>
 
 <script>
@@ -381,6 +452,35 @@
 
     function round(value, places = 1) {
         return Number(value.toFixed(places));
+    }
+
+    const superscriptChars = {
+        "-": "⁻", "+": "⁺", "0": "⁰", "1": "¹", "2": "²", "3": "³", "4": "⁴",
+        "5": "⁵", "6": "⁶", "7": "⁷", "8": "⁸", "9": "⁹", "n": "ⁿ", "t": "ᵗ", "x": "ˣ"
+    };
+    const subscriptChars = {
+        "0": "₀", "1": "₁", "2": "₂", "3": "₃", "4": "₄", "5": "₅",
+        "6": "₆", "7": "₇", "8": "₈", "9": "₉", "r": "ᵣ"
+    };
+
+    function toSuperscript(value) {
+        return String(value).split("").map(char => superscriptChars[char] || char).join("");
+    }
+
+    function toSubscript(value) {
+        return String(value).split("").map(char => subscriptChars[char] || char).join("");
+    }
+
+    function power(base, exponent) {
+        return `${base}${toSuperscript(exponent)}`;
+    }
+
+    function logBase(base, argument) {
+        return `log${toSubscript(base)}(${argument})`;
+    }
+
+    function linearFactor(root) {
+        return root < 0 ? `(x + ${Math.abs(root)})` : `(x - ${root})`;
     }
 
     function gcd(a, b) {
@@ -638,9 +738,14 @@
             hints: "A negative outside exponent flips the fraction and applies the power to every factor. Final answers should have positive exponents only.",
             generateProblem: () => {
                 const a = randInt(1, 3), b = randInt(2, 4), c = randInt(1, 3), n = choice([2, 3]);
-                const correct = `x^${n * b}z^${n * c}/y^${n * a}`;
-                const options = shuffle([correct, `y^${n * a}/x^${n * b}z^${n * c}`, `x^${b}z^${c}/y^${a}`, `x^${n * b}y^${n * a}/z^${n * c}`]);
-                return { type: "mc", text: `Simplify ((x^-${b} y^${a}) / z^${c})^-${n} with positive exponents only.`, options, correct: options.indexOf(correct), solution: `Flip because of the negative outside exponent: (z^${c}/(x^-${b}y^${a}))^${n} = (x^${b}z^${c}/y^${a})^${n} = ${correct}.` };
+                const correct = `${power("x", n * b)}${power("z", n * c)} / ${power("y", n * a)}`;
+                const options = shuffle([
+                    correct,
+                    `${power("y", n * a)} / ${power("x", n * b)}${power("z", n * c)}`,
+                    `${power("x", b)}${power("z", c)} / ${power("y", a)}`,
+                    `${power("x", n * b)}${power("y", n * a)} / ${power("z", n * c)}`
+                ]);
+                return { type: "mc", text: `Simplify ((x${toSuperscript(-b)} y${toSuperscript(a)}) / z${toSuperscript(c)})${toSuperscript(-n)} with positive exponents only.`, options, correct: options.indexOf(correct), solution: `Flip because of the negative outside exponent: (z${toSuperscript(c)} / (x${toSuperscript(-b)}y${toSuperscript(a)}))${toSuperscript(n)} = (${power("x", b)}${power("z", c)} / ${power("y", a)})${toSuperscript(n)} = ${correct}.` };
             }
         },
         {
@@ -685,33 +790,33 @@
         },
         {
             title: "Question 19: Logarithmic Equation",
-            hints: "Rewrite log_b(argument) = exponent as argument = b^exponent, then solve for x.",
+            hints: "Rewrite log base b of the argument as: argument = b raised to that exponent, then solve for x.",
             generateProblem: () => {
                 const b = choice([2, 3, 4, 5]), m = choice([2, 3, 4]), k = choice([2, 3, 5]);
                 const x = Math.pow(b, m) / k;
-                return { type: "numeric", text: `Solve log_${b}(${k}x) = ${m}. Round x to one decimal place.`, answer: round(x), tolerance: 0.05, solution: `Rewrite as ${k}x = ${b}^${m} = ${Math.pow(b, m)}. Therefore x = ${Math.pow(b, m)}/${k} = ${round(x)}.` };
+                return { type: "numeric", text: `Solve ${logBase(b, `${k}x`)} = ${m}. Round x to one decimal place.`, answer: round(x), tolerance: 0.05, solution: `Rewrite as ${k}x = ${power(b, m)} = ${Math.pow(b, m)}. Therefore x = ${Math.pow(b, m)}/${k} = ${round(x)}.` };
             }
         },
         {
             title: "Question 20: Exponential Equation",
-            hints: "Rewrite b^x = N as x = log_b(N), then use change of base if needed.",
+            hints: "Rewrite bˣ = N as x = log base b of N, then use change of base if needed.",
             generateProblem: () => {
                 const base = choice([2, 3, 5, 7]);
                 const value = choice([10, 18, 25, 40, 75, 100]);
                 const x = Math.log(value) / Math.log(base);
-                return { type: "numeric", text: `Solve ${base}^x = ${value}. Round x to one decimal place.`, answer: round(x), tolerance: 0.05, solution: `In logarithmic form, x = log_${base}(${value}) = ln(${value})/ln(${base}) = ${round(x)}.` };
+                return { type: "numeric", text: `Solve ${power(base, "x")} = ${value}. Round x to one decimal place.`, answer: round(x), tolerance: 0.05, solution: `In logarithmic form, x = ${logBase(base, value)} = ln(${value})/ln(${base}) = ${round(x)}.` };
             }
         },
         {
             title: "Question 21: Compound Interest",
-            hints: "Use A = P(1 + r/n)^(nt), with r written as a decimal.",
+            hints: "Use A = P(1 + r/n)ⁿᵗ, with r written as a decimal.",
             generateProblem: () => {
                 const P = choice([1500, 2500, 4000, 6000]);
                 const rate = choice([3.2, 4.5, 5.1, 6.0]);
                 const n = choice([4, 12, 365]);
                 const t = choice([3, 5, 8]);
                 const A = P * Math.pow(1 + (rate / 100) / n, n * t);
-                return { type: "numeric", text: `Use A = P(1 + r/n)^(nt). Find the balance for $${P} at ${rate}% interest, compounded ${n} times per year for ${t} years. Round to the nearest cent.`, answer: round(A, 2), tolerance: 0.01, solution: `A = ${P}(1 + ${rate / 100}/${n})^(${n}·${t}) = $${round(A, 2)}.` };
+                return { type: "numeric", text: `Use A = P(1 + r/n)ⁿᵗ. Find the balance for $${P} at ${rate}% interest, compounded ${n} times per year for ${t} years. Round to the nearest cent.`, answer: round(A, 2), tolerance: 0.01, solution: `A = ${P}(1 + ${rate / 100}/${n})${toSuperscript(n * t)} = $${round(A, 2)}.` };
             }
         },
         {
@@ -758,7 +863,7 @@
                 const constantNum = a * (x - q) + c * (x - p);
                 const constantDen = (x - p) * (x - q);
                 const constant = frac(constantNum, constantDen);
-                return { type: "numeric", text: `Solve the rational equation ${a}/(x - ${p}) + ${c}/(x ${q < 0 ? "+" : "-"} ${Math.abs(q)}) = ${constant}. Enter x, and remember to reject excluded values.`, answer: x, tolerance: 0.01, solution: `Excluded values are x = ${p} and x = ${q}. Multiplying by (x-${p})(x-${q}) clears denominators: ${a}(x-${q}) + ${c}(x-${p}) = (${constant}) (x-${p})(x-${q}). Solving gives x = ${x}, which is not excluded.` };
+                return { type: "numeric", text: `Solve the rational equation ${a}/${linearFactor(p)} + ${c}/${linearFactor(q)} = ${constant}. Enter x, and remember to reject excluded values.`, answer: x, tolerance: 0.01, solution: `Excluded values are x = ${p} and x = ${q}. Multiplying by ${linearFactor(p)}${linearFactor(q)} clears denominators: ${a}${linearFactor(q)} + ${c}${linearFactor(p)} = (${constant})${linearFactor(p)}${linearFactor(q)}. Solving gives x = ${x}, which is not excluded.` };
             }
         },
         {
@@ -775,7 +880,7 @@
                 const mag = Math.sqrt(rx * rx + ry * ry);
                 let theta = Math.atan2(ry, rx) * 180 / Math.PI;
                 if (theta < 0) theta += 360;
-                return { type: "multi", text: `Let u = <${u[0]}, ${u[1]}> and v = <${v[0]}, ${v[1]}>. Find r = u + v, |r|, and the direction angle θr from the positive x-axis.`, fields: [{ id: "rx", label: "r x-component", answer: rx, tolerance: 0.001 }, { id: "ry", label: "r y-component", answer: ry, tolerance: 0.001 }, { id: "mag", label: "|r|", answer: round(mag), tolerance: 0.05 }, { id: "theta", label: "θr in degrees", answer: round(theta), tolerance: 0.05 }], solution: `r = <${rx}, ${ry}>. |r| = √(${rx}²+${ry}²) = ${round(mag)}. θr = atan2(${ry}, ${rx}) = ${round(theta)}° from the positive x-axis.` };
+                return { type: "multi", text: `Let u = ⟨${u[0]}, ${u[1]}⟩ and v = ⟨${v[0]}, ${v[1]}⟩. Find r = u + v, |r|, and the direction angle θᵣ from the positive x-axis.`, fields: [{ id: "rx", label: "r x-component", answer: rx, tolerance: 0.001 }, { id: "ry", label: "r y-component", answer: ry, tolerance: 0.001 }, { id: "mag", label: "|r|", answer: round(mag), tolerance: 0.05 }, { id: "theta", label: "θᵣ in degrees", answer: round(theta), tolerance: 0.05 }], solution: `r = ⟨${rx}, ${ry}⟩. |r| = √(${rx}²+${ry}²) = ${round(mag)}. θᵣ = atan2(${ry}, ${rx}) = ${round(theta)}° from the positive x-axis.` };
             }
         }
     ];


### PR DESCRIPTION
### Motivation
- Improve the user experience and visual consistency of the Math 130 Test 4 practice lab by introducing a page shell with navigation, breadcrumb, and header.
- Scope and modernize styles to avoid global collisions and support responsive layouts. 
- Make in-problem math rendering more readable by using superscript/subscript notation and clearer formatted expressions.

### Description
- Add a top navigation, breadcrumb, header, and `main` wrapper and link an external `styles.css` and `theme.js` for site-wide theming, and wrap the app with new page classes like `test4-lab-page` and `test4-lab-main`.
- Refactor inline CSS selectors to be scoped under `#app-container` and the new page classes, adjust layout/padding, and improve responsive behavior in the media query.
- Introduce helper functions and maps (`superscriptChars`, `subscriptChars`, `toSuperscript`, `toSubscript`, `power`, `logBase`, `linearFactor`) to produce unicode superscripts/subscripts and formatted math strings, and apply these helpers across several problem generators to present exponents, logs, powers, fractions, and factors in clearer notation.
- Update problem text, solution strings, and UI copy for multiple questions to use the new formatting helpers and slightly reword hints for clarity, and add small accessibility attributes (`aria-*`) in navigation elements.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad4623f748331afef4477d59a70ee)