### PR TITLE
Update Liberty Success Story contact information in Fulbright guide

### DIFF
--- a/fulbright_guide.html
+++ b/fulbright_guide.html
@@ -84,7 +84,7 @@
                 <div class="bg-white p-5 rounded-lg border border-gray-200 shadow-sm hover:shadow-md transition-shadow">
                     <h3 class="font-bold text-lg text-liberty-red mb-1">Liberty Success Story</h3>
                     <p class="text-sm text-gray-600 mb-3">Campus Mentorship</p>
-                    <p class="text-sm text-gray-700">Dr. Esswein (Math Dept) has successfully mentored multiple LU students to win Fulbrights and P.A.R.E. grants. Connect with him early!</p>
+                    <p class="text-sm text-gray-700">For more information on the Provost’s Award for Research Excellence and Fulbright Awards contact Edna Udobong at <a href="mailto:internationalexchange@liberty.edu" class="underline text-liberty-blue">internationalexchange@liberty.edu</a>.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Motivation
- Replace a campus-mentorship sentence that referenced a specific faculty mentor with a clear contact for inquiries about the Provost’s Award for Research Excellence and Fulbright Awards.

### Description
- Update the `Liberty Success Story` block in `fulbright_guide.html` to replace the existing mentorship sentence with: "For more information on the Provost’s Award for Research Excellence and Fulbright Awards contact Edna Udobong at `mailto:internationalexchange@liberty.edu`." 

### Testing
- Verified the change with a content diff of `fulbright_guide.html` and a line-range inspection to confirm only the requested sentence was replaced and no other files were modified, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1472dd30408331adb58160bc9d3f90)