### PR TITLE
Prepare course pages for Fall 2026

### DIFF
--- a/courses/math114.html
+++ b/courses/math114.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MATH 114: Quantitative Reasoning | Prof. Volk's Office</title>
-  <meta name="description" content="MATH 114 course hub with quick-start links, unit pages, final review, and common tools.">
+  <meta name="description" content="MATH 114 course hub with Fall 2026 quick-start links, unit pages, final review, and common tools.">
   <link rel="stylesheet" href="/styles.css">
   <script src="/theme.js" defer></script>
 </head>
@@ -63,12 +63,12 @@
     <h1>MATH 114: Quantitative Reasoning</h1>
     <p class="page-hero__lede">Enhancing data interpretation, logical reasoning, and real-world problem solving.</p>
     <ul class="badge-list" aria-label="Course highlights">
-      <li><span class="site-badge">Evergreen course resources</span></li>
+      <li><span class="site-badge">Fall 2026 course hub</span></li>
       <li><span class="site-badge">Canvas holds current deadlines</span></li>
       <li><span class="site-badge">Unit-based review</span></li>
     </ul>
     <div class="page-actions">
-      <a href="/courses/math114Spring26Links.html" class="button">Open Spring Assignment Page</a>
+      <a href="https://canvas.liberty.edu/" class="button external-destination" target="_blank" rel="noopener noreferrer">Open Canvas</a>
       <a href="/courses/math114-final-review.html" class="button button-secondary">Open Final Review</a>
       <a href="#common-tools" class="button button-secondary">Open Common Tools</a>
     </div>
@@ -80,14 +80,14 @@
     <div class="section-header">
       <p class="section-kicker">Quick Start</p>
       <h2 id="quick-start-title">Frequently used MATH 114 links.</h2>
-      <p>Assignment links, final review, and common calculators are placed here before the full unit list.</p>
+      <p>Start with Canvas for current assignments and deadlines, then use the review and tool links below as reusable support.</p>
     </div>
     <div class="card-grid quick-start-grid">
       <article class="resource-card">
         <span class="resource-card__type">Current term</span>
-        <h3>Spring Assignment Links</h3>
-        <p>Use the separate Spring assignment page for current Canvas links and due-date details.</p>
-        <a href="/courses/math114Spring26Links.html" class="button">Open Spring Assignment Page</a>
+        <h3>Fall 2026 assignments and deadlines</h3>
+        <p>Use Canvas for official assignment links, due dates, grades, announcements, and section-specific instructions.</p>
+        <a href="https://canvas.liberty.edu/" class="button external-destination" target="_blank" rel="noopener noreferrer">Open Canvas</a>
       </article>
       <article class="resource-card">
         <span class="resource-card__type">Review</span>
@@ -115,7 +115,7 @@
     <div class="card-grid course-dashboard-grid">
       <article class="profile-card">
         <h3>How to use this course hub</h3>
-        <p>Start here for evergreen unit pages, archived learning resources, and the main course navigation.</p>
+        <p>Start here for evergreen unit pages, review materials, and the main course navigation.</p>
         <p>For section-specific meeting times, office hours, policies, deadlines, and announcements, use Canvas and the current syllabus.</p>
       </article>
       <article class="profile-card">
@@ -133,7 +133,7 @@
 
   <section class="site-section site-note" aria-labelledby="policies-title">
     <h2 id="policies-title">Syllabus and policies</h2>
-    <p>Review the current syllabus in Canvas for term-specific grading policies, attendance expectations, deadlines, and section logistics. This website focuses on reusable course organization and archived learning materials.</p>
+    <p>Review the current syllabus in Canvas for term-specific grading policies, attendance expectations, deadlines, and section logistics. This website focuses on reusable course organization and learning materials.</p>
   </section>
 
   <section class="site-section" aria-labelledby="mathclub-title">
@@ -156,6 +156,11 @@
       <p>Final review materials, end-of-course module links, exam preparation, and cumulative wrap-up materials.</p>
       <a href="/courses/math114-final-review.html" class="button">Open Featured Unit</a>
     </article>
+  </section>
+
+  <section class="site-section site-note" aria-labelledby="archived-title">
+    <h2 id="archived-title">Archived prior-term links</h2>
+    <p>The <a href="/courses/math114Spring26Links.html">Spring 2026 assignment page</a> is retained only as an archive. Fall 2026 students should use Canvas for current assignment links, dates, and submission instructions.</p>
   </section>
 
   <section class="site-section" aria-labelledby="units-title">

--- a/courses/math130.html
+++ b/courses/math130.html
@@ -63,10 +63,10 @@
 <header class="page-hero math130-header">
   <div class="page-hero__inner">
     <p class="page-hero__eyebrow">MATH 130 Course Dashboard</p>
-    <h1>Advanced Technical Mathematics</h1>
+    <h1>MATH 130: Advanced Technical Mathematics</h1>
     <p class="page-hero__lede">Home base for all four MATH 130 review units.</p>
     <ul class="badge-list" aria-label="Course highlights">
-      <li><span class="site-badge">4 review units</span></li>
+      <li><span class="site-badge">Fall 2026 course hub</span></li>
       <li><span class="site-badge">Slides, videos, and review tools</span></li>
       <li><span class="site-badge">Exam-by-exam study flow</span></li>
     </ul>
@@ -74,6 +74,12 @@
 </header>
 
 <main id="main-content" class="site-main math130-dashboard">
+  <section class="site-section site-note" aria-labelledby="canvas-title">
+    <h2 id="canvas-title">Start with Canvas for current-term details.</h2>
+    <p>Use Canvas for official deadlines, grades, announcements, assignment submissions, section policies, and the current syllabus. Use this page for reusable study flow and review resources.</p>
+    <a href="https://canvas.liberty.edu/" class="button external-destination" target="_blank" rel="noopener noreferrer">Open Canvas</a>
+  </section>
+
   <section class="site-section" aria-labelledby="current-need-title">
     <div class="section-header">
       <p class="section-kicker">Current Need</p>

--- a/courses/physics-labs.html
+++ b/courses/physics-labs.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Physics Labs | Prof. Volk's Office</title>
-  <meta name="description" content="Physics lab course home pages and preparation resources for PHYS 103, PHYS 201L/231L, and PHYS 202L/232L.">
+  <meta name="description" content="Physics lab course home pages and preparation resources for PHYS 201L/231L and PHYS 202L/232L.">
   <link rel="stylesheet" href="/styles.css">
   <script src="/theme.js" defer></script>
 </head>
@@ -61,7 +61,7 @@
   <div class="page-hero__inner">
     <p class="page-hero__eyebrow">Physics Lab Resources</p>
     <h1>Physics Labs</h1>
-    <p class="page-hero__lede">Choose the lab course home that matches your section.</p>
+    <p class="page-hero__lede">Choose the lab course home that matches your Fall 2026 section.</p>
     <div class="page-actions">
       <a href="#lab-courses" class="button">Find My Lab Course</a>
       <a href="#before-lab" class="button button-secondary">Before Lab Checklist</a>
@@ -75,7 +75,7 @@
       <h2 id="how-title">How to use this page</h2>
       <ol>
         <li>Identify the course number listed in Canvas or on your syllabus.</li>
-        <li>Open the matching course home below.</li>
+        <li>Open the matching Fall 2026 course home below.</li>
         <li>Use that course page as your starting point for manuals, experiment preparation, and lab-day reference material.</li>
       </ol>
     </div>
@@ -83,26 +83,20 @@
 
   <section id="lab-courses" class="site-section" aria-labelledby="lab-courses-title">
     <div class="section-header">
-      <p class="section-kicker">Lab Course Homes</p>
+      <p class="section-kicker">Fall 2026 Lab Course Homes</p>
       <h2 id="lab-courses-title">Choose the page that corresponds to your section.</h2>
     </div>
     <div class="card-grid lab-course-grid">
       <article class="course-card">
-        <span class="course-card__meta">PHYS 103</span>
-        <h3>Elements of Physics Lab</h3>
-        <p>Introductory measurement, motion, waves, and electricity labs.</p>
-        <a href="/courses/phys103.html" class="button">Open PHYS 103</a>
-      </article>
-      <article class="course-card">
-        <span class="course-card__meta">PHYS 201L / 231L</span>
-        <h3>Physics Lab 1</h3>
-        <p>Mechanics-focused investigations and first-semester laboratory work.</p>
+        <span class="course-card__meta">PHYS 201L / PHYS 231L</span>
+        <h3>PHYS 201L / PHYS 231L: Physics Lab 1</h3>
+        <p>Mechanics-focused investigations, lab preparation, report expectations, and first-semester laboratory guidance.</p>
         <a href="/courses/physlab1.html" class="button">Open Physics Lab 1</a>
       </article>
       <article class="course-card">
-        <span class="course-card__meta">PHYS 202L / 232L</span>
-        <h3>Physics Lab 2</h3>
-        <p>Electricity, magnetism, optics, and later-semester experiments.</p>
+        <span class="course-card__meta">PHYS 202L / PHYS 232L</span>
+        <h3>PHYS 202L / PHYS 232L: Physics Lab 2</h3>
+        <p>Electricity, magnetism, optics, and later-semester experiment preparation and reporting guidance.</p>
         <a href="/courses/physlab2.html" class="button">Open Physics Lab 2</a>
       </article>
     </div>
@@ -121,6 +115,22 @@
         <li>Bring a notebook or data sheet so you can record measurements clearly during the experiment.</li>
         <li>Review any formulas or safety notes before class so lab time can focus on observation and analysis.</li>
       </ol>
+    </div>
+  </section>
+
+  <section class="site-section" aria-labelledby="other-labs-title">
+    <div class="section-header">
+      <p class="section-kicker">Other Lab Pages</p>
+      <h2 id="other-labs-title">Archived or non-Fall lab pages.</h2>
+      <p>These pages are not part of the Fall 2026 course list above, but remain available for reference.</p>
+    </div>
+    <div class="card-grid lab-course-grid">
+      <article class="course-card">
+        <span class="course-card__meta">PHYS 103</span>
+        <h3>Elements of Physics Lab</h3>
+        <p>Introductory measurement, motion, waves, and electricity labs.</p>
+        <a href="/courses/phys103.html" class="button button-secondary">Open PHYS 103</a>
+      </article>
     </div>
   </section>
 

--- a/courses/physlab1.html
+++ b/courses/physlab1.html
@@ -3,38 +3,40 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>PHYS 201L/231L Course Resources | Physics Lab 1</title>
+  <title>PHYS 201L/231L: Physics Lab 1 | Prof. Volk's Office</title>
+  <meta name="description" content="Fall 2026 PHYS 201L and PHYS 231L Physics Lab 1 course home with lab preparation, resources, and report guidance.">
   <link rel="stylesheet" href="/styles.css">
-  <script src="../theme.js"></script>
+  <script src="/theme.js" defer></script>
 </head>
 <body>
+<a class="skip-to-main" href="#main-content">Skip to main content</a>
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
-      <a class="top-nav-title" href="../index.html">Prof. Volk's Office</a>
+      <a class="top-nav-title" href="/index.html">Prof. Volk's Office</a>
     </div>
     <div class="top-nav-actions">
       <ul class="top-nav-links">
-        <li><a href="../index.html">Home</a></li>
-        <li><a href="../CV.html">About</a></li>
+        <li><a href="/index.html">Home</a></li>
         <li class="dropdown">
-          <button class="dropdown-trigger" type="button" aria-haspopup="true" aria-current="page">Courses ▾</button>
+          <button class="dropdown-trigger" type="button" aria-haspopup="menu" aria-current="page">Courses</button>
           <ul class="dropdown-menu">
-            <li><a href="../learn.html">Course Home</a></li>
-            <li><a href="math114.html">MATH 114</a></li>
-            <li><a href="math130.html">MATH 130</a></li>
-            <li><a href="physics-labs.html">Physics Labs</a></li>
+            <li><a href="/learn.html">Course Home</a></li>
+            <li><a href="/courses/math114.html">MATH 114</a></li>
+            <li><a href="/courses/math130.html">MATH 130</a></li>
+            <li><a href="/courses/physics-labs.html">Physics Labs</a></li>
           </ul>
         </li>
-        <li><a href="../projects.html">Tools &amp; Resources</a></li>
+        <li><a href="/projects.html">Tools &amp; Resources</a></li>
+        <li><a href="/CV.html">About / CV</a></li>
+        <li><a href="/LibertyMathClub/">Math Club</a></li>
+        <li><a href="/contact.html">Contact</a></li>
       </ul>
       <ul class="top-nav-utilities" aria-label="More">
         <li class="dropdown">
-          <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
+          <button class="dropdown-trigger" type="button" aria-haspopup="menu">More</button>
           <ul class="dropdown-menu dropdown-menu--right">
-            <li><a href="/LibertyMathClub/">Math Club</a></li>
-            <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-            <li><a href="/contact.html">Contact</a></li>
+            <li><a class="external-destination" href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
           </ul>
         </li>
       </ul>
@@ -42,58 +44,145 @@
     </div>
   </div>
 </nav>
+
 <div class="page-context-bar">
   <div class="container">
     <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../index.html">Home</a>
+      <a href="/index.html">Home</a>
       <span aria-hidden="true" class="breadcrumb-sep">›</span>
-      <a href="../learn.html">Courses</a>
+      <a href="/learn.html">Courses</a>
       <span aria-hidden="true" class="breadcrumb-sep">›</span>
-      <span class="breadcrumb-current" aria-current="page">PHYS 201L/231L</span>
+      <a href="/courses/physics-labs.html">Physics Labs</a>
+      <span aria-hidden="true" class="breadcrumb-sep">›</span>
+      <span class="breadcrumb-current" aria-current="page">PHYS 201L / 231L</span>
     </nav>
   </div>
 </div>
-<header class="course-header course-header--unit">
-  <div class="container">
-    <h1>PHYS 201L / 231L: Physics Lab 1</h1>
-    <p class="subtitle">A long-form lab home for first-semester physics experiments, preparation, and course guidance.</p>
+
+<header class="page-hero">
+  <div class="page-hero__inner">
+    <p class="page-hero__eyebrow">Physics Lab 1</p>
+    <h1>PHYS 201L / PHYS 231L: Physics Lab 1</h1>
+    <p class="page-hero__lede">Fall 2026 course home for first-semester mechanics lab preparation, lab-day reference, and report guidance.</p>
+    <ul class="badge-list" aria-label="Course highlights">
+      <li><span class="site-badge">Shared 201L / 231L page</span></li>
+      <li><span class="site-badge">Canvas holds current deadlines</span></li>
+      <li><span class="site-badge">Mechanics lab focus</span></li>
+    </ul>
+    <div class="page-actions">
+      <a href="https://canvas.liberty.edu/" class="button external-destination" target="_blank" rel="noopener noreferrer">Open Canvas</a>
+      <a href="#before-lab" class="button button-secondary">Before Lab Checklist</a>
+      <a href="#reporting" class="button button-secondary">Report Guidance</a>
+    </div>
   </div>
 </header>
-<main class="container course-page course-page--longform reading-page">
-  <article class="reading-flow course-page__prose">
-    <section>
-      <h2>Course overview</h2>
-      <p class="course-page__lede">Physics Lab 1 supports mechanics-centered experiments that ask students to measure physical quantities carefully, compare theory with data, and document uncertainty responsibly.</p>
-    </section>
-    <section>
-      <h2>Instructional focus</h2>
+
+<main id="main-content" class="site-main">
+  <section class="site-section site-note" aria-labelledby="current-term-title">
+    <h2 id="current-term-title">Start with Canvas and the current syllabus.</h2>
+    <p>Use Canvas for official lab meeting details, assigned experiment numbers, due dates, submission instructions, grades, and announcements. Use this page as the reusable PHYS 201L / PHYS 231L lab hub.</p>
+  </section>
+
+  <section class="site-section" aria-labelledby="overview-title">
+    <div class="section-header">
+      <p class="section-kicker">Course Overview</p>
+      <h2 id="overview-title">What this lab page is for.</h2>
+    </div>
+    <div class="card-grid course-dashboard-grid">
+      <article class="profile-card">
+        <h3>Course identity</h3>
+        <p>PHYS 201L and PHYS 231L share this Physics Lab 1 resource page. If Canvas lists either code, this is the correct lab hub.</p>
+      </article>
+      <article class="profile-card">
+        <h3>Instructional focus</h3>
+        <p>Physics Lab 1 emphasizes mechanics-centered measurements, graphing, uncertainty, and clear comparison between physical models and collected data.</p>
+      </article>
+      <article class="profile-card">
+        <h3>Instructor contact</h3>
+        <p>For section-specific questions, use Canvas messages or email <a href="mailto:ahvolk@liberty.edu">ahvolk@liberty.edu</a>.</p>
+      </article>
+    </div>
+  </section>
+
+  <section id="before-lab" class="site-section" aria-labelledby="before-title">
+    <div class="checklist-card">
+      <h2 id="before-title">Before you come to lab</h2>
       <ol>
-        <li>Review each experiment before lab so the setup and target quantities are familiar.</li>
-        <li>Prepare units, formulas, and diagram conventions before collecting data.</li>
-        <li>Record measurements clearly enough that another student could follow your work.</li>
-        <li>Use graphs, slopes, and uncertainty language when interpreting results.</li>
-        <li>Return to manuals and notes when preparing reports or exam review.</li>
+        <li>Check Canvas for the assigned experiment, due date, and any instructor notes for your section.</li>
+        <li>Read the relevant lab manual pages before class and identify the objective, apparatus, and major procedure steps.</li>
+        <li>Write down expected quantities, units, formulas, and graph relationships before collecting data.</li>
+        <li>Bring the required notebook, data sheet, calculator, and any files or printouts requested in Canvas.</li>
+        <li>Ask before changing a setup, using unfamiliar equipment, or continuing when a measurement seems unsafe.</li>
       </ol>
-    </section>
-    <section>
-      <h2>Suggested workflow</h2>
-      <ol>
-        <li>Start each week by identifying the vocabulary, formulas, and examples emphasized in class.</li>
-        <li>Work through guided examples before independent homework so methods stay organized.</li>
-        <li>Show steps clearly, label units when relevant, and keep track of questions for class or office hours.</li>
-        <li>Use quizzes, review sheets, and prior assignments to identify patterns in mistakes.</li>
-        <li>Revisit this page as a stable landing point for archived resources and future additions.</li>
-      </ol>
-    </section>
-    <section>
-      <h2>Resources</h2>
-      <ul>
-        <li>Current-term syllabus details and due dates should be checked in Canvas.</li>
-        <li>Contact <a href="mailto:ahvolk@liberty.edu">Prof. Volk</a> for section-specific questions or support.</li>
-        <li>Additional archived notes, links, or review materials can be added here as the course library grows.</li>
-      </ul>
-    </section>
-  </article>
+    </div>
+  </section>
+
+  <section class="site-section" aria-labelledby="resources-title">
+    <div class="section-header">
+      <p class="section-kicker">Lab Manual &amp; Resources</p>
+      <h2 id="resources-title">Use these materials during preparation and lab day.</h2>
+      <p>The current manual, required files, and section-specific handouts live in Canvas. This page keeps the reusable workflow in one place.</p>
+    </div>
+    <div class="card-grid quick-start-grid">
+      <article class="resource-card">
+        <span class="resource-card__type">Manual</span>
+        <h3>Assigned experiment</h3>
+        <p>Read the Canvas-posted manual before lab and bring the needed pages, notes, or data sheet.</p>
+        <a href="https://canvas.liberty.edu/" class="button external-destination" target="_blank" rel="noopener noreferrer">Open Canvas</a>
+      </article>
+      <article class="resource-card">
+        <span class="resource-card__type">Data</span>
+        <h3>Tables and graphs</h3>
+        <p>Record raw measurements with units and uncertainty notes. Preserve enough detail that the analysis can be checked later.</p>
+      </article>
+      <article class="resource-card">
+        <span class="resource-card__type">Safety</span>
+        <h3>Equipment setup</h3>
+        <p>Follow the manual and instructor directions exactly before releasing carts, hanging masses, adjusting sensors, or changing any setup.</p>
+      </article>
+    </div>
+  </section>
+
+  <section id="reporting" class="site-section" aria-labelledby="reporting-title">
+    <div class="section-header">
+      <p class="section-kicker">Reports &amp; Data Analysis</p>
+      <h2 id="reporting-title">Make your lab work traceable.</h2>
+    </div>
+    <div class="card-grid course-dashboard-grid">
+      <article class="site-card">
+        <h3>Show the measurement trail</h3>
+        <p>Include raw data, units, sample calculations, and graph labels so another reader can follow how each result was produced.</p>
+      </article>
+      <article class="site-card">
+        <h3>Connect results to the model</h3>
+        <p>Compare slopes, fitted values, or calculated quantities with the expected physical relationship. Explain differences with evidence from the experiment.</p>
+      </article>
+      <article class="site-card">
+        <h3>Use uncertainty language</h3>
+        <p>State major sources of uncertainty, distinguish random variation from systematic effects, and avoid unsupported claims about accuracy.</p>
+      </article>
+    </div>
+  </section>
+
+  <section class="site-section site-note" aria-labelledby="support-title">
+    <h2 id="support-title">Getting help</h2>
+    <p>For due dates, submissions, and section-specific instructions, use Canvas first. For questions about experiment preparation, analysis, or reports, contact Prof. Volk through Canvas or at <a href="mailto:ahvolk@liberty.edu">ahvolk@liberty.edu</a>.</p>
+  </section>
 </main>
+
+<footer class="site-footer">
+  <div class="container">
+    <p>&copy; <span id="current-year">2026</span> Andrew H. Volk. Course materials, tools, and academic resources.</p>
+    <nav aria-label="Footer">
+      <a href="/index.html">Home</a>
+      <a href="/learn.html">Courses</a>
+      <a href="/projects.html">Tools &amp; Resources</a>
+      <a href="/CV.html">About / CV</a>
+      <a href="/LibertyMathClub/">Math Club</a>
+      <a href="/contact.html">Contact</a>
+    </nav>
+  </div>
+</footer>
+<script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/courses/physlab2.html
+++ b/courses/physlab2.html
@@ -3,38 +3,40 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>PHYS 202L/232L Course Resources | Physics Lab 2</title>
+  <title>PHYS 202L/232L: Physics Lab 2 | Prof. Volk's Office</title>
+  <meta name="description" content="Fall 2026 PHYS 202L and PHYS 232L Physics Lab 2 course home with lab preparation, resources, and report guidance.">
   <link rel="stylesheet" href="/styles.css">
-  <script src="../theme.js"></script>
+  <script src="/theme.js" defer></script>
 </head>
 <body>
+<a class="skip-to-main" href="#main-content">Skip to main content</a>
 <nav class="top-nav" aria-label="Primary">
   <div class="top-nav-inner">
     <div class="top-nav-branding">
-      <a class="top-nav-title" href="../index.html">Prof. Volk's Office</a>
+      <a class="top-nav-title" href="/index.html">Prof. Volk's Office</a>
     </div>
     <div class="top-nav-actions">
       <ul class="top-nav-links">
-        <li><a href="../index.html">Home</a></li>
-        <li><a href="../CV.html">About</a></li>
+        <li><a href="/index.html">Home</a></li>
         <li class="dropdown">
-          <button class="dropdown-trigger" type="button" aria-haspopup="true" aria-current="page">Courses ▾</button>
+          <button class="dropdown-trigger" type="button" aria-haspopup="menu" aria-current="page">Courses</button>
           <ul class="dropdown-menu">
-            <li><a href="../learn.html">Course Home</a></li>
-            <li><a href="math114.html">MATH 114</a></li>
-            <li><a href="math130.html">MATH 130</a></li>
-            <li><a href="physics-labs.html">Physics Labs</a></li>
+            <li><a href="/learn.html">Course Home</a></li>
+            <li><a href="/courses/math114.html">MATH 114</a></li>
+            <li><a href="/courses/math130.html">MATH 130</a></li>
+            <li><a href="/courses/physics-labs.html">Physics Labs</a></li>
           </ul>
         </li>
-        <li><a href="../projects.html">Tools &amp; Resources</a></li>
+        <li><a href="/projects.html">Tools &amp; Resources</a></li>
+        <li><a href="/CV.html">About / CV</a></li>
+        <li><a href="/LibertyMathClub/">Math Club</a></li>
+        <li><a href="/contact.html">Contact</a></li>
       </ul>
       <ul class="top-nav-utilities" aria-label="More">
         <li class="dropdown">
-          <button class="dropdown-trigger" type="button" aria-haspopup="true">More ▾</button>
+          <button class="dropdown-trigger" type="button" aria-haspopup="menu">More</button>
           <ul class="dropdown-menu dropdown-menu--right">
-            <li><a href="/LibertyMathClub/">Math Club</a></li>
-            <li><a href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
-            <li><a href="/contact.html">Contact</a></li>
+            <li><a class="external-destination" href="https://www.youtube.com/learnabundantly" target="_blank" rel="noopener noreferrer">YouTube</a></li>
           </ul>
         </li>
       </ul>
@@ -42,58 +44,145 @@
     </div>
   </div>
 </nav>
+
 <div class="page-context-bar">
   <div class="container">
     <nav class="breadcrumb" aria-label="Breadcrumb">
-      <a href="../index.html">Home</a>
+      <a href="/index.html">Home</a>
       <span aria-hidden="true" class="breadcrumb-sep">›</span>
-      <a href="../learn.html">Courses</a>
+      <a href="/learn.html">Courses</a>
       <span aria-hidden="true" class="breadcrumb-sep">›</span>
-      <span class="breadcrumb-current" aria-current="page">PHYS 202L/232L</span>
+      <a href="/courses/physics-labs.html">Physics Labs</a>
+      <span aria-hidden="true" class="breadcrumb-sep">›</span>
+      <span class="breadcrumb-current" aria-current="page">PHYS 202L / 232L</span>
     </nav>
   </div>
 </div>
-<header class="course-header course-header--unit">
-  <div class="container">
-    <h1>PHYS 202L / 232L: Physics Lab 2</h1>
-    <p class="subtitle">A long-form lab home for second-semester experiments in electricity, magnetism, and optics.</p>
+
+<header class="page-hero">
+  <div class="page-hero__inner">
+    <p class="page-hero__eyebrow">Physics Lab 2</p>
+    <h1>PHYS 202L / PHYS 232L: Physics Lab 2</h1>
+    <p class="page-hero__lede">Fall 2026 course home for electricity, magnetism, optics, lab preparation, and report guidance.</p>
+    <ul class="badge-list" aria-label="Course highlights">
+      <li><span class="site-badge">Shared 202L / 232L page</span></li>
+      <li><span class="site-badge">Canvas holds current deadlines</span></li>
+      <li><span class="site-badge">E&amp;M and optics focus</span></li>
+    </ul>
+    <div class="page-actions">
+      <a href="https://canvas.liberty.edu/" class="button external-destination" target="_blank" rel="noopener noreferrer">Open Canvas</a>
+      <a href="#before-lab" class="button button-secondary">Before Lab Checklist</a>
+      <a href="#reporting" class="button button-secondary">Report Guidance</a>
+    </div>
   </div>
 </header>
-<main class="container course-page course-page--longform reading-page">
-  <article class="reading-flow course-page__prose">
-    <section>
-      <h2>Course overview</h2>
-      <p class="course-page__lede">Physics Lab 2 organizes later-semester investigations around careful setup, measurement, and interpretation in electricity, magnetism, and optical systems.</p>
-    </section>
-    <section>
-      <h2>Instructional focus</h2>
+
+<main id="main-content" class="site-main">
+  <section class="site-section site-note" aria-labelledby="current-term-title">
+    <h2 id="current-term-title">Start with Canvas and the current syllabus.</h2>
+    <p>Use Canvas for official lab meeting details, assigned experiment numbers, due dates, submission instructions, grades, and announcements. Use this page as the reusable PHYS 202L / PHYS 232L lab hub.</p>
+  </section>
+
+  <section class="site-section" aria-labelledby="overview-title">
+    <div class="section-header">
+      <p class="section-kicker">Course Overview</p>
+      <h2 id="overview-title">What this lab page is for.</h2>
+    </div>
+    <div class="card-grid course-dashboard-grid">
+      <article class="profile-card">
+        <h3>Course identity</h3>
+        <p>PHYS 202L and PHYS 232L share this Physics Lab 2 resource page. If Canvas lists either code, this is the correct lab hub.</p>
+      </article>
+      <article class="profile-card">
+        <h3>Instructional focus</h3>
+        <p>Physics Lab 2 emphasizes careful setup, measurement, and interpretation in electricity, magnetism, and optical systems.</p>
+      </article>
+      <article class="profile-card">
+        <h3>Instructor contact</h3>
+        <p>For section-specific questions, use Canvas messages or email <a href="mailto:ahvolk@liberty.edu">ahvolk@liberty.edu</a>.</p>
+      </article>
+    </div>
+  </section>
+
+  <section id="before-lab" class="site-section" aria-labelledby="before-title">
+    <div class="checklist-card">
+      <h2 id="before-title">Before you come to lab</h2>
       <ol>
-        <li>Preview the experiment and identify the instruments used that day.</li>
-        <li>Pay attention to setup diagrams, polarity, alignment, and calibration steps.</li>
-        <li>Record data in tables as you work so later analysis remains traceable.</li>
-        <li>Use the manual discussion prompts to connect observations with theory.</li>
-        <li>Keep a running reference list of formulas, units, and common conversions.</li>
+        <li>Check Canvas for the assigned experiment, due date, and any instructor notes for your section.</li>
+        <li>Read the relevant lab manual pages before class and identify the objective, apparatus, and major procedure steps.</li>
+        <li>Review setup diagrams, polarity, alignment, calibration, formulas, and safety notes before touching equipment.</li>
+        <li>Bring the required notebook, data sheet, calculator, and any files or printouts requested in Canvas.</li>
+        <li>Ask before changing a circuit, optical path, sensor configuration, or unfamiliar equipment setup.</li>
       </ol>
-    </section>
-    <section>
-      <h2>Suggested workflow</h2>
-      <ol>
-        <li>Start each week by identifying the vocabulary, formulas, and examples emphasized in class.</li>
-        <li>Work through guided examples before independent homework so methods stay organized.</li>
-        <li>Show steps clearly, label units when relevant, and keep track of questions for class or office hours.</li>
-        <li>Use quizzes, review sheets, and prior assignments to identify patterns in mistakes.</li>
-        <li>Revisit this page as a stable landing point for archived resources and future additions.</li>
-      </ol>
-    </section>
-    <section>
-      <h2>Resources</h2>
-      <ul>
-        <li>Current-term syllabus details and due dates should be checked in Canvas.</li>
-        <li>Contact <a href="mailto:ahvolk@liberty.edu">Prof. Volk</a> for section-specific questions or support.</li>
-        <li>Additional archived notes, links, or review materials can be added here as the course library grows.</li>
-      </ul>
-    </section>
-  </article>
+    </div>
+  </section>
+
+  <section class="site-section" aria-labelledby="resources-title">
+    <div class="section-header">
+      <p class="section-kicker">Lab Manual &amp; Resources</p>
+      <h2 id="resources-title">Use these materials during preparation and lab day.</h2>
+      <p>The current manual, required files, and section-specific handouts live in Canvas. This page keeps the reusable workflow in one place.</p>
+    </div>
+    <div class="card-grid quick-start-grid">
+      <article class="resource-card">
+        <span class="resource-card__type">Manual</span>
+        <h3>Assigned experiment</h3>
+        <p>Read the Canvas-posted manual before lab and bring the needed pages, notes, or data sheet.</p>
+        <a href="https://canvas.liberty.edu/" class="button external-destination" target="_blank" rel="noopener noreferrer">Open Canvas</a>
+      </article>
+      <article class="resource-card">
+        <span class="resource-card__type">Data</span>
+        <h3>Tables and graphs</h3>
+        <p>Record raw measurements with units, instrument settings, and uncertainty notes. Preserve enough detail that the analysis can be checked later.</p>
+      </article>
+      <article class="resource-card">
+        <span class="resource-card__type">Safety</span>
+        <h3>Equipment setup</h3>
+        <p>Follow the manual and instructor directions exactly before energizing circuits, adjusting magnets, aligning optics, or changing any setup.</p>
+      </article>
+    </div>
+  </section>
+
+  <section id="reporting" class="site-section" aria-labelledby="reporting-title">
+    <div class="section-header">
+      <p class="section-kicker">Reports &amp; Data Analysis</p>
+      <h2 id="reporting-title">Make your lab work traceable.</h2>
+    </div>
+    <div class="card-grid course-dashboard-grid">
+      <article class="site-card">
+        <h3>Document the setup</h3>
+        <p>Include circuit diagrams, optical arrangements, instrument settings, units, and any calibration steps needed to understand the data.</p>
+      </article>
+      <article class="site-card">
+        <h3>Connect observations to theory</h3>
+        <p>Use graphs, slopes, fitted values, or calculated quantities to connect measurements with the expected physical relationship.</p>
+      </article>
+      <article class="site-card">
+        <h3>Explain limitations</h3>
+        <p>Discuss alignment, calibration, resistance, field effects, reading uncertainty, or other sources that shape the reliability of your result.</p>
+      </article>
+    </div>
+  </section>
+
+  <section class="site-section site-note" aria-labelledby="support-title">
+    <h2 id="support-title">Getting help</h2>
+    <p>For due dates, submissions, and section-specific instructions, use Canvas first. For questions about experiment preparation, analysis, or reports, contact Prof. Volk through Canvas or at <a href="mailto:ahvolk@liberty.edu">ahvolk@liberty.edu</a>.</p>
+  </section>
 </main>
+
+<footer class="site-footer">
+  <div class="container">
+    <p>&copy; <span id="current-year">2026</span> Andrew H. Volk. Course materials, tools, and academic resources.</p>
+    <nav aria-label="Footer">
+      <a href="/index.html">Home</a>
+      <a href="/learn.html">Courses</a>
+      <a href="/projects.html">Tools &amp; Resources</a>
+      <a href="/CV.html">About / CV</a>
+      <a href="/LibertyMathClub/">Math Club</a>
+      <a href="/contact.html">Contact</a>
+    </nav>
+  </div>
+</footer>
+<script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -61,6 +61,40 @@
 </header>
 
 <main id="main-content" class="site-main home-page">
+  <section class="site-section" aria-labelledby="fall-courses-title">
+    <div class="section-header">
+      <p class="section-kicker">Fall 2026 Courses</p>
+      <h2 id="fall-courses-title">Go directly to your current course.</h2>
+      <p>Students in the Fall 2026 courses below can open the matching course home from here.</p>
+    </div>
+    <div class="card-grid course-home-grid">
+      <article class="course-card">
+        <span class="course-card__meta">MATH 114</span>
+        <h3>Quantitative Reasoning</h3>
+        <p>Unit pages, review materials, common tools, and Canvas/current-term guidance.</p>
+        <a href="/courses/math114.html" class="button">Open MATH 114</a>
+      </article>
+      <article class="course-card">
+        <span class="course-card__meta">MATH 130</span>
+        <h3>Advanced Technical Mathematics</h3>
+        <p>Exam-by-exam review units with slides, videos, practice, and study flow.</p>
+        <a href="/courses/math130.html" class="button">Open MATH 130</a>
+      </article>
+      <article class="course-card">
+        <span class="course-card__meta">PHYS 201L / 231L</span>
+        <h3>Physics Lab 1</h3>
+        <p>Mechanics lab preparation, manual guidance, reports, and lab-day expectations.</p>
+        <a href="/courses/physlab1.html" class="button">Open Physics Lab 1</a>
+      </article>
+      <article class="course-card">
+        <span class="course-card__meta">PHYS 202L / 232L</span>
+        <h3>Physics Lab 2</h3>
+        <p>Electricity, magnetism, and optics lab preparation and reporting guidance.</p>
+        <a href="/courses/physlab2.html" class="button">Open Physics Lab 2</a>
+      </article>
+    </div>
+  </section>
+
   <section class="site-section" aria-labelledby="start-title">
     <div class="section-header">
       <p class="section-kicker">Start Here</p>

--- a/learn.html
+++ b/learn.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Course Home Pages | Prof. Volk's Office</title>
-  <meta name="description" content="Course home pages for MATH 114, MATH 130, and Physics Labs.">
+  <meta name="description" content="Course home pages for Fall 2026 MATH 114, MATH 130, PHYS 201L/231L, and PHYS 202L/232L.">
   <link rel="stylesheet" href="/styles.css">
   <script src="/theme.js" defer></script>
 </head>
@@ -61,16 +61,70 @@
     <h1>Course Home Pages</h1>
     <p class="page-hero__lede">Choose the course or lab page that matches your current class.</p>
     <ul class="badge-list" aria-label="Course home notes">
-      <li><span class="site-badge">Evergreen resources</span></li>
+      <li><span class="site-badge">Fall 2026 courses first</span></li>
       <li><span class="site-badge">Canvas holds current deadlines</span></li>
     </ul>
   </div>
 </header>
 
 <main id="main-content" class="site-main">
+  <section class="site-section" aria-labelledby="fall-courses-title">
+    <div class="section-header">
+      <p class="section-kicker">Fall 2026 Courses</p>
+      <h2 id="fall-courses-title">Open the page for your current course.</h2>
+      <p>Use the course code shown in Canvas or on your syllabus to choose the correct page.</p>
+    </div>
+    <div class="card-grid course-home-grid">
+      <article class="course-card">
+        <span class="course-card__meta">MATH 114</span>
+        <h3>Quantitative Reasoning</h3>
+        <p>Unit materials, final review resources, common tools, and current-term Canvas guidance.</p>
+        <a href="/courses/math114.html" class="button">Open MATH 114</a>
+      </article>
+      <article class="course-card">
+        <span class="course-card__meta">MATH 130</span>
+        <h3>Advanced Technical Mathematics</h3>
+        <p>Four review units with slides, videos, guided practice, and exam-by-exam support.</p>
+        <a href="/courses/math130.html" class="button">Open MATH 130</a>
+      </article>
+      <article class="course-card">
+        <span class="course-card__meta">PHYS 201L / 231L</span>
+        <h3>Physics Lab 1</h3>
+        <p>Mechanics lab preparation, manual guidance, lab reports, and lab-day reference material.</p>
+        <a href="/courses/physlab1.html" class="button">Open Physics Lab 1</a>
+      </article>
+      <article class="course-card">
+        <span class="course-card__meta">PHYS 202L / 232L</span>
+        <h3>Physics Lab 2</h3>
+        <p>Electricity, magnetism, and optics lab preparation, resources, and reporting guidance.</p>
+        <a href="/courses/physlab2.html" class="button">Open Physics Lab 2</a>
+      </article>
+    </div>
+  </section>
+
   <section class="site-section site-note" aria-labelledby="canvas-note-title">
     <h2 id="canvas-note-title">Use Canvas for current-term details.</h2>
     <p>Official deadlines, grades, announcements, section policies, and assignment submissions remain in Canvas. These course pages collect reusable support materials and course navigation.</p>
+  </section>
+
+  <section class="site-section" aria-labelledby="physics-courses-title">
+    <div class="section-header">
+      <p class="section-kicker">Other Lab Pages</p>
+      <h2 id="physics-courses-title">Need a different physics lab page?</h2>
+    </div>
+    <div class="card-grid course-home-grid">
+      <article class="course-card">
+        <span class="course-card__meta">Physics Lab Directory</span>
+        <h3>Physics Labs</h3>
+        <p>Use the lab directory for shared lab-page clarification and archived or non-Fall lab pages.</p>
+        <a href="/courses/physics-labs.html" class="button">Open Physics Labs</a>
+      </article>
+      <aside class="checklist-card">
+        <h3>Not sure where to go?</h3>
+        <p>Check your Canvas course code or syllabus first. If the course code still does not match a page, use the contact page.</p>
+        <a href="/contact.html" class="button button-secondary">Contact Prof. Volk</a>
+      </aside>
+    </div>
   </section>
 
   <section class="site-section" aria-labelledby="beyond-class-title">
@@ -80,47 +134,6 @@
       <p>Visit the Liberty University Math Club section for events, student teams, career preparation, and honor society opportunities.</p>
       <a href="/LibertyMathClub/" class="button">Open Math Club</a>
     </article>
-  </section>
-
-  <section class="site-section" aria-labelledby="math-courses-title">
-    <div class="section-header">
-      <p class="section-kicker">Math Courses</p>
-      <h2 id="math-courses-title">Choose your math course.</h2>
-    </div>
-    <div class="card-grid course-home-grid">
-      <article class="course-card">
-        <span class="course-card__meta">MATH 114</span>
-        <h3>Quantitative Reasoning</h3>
-        <p>Unit materials, final review resources, common tools, and course logistics.</p>
-        <a href="/courses/math114.html" class="button">Open MATH 114</a>
-      </article>
-      <article class="course-card">
-        <span class="course-card__meta">MATH 130</span>
-        <h3>Advanced Technical Mathematics</h3>
-        <p>Four review units with slides, videos, guided practice, and exam-by-exam support.</p>
-        <a href="/courses/math130.html" class="button">Open MATH 130</a>
-      </article>
-    </div>
-  </section>
-
-  <section class="site-section" aria-labelledby="physics-courses-title">
-    <div class="section-header">
-      <p class="section-kicker">Physics Labs</p>
-      <h2 id="physics-courses-title">Find your lab course home.</h2>
-    </div>
-    <div class="card-grid course-home-grid">
-      <article class="course-card">
-        <span class="course-card__meta">PHYS Labs</span>
-        <h3>Physics Labs</h3>
-        <p>Lab course homes for PHYS 103, PHYS 201L/231L, and PHYS 202L/232L.</p>
-        <a href="/courses/physics-labs.html" class="button">Open Physics Labs</a>
-      </article>
-      <aside class="checklist-card">
-        <h3>Not sure where to go?</h3>
-        <p>Check your Canvas course code or syllabus first. If the course code still does not match a page, use the contact page.</p>
-        <a href="/contact.html" class="button button-secondary">Contact Prof. Volk</a>
-      </aside>
-    </div>
   </section>
 </main>
 


### PR DESCRIPTION
## Summary
- Put Fall 2026 course shortcuts on the home page and move current course selection to the top of the course directory.
- Replace stale MATH 114 Spring assignment CTAs with Canvas/current-term guidance while keeping the prior-term page clearly archived.
- Refresh MATH 130 with the course code in the visible H1 and a Canvas/current-term note.
- Prioritize PHYS 201L/231L and PHYS 202L/232L in the physics lab directory.
- Rebuild Physics Lab 1 and Physics Lab 2 pages on the modern site template with lab preparation, resources, reporting, support, skip link, main landmark, and footer.

## Verification
- Checked edited pages for title/H1 presence, skip link, `main-content`, and footer.
- Checked same-page anchors from edited pages.
- Checked internal paths referenced by edited pages on the branch.
- Confirmed Spring wording appears only in the archived MATH 114 prior-term context.