### PR TITLE
Fix Math 130 flow on legacy notes page

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -688,8 +688,24 @@ function insertMath130FallFlow(config) {
         return;
     }
 
-    const main = document.querySelector('main, .container, #app-container');
-    if (main) main.prepend(flow);
+    const pageHeader = document.querySelector('.page > header');
+    if (pageHeader) {
+        pageHeader.insertAdjacentElement('afterend', flow);
+        return;
+    }
+
+    const main = document.querySelector('main, .container, #app-container, .page');
+    if (main) {
+        main.prepend(flow);
+        return;
+    }
+
+    const firstBodyChild = Array.from(document.body.children).find((element) => !element.matches('script, style'));
+    if (firstBodyChild) {
+        firstBodyChild.insertAdjacentElement('beforebegin', flow);
+    } else {
+        document.body.prepend(flow);
+    }
 }
 
 function applyMath130FallTextUpdates(config) {


### PR DESCRIPTION
## Summary
- Adds a legacy page-header fallback for the Fall 2026 Math 130 flow injection.
- Ensures the Quiz 10 notes page receives the same unit context banner as the other Math 130 pages.

## Verification
- Fetched branch `theme.js` and checked JavaScript syntax with `new Function(...)`.
- Confirmed the fallback selectors are present in the branch build.