### PR TITLE
Relax CSS link lint for slide decks and ignore node_modules

### DIFF
--- a/scripts/check_css_links.py
+++ b/scripts/check_css_links.py
@@ -2,35 +2,56 @@
 """Lightweight lint for stylesheet href conventions.
 
 Checks:
-1) non-canonical local stylesheet hrefs (anything local that's not /styles.css)
+1) non-canonical local stylesheet hrefs on site pages
 2) duplicate CDN variants for the same library
+
+Slide decks are standalone documents and may load stylesheets from within the
+``slides`` directory.
 """
 from __future__ import annotations
 
-import glob
 import re
 from collections import defaultdict
 from html import unescape
+from pathlib import Path
 from urllib.parse import urlparse
 
+ROOT = Path(__file__).resolve().parents[1]
+EXCLUDED_DIRS = {".git", "node_modules"}
 STYLESHEET_LINK_RE = re.compile(r"<link\b[^>]*\brel\s*=\s*['\"]stylesheet['\"][^>]*>", re.IGNORECASE)
 HREF_RE = re.compile(r"\bhref\s*=\s*['\"]([^'\"]+)['\"]", re.IGNORECASE)
 
 
-def iter_stylesheet_hrefs() -> list[tuple[str, str]]:
-    results: list[tuple[str, str]] = []
-    for file_path in sorted(glob.glob("**/*.html", recursive=True)):
-        with open(file_path, encoding="utf-8", errors="ignore") as fh:
-            text = fh.read()
+def iter_stylesheet_hrefs() -> list[tuple[Path, str]]:
+    results: list[tuple[Path, str]] = []
+    html_files = sorted(
+        path
+        for path in ROOT.rglob("*.html")
+        if not EXCLUDED_DIRS.intersection(path.relative_to(ROOT).parts)
+    )
+    for file_path in html_files:
+        text = file_path.read_text(encoding="utf-8", errors="ignore")
         for tag in STYLESHEET_LINK_RE.findall(text):
             href_match = HREF_RE.search(tag)
             if href_match:
-                results.append((file_path, unescape(href_match.group(1).strip())))
+                results.append((file_path.relative_to(ROOT), unescape(href_match.group(1).strip())))
     return results
 
 
 def is_local_href(href: str) -> bool:
     return not re.match(r"^(https?:|//|mailto:|tel:|data:|javascript:|#)", href, flags=re.IGNORECASE)
+
+
+def is_canonical_local_stylesheet(file_path: Path, href: str) -> bool:
+    if href == "/styles.css":
+        return True
+
+    if not file_path.parts or file_path.parts[0] != "slides":
+        return False
+
+    resolved = (ROOT / file_path.parent / href).resolve()
+    slides_root = (ROOT / "slides").resolve()
+    return resolved.is_relative_to(slides_root) and resolved.is_file()
 
 
 def normalize_jsdelivr(path: str) -> tuple[str | None, str | None]:
@@ -66,14 +87,14 @@ def classify_external_variant(href: str) -> tuple[str | None, str | None]:
 
 
 def main() -> int:
-    local_non_canonical: list[tuple[str, str]] = []
+    local_non_canonical: list[tuple[Path, str]] = []
     variants: dict[str, set[str]] = defaultdict(set)
 
     for file_path, href in iter_stylesheet_hrefs():
         href_no_hash = href.split("#", 1)[0].split("?", 1)[0]
 
         if is_local_href(href):
-            if href_no_hash != "/styles.css":
+            if not is_canonical_local_stylesheet(file_path, href_no_hash):
                 local_non_canonical.append((file_path, href))
             continue
 
@@ -85,7 +106,7 @@ def main() -> int:
 
     if local_non_canonical:
         failed = True
-        print("Non-canonical local stylesheet hrefs found (expected '/styles.css'):")
+        print("Non-canonical local stylesheet hrefs found:")
         for file_path, href in local_non_canonical:
             print(f"- {file_path}: {href}")
     else:


### PR DESCRIPTION
### Motivation
- The CSS lint assumed every local stylesheet must be `/styles.css`, which flagged vendored slide decks and produced false positives.
- The scanner also descended into installed dependency trees (e.g., `slides/node_modules`), generating unrelated errors.

### Description
- Update `scripts/check_css_links.py` to scan HTML files from the repository `ROOT` using `Path.rglob` and skip `.git` and `node_modules` by introducing `EXCLUDED_DIRS`.
- Add `is_canonical_local_stylesheet(file_path, href)` to allow the canonical `/styles.css` for normal pages and permit slide decks to reference CSS files that are physically inside the `slides/` tree while preventing path traversal out of `slides/`.
- Convert internal href/file handling to use `Path` for resolved checks and return `Path`-relative file paths in results, and adjust type annotations accordingly.
- Keep existing CDN duplicate detection logic and update lint messages to reflect the relaxed policy.

### Testing
- Ran `python scripts/check_css_links.py` and observed no non-canonical stylesheet errors (passed).
- Executed policy assertions in an isolated temp `ROOT` to validate canonical site CSS, valid slide CSS, path traversal rejection, and missing slide CSS (passed).
- Compiled the script with `python -m py_compile scripts/check_css_links.py` (passed).
- Ran `python scripts/check_links.py` and `python scripts/check_html_structure.py` to ensure no regressions (both passed).
- Ran `git diff --check` to ensure no whitespace/format issues (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29fa58146c8331a42e73265c24996b)